### PR TITLE
handle serialization of JArray type messages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -133,3 +133,4 @@ src/Examples/PubnubApiPCL.XamariniMacExample/obj/*
 *.suo
 src/UnitTests/MockServer/bin/*
 src/UnitTests/MockServer/obj/*
+/src/.vs/Pubnub/v15/Server/sqlite3

--- a/src/Api/PubnubApi/NewtonsoftJsonDotNet.cs
+++ b/src/Api/PubnubApi/NewtonsoftJsonDotNet.cs
@@ -236,8 +236,15 @@ namespace PubnubApi
                 }
                 else if (listObject[0].GetType() == typeof(Newtonsoft.Json.Linq.JArray))
                 {
-                    JToken token = listObject[0] as JToken;
-                    userMessage = token.ToObject(dataProp.PropertyType, JsonSerializer.Create());
+                    JArray array = listObject[0] as JArray;
+                    if (dataProp.PropertyType == typeof(string))
+                    {
+                        userMessage = JsonConvert.SerializeObject(array);
+                    }
+                    else
+                    {
+                        userMessage = array.ToObject(dataProp.PropertyType, JsonSerializer.Create());
+                    }
 
                     dataProp.SetValue(message, userMessage, null);
                 }

--- a/src/UnitTests/PubnubApi.Tests/PubnubApi.Tests.csproj
+++ b/src/UnitTests/PubnubApi.Tests/PubnubApi.Tests.csproj
@@ -17,7 +17,7 @@
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
     <OutputPath>bin\Debug\</OutputPath>
-    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <DefineConstants>TRACE;DEBUG;NET35</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
@@ -491,6 +491,7 @@
     <Compile Include="WhenGetRequestServerTime.cs" />
     <Compile Include="WhenGrantIsRequested.cs" />
     <Compile Include="WhenMessageDeletedFromChannel.cs" />
+    <Compile Include="WhenMessageIsDeserialized.cs" />
     <Compile Include="WhenPushIsRequested.cs" />
     <Compile Include="WhenSubscribedToAChannel.cs" />
     <Compile Include="WhenSubscribedToAChannel2.cs" />

--- a/src/UnitTests/PubnubApi.Tests/WhenMessageIsDeserialized.cs
+++ b/src/UnitTests/PubnubApi.Tests/WhenMessageIsDeserialized.cs
@@ -1,0 +1,49 @@
+﻿using System;
+using NUnit.Framework;
+using PubnubApi;
+using System.Collections.Generic;
+using Newtonsoft.Json.Linq;
+
+namespace PubNubMessaging.Tests
+{
+    [TestFixture]
+    public class WhenMessageIsDeserialized
+    {
+        private static string authKey = "myAuth";
+        private PNConfiguration config;
+        private IPubnubLog pubnubLog = null;
+
+        [TestFixtureSetUp]
+        public void Init()
+        {
+            config = new PNConfiguration()
+            {
+                PublishKey = PubnubCommon.PublishKey,
+                SubscribeKey = PubnubCommon.SubscribeKey,
+                SecretKey = PubnubCommon.SecretKey,
+                AuthKey = authKey,
+                Uuid = "mytestuuid",
+                Secure = false
+            };
+        }
+
+        [Test]
+        public void JArrayMessageShouldDeserializedWithoutError()
+        {
+            String messageContent = "[{\"a\":1,\"b\":2}{\"c\":3,\"d\":4}]";
+            Object[] content = new Object[] { messageContent };
+            JArray jArray = new JArray(content);
+
+            NewtonsoftJsonDotNet newtonsoftJsonDotNet = new NewtonsoftJsonDotNet(config, pubnubLog);
+            var listObject = new List<object>
+            {
+                jArray,
+                null,
+                12345L,
+                "MessageName"
+            };
+            PNMessageResult<String> result = newtonsoftJsonDotNet.DeserializeToObject<PNMessageResult<String>>(listObject);
+            Assert.AreEqual("[\"[{\\\"a\\\":1,\\\"b\\\":2}{\\\"c\\\":3,\\\"d\\\":4}]\"]", result.Message);
+        }
+}
+}

--- a/src/UnitTests/PubnubApi.Tests/WhenMessageIsDeserialized.cs
+++ b/src/UnitTests/PubnubApi.Tests/WhenMessageIsDeserialized.cs
@@ -11,12 +11,11 @@ namespace PubNubMessaging.Tests
     {
         private static string authKey = "myAuth";
         private PNConfiguration config;
-        private IPubnubLog pubnubLog = null;
 
         [TestFixtureSetUp]
         public void Init()
         {
-            config = new PNConfiguration()
+            config = new PNConfiguration
             {
                 PublishKey = PubnubCommon.PublishKey,
                 SubscribeKey = PubnubCommon.SubscribeKey,
@@ -34,7 +33,7 @@ namespace PubNubMessaging.Tests
             Object[] content = new Object[] { messageContent };
             JArray jArray = new JArray(content);
 
-            NewtonsoftJsonDotNet newtonsoftJsonDotNet = new NewtonsoftJsonDotNet(config, pubnubLog);
+            NewtonsoftJsonDotNet newtonsoftJsonDotNet = new NewtonsoftJsonDotNet(config, null);
             var listObject = new List<object>
             {
                 jArray,


### PR DESCRIPTION
I found a parsing exception was being thrown when the message content was a JSON array. I changed the internals of NewtonsoftJsonDotNet to serialize out JArray types specifically.

I added a Unit Test for this, I couldn't find any tests to cover the NewtonsoftJsonDotNet class.

I also had to add a NET35 compilation symbol to the Unit Tests project; the json parsing code is wrapped in conditional compiler directives.