### PR TITLE
Replacing <> with their Entity name

### DIFF
--- a/.pubnub.yml
+++ b/.pubnub.yml
@@ -118,7 +118,7 @@ changelog:
       - type: Improvement
         text: Relay server sent 403 status to PNStatus for PCL 
       - type: Improvement
-        text: Resolved array type published message for Subscribe<string>
+        text: Resolved array type published message for Subscribe&lt;string&gt;
   - version: 4.0.11.0
     date: Dec 14, 17
     changes:


### PR DESCRIPTION
This change may resolves the issue on the Changelog page.
https://www.pubnub.com/docs/c-sharp-dot-net-c-sharp/changelog

For now, browser taking the &lt;string&gt; as the HTML code and it is not showing this as shown in screenshot.
<img width="853" alt="Screen Shot 2019-03-26 at 12 11 51 PM" src="https://user-images.githubusercontent.com/16156106/54977982-b9bd0b00-4fc0-11e9-84e3-afa21d384b9c.png">
