### PR TITLE
Handle case where channelGroups is null

### DIFF
--- a/csharp.net/PubNub-Messaging/ClientNetworkStatus.cs
+++ b/csharp.net/PubNub-Messaging/ClientNetworkStatus.cs
@@ -265,6 +265,11 @@ namespace PubNubMessaging.Core
 
         static void ParseCheckSocketConnectException<T> (Exception ex, string[] channels, string[] channelGroups, Action<PubnubClientError> errorCallback, Action<bool> callback)
 		{
+            if(channelGroups == null)
+            {
+                channelGroups = new string[0];
+            }
+
 			PubnubErrorCode errorType = PubnubErrorCodeHelper.GetErrorType(ex);
 			int statusCode = (int)errorType;
 			string errorDescription = PubnubErrorCodeDescription.GetStatusCodeDescription(errorType);


### PR DESCRIPTION
ChannelGroups variable is null if you are not using channel groups. Pubnub was throwing a null pointer exception when attempting to execute
````
string.Join(",", channelGroups)
````