### PR TITLE
Merging Fixes for Xamarin Android SDK for: (1) Compilation Issues. (2) Re-connect if internet connection is up again.

### DIFF
--- a/mono-for-android/PubNubMessaging.Example/MainActivity.cs
+++ b/mono-for-android/PubNubMessaging.Example/MainActivity.cs
@@ -264,7 +264,7 @@ namespace PubNubMessaging.Example
                 this.m_DrawerList.Adapter = new ArrayAdapter<string> (this, Resource.Layout.ItemMenu, Sections);
                 this.m_DrawerList.ItemClick += (sender, args) => ListItemClicked (args.Position);
 
-                this.m_Drawer.SetDrawerShadow (Resource.Drawable.drawer_shadow_dark, (int)GravityFlags.Start);
+                this.m_Drawer.SetDrawerShadow (Resource.Drawable.drawer_shadow_dark, GravityFlags.Start);
                 //DrawerToggle is the animation that happens with the indicator next to the actionbar
                 this.m_DrawerToggle = new MyActionBarDrawerToggle (this, this.m_Drawer,
                     Resource.Drawable.ic_drawer_light,

--- a/mono-for-android/PubNubMessaging/ClientNetworkStatus.cs
+++ b/mono-for-android/PubNubMessaging/ClientNetworkStatus.cs
@@ -50,7 +50,7 @@ namespace PubNubMessaging.Core
         /*#if(__MonoCS__ && !UNITY_IOS && !UNITY_ANDROID)
         static UdpClient udp;
         #endif*/
-        #if(UNITY_IOS || UNITY_ANDROID || __MonoCS__)
+        #if(UNITY_IOS || UNITY_ANDROID || MONODROID || __MonoCS__)
         static HttpWebRequest request;
         static WebResponse response;
 

--- a/mono-for-android/PubNubMessaging/PubnubCore.cs
+++ b/mono-for-android/PubNubMessaging/PubnubCore.cs
@@ -397,6 +397,13 @@ namespace PubNubMessaging.Core
 
                     if (channelInternetStatus.ContainsKey (channel)
                     && (netState.Type == ResponseType.Subscribe || netState.Type == ResponseType.Presence)) {
+
+                        // Check if Internet connection is back if it was lost earlier.
+                        if(!channelInternetStatus [channel])
+						{
+							channelInternetStatus [channel] = CheckInternetConnectionStatus<T> (pubnetSystemActive, netState.ErrorCallback, netState.Channels);
+						}
+
                         if (channelInternetStatus [channel]) {
                             //Reset Retry if previous state is true
                             channelInternetRetry.AddOrUpdate (channel, 0, (key, oldValue) => 0);

--- a/mono-for-android/PubNubMessaging/PubnubXamarinAndroid.cs
+++ b/mono-for-android/PubNubMessaging/PubnubXamarinAndroid.cs
@@ -497,7 +497,9 @@ namespace PubNubMessaging.Core
 
             base.VerifyOrSetSessionUUID ();
 
+            #if(__MonoCS__)
             PubnubWebRequest.ServicePointConnectionLimit = 300;
+            #endif
         }
 
         protected override bool InternetConnectionStatus<T> (string channel, Action<PubnubClientError> errorCallback, string[] rawChannels)
@@ -526,9 +528,12 @@ namespace PubNubMessaging.Core
 
         protected override sealed void SendRequestAndGetResult<T> (Uri requestUri, RequestState<T> pubnubRequestState, PubnubWebRequest request)
         {
+            #if (__MonoCS__)
             if ((pubnubRequestState.Type == ResponseType.Publish) && (RequestIsUnsafe (requestUri))) {
                 SendRequestUsingTcpClient<T> (requestUri, pubnubRequestState);
-            } else {
+            } else 
+            #endif
+            {
                 IAsyncResult asyncResult = request.BeginGetResponse (new AsyncCallback (UrlProcessResponseCallback<T>), pubnubRequestState);
                 if (!asyncResult.AsyncWaitHandle.WaitOne (GetTimeoutInSecondsForResponseType (pubnubRequestState.Type) * 1000)) {
                     OnPubnubWebRequestTimeout<T> (pubnubRequestState, true);
@@ -1144,7 +1149,9 @@ namespace PubNubMessaging.Core
         #endif
         public PubnubWebRequest (HttpWebRequest request) : base (request)
         {
+            #if(__MonoCS__)
             base.request.ServicePoint.ConnectionLimit = ServicePointConnectionLimit;
+            #endif
             #if ((!__MonoCS__) && (!SILVERLIGHT) && !WINDOWS_PHONE)
                 this.ServicePoint = this.request.ServicePoint;
             #endif
@@ -1159,7 +1166,10 @@ namespace PubNubMessaging.Core
         public PubnubWebRequest (HttpWebRequest request, IPubnubUnitTest pubnubUnitTest)
             : base (request, pubnubUnitTest)
         {
+            #if(__MonoCS__)
             this.request.ServicePoint.ConnectionLimit = ServicePointConnectionLimit;
+            #endif
+
             #if ((!__MonoCS__) && (!SILVERLIGHT) && !WINDOWS_PHONE)
                 this.ServicePoint = this.request.ServicePoint;
             #endif


### PR DESCRIPTION
The changes are actually very small, but the diff is not working correctly and showing same text also being deleted and added.



