### PR TITLE
Ensure Task.Factory.StartNew is used over new Thread in all NETSTANDARD versions

### DIFF
--- a/src/Api/PubnubApi/ClientNetworkStatus.cs
+++ b/src/Api/PubnubApi/ClientNetworkStatus.cs
@@ -119,7 +119,7 @@ namespace PubnubApi
 			{
                 try
                 {
-#if NETFX_CORE || WINDOWS_UWP || UAP || NETSTANDARD10 || NETSTANDARD11 || NETSTANDARD12
+#if NETFX_CORE || WINDOWS_UWP || UAP || NETSTANDARD
                     Task[] tasks = new Task[1];
                     tasks[0] = Task.Factory.StartNew(async() =>
                     {

--- a/src/Api/PubnubApi/EndPoint/Access/AuditOperation.cs
+++ b/src/Api/PubnubApi/EndPoint/Access/AuditOperation.cs
@@ -58,7 +58,7 @@ namespace PubnubApi.EndPoint
 
         public void Async(PNCallback<PNAccessManagerAuditResult> callback)
         {
-#if NETFX_CORE || WINDOWS_UWP || UAP || NETSTANDARD10 || NETSTANDARD11 || NETSTANDARD12
+#if NETFX_CORE || WINDOWS_UWP || UAP || NETSTANDARD
             Task.Factory.StartNew(() => 
             {
                 this.savedCallback = callback;
@@ -76,7 +76,7 @@ namespace PubnubApi.EndPoint
 
         internal void Retry()
         {
-#if NETFX_CORE || WINDOWS_UWP || UAP || NETSTANDARD10 || NETSTANDARD11 || NETSTANDARD12
+#if NETFX_CORE || WINDOWS_UWP || UAP || NETSTANDARD
             Task.Factory.StartNew(() =>
             {
                 AuditAccess(this.channelName, this.channelGroupName, this.authenticationKeys, this.queryParam, savedCallback);

--- a/src/Api/PubnubApi/EndPoint/Access/GrantOperation.cs
+++ b/src/Api/PubnubApi/EndPoint/Access/GrantOperation.cs
@@ -93,7 +93,7 @@ namespace PubnubApi.EndPoint
 
         public void Async(PNCallback<PNAccessManagerGrantResult> callback)
         {
-#if NETFX_CORE || WINDOWS_UWP || UAP || NETSTANDARD10 || NETSTANDARD11 || NETSTANDARD12
+#if NETFX_CORE || WINDOWS_UWP || UAP || NETSTANDARD
             Task.Factory.StartNew(() =>
             {
                 this.savedCallback = callback;
@@ -111,7 +111,7 @@ namespace PubnubApi.EndPoint
 
         internal void Retry()
         {
-#if NETFX_CORE || WINDOWS_UWP || UAP || NETSTANDARD10 || NETSTANDARD11 || NETSTANDARD12
+#if NETFX_CORE || WINDOWS_UWP || UAP || NETSTANDARD
             Task.Factory.StartNew(() =>
             {
                 GrantAccess(this.pubnubChannelNames, this.pubnubChannelGroupNames, this.pamAuthenticationKeys, this.grantRead, this.grantWrite, this.grantDelete, this.grantManage, this.grantTTL, this.queryParam, savedCallback);

--- a/src/Api/PubnubApi/EndPoint/ChannelGroup/AddChannelsToChannelGroupOperation.cs
+++ b/src/Api/PubnubApi/EndPoint/ChannelGroup/AddChannelsToChannelGroupOperation.cs
@@ -50,7 +50,7 @@ namespace PubnubApi.EndPoint
 
         public void Async(PNCallback<PNChannelGroupsAddChannelResult> callback)
         {
-#if NETFX_CORE || WINDOWS_UWP || UAP || NETSTANDARD10 || NETSTANDARD11 || NETSTANDARD12
+#if NETFX_CORE || WINDOWS_UWP || UAP || NETSTANDARD
             Task.Factory.StartNew(() =>
             {
                 this.savedCallback = callback;
@@ -68,7 +68,7 @@ namespace PubnubApi.EndPoint
 
         internal void Retry()
         {
-#if NETFX_CORE || WINDOWS_UWP || UAP || NETSTANDARD10 || NETSTANDARD11 || NETSTANDARD12
+#if NETFX_CORE || WINDOWS_UWP || UAP || NETSTANDARD
             Task.Factory.StartNew(() =>
             {
                 AddChannelsToChannelGroup(this.channelNames, "", this.channelGroupName, this.queryParam, savedCallback);

--- a/src/Api/PubnubApi/EndPoint/ChannelGroup/DeleteChannelGroupOperation.cs
+++ b/src/Api/PubnubApi/EndPoint/ChannelGroup/DeleteChannelGroupOperation.cs
@@ -42,7 +42,7 @@ namespace PubnubApi.EndPoint
 
         public void Async(PNCallback<PNChannelGroupsDeleteGroupResult> callback)
         {
-#if NETFX_CORE || WINDOWS_UWP || UAP || NETSTANDARD10 || NETSTANDARD11 || NETSTANDARD12
+#if NETFX_CORE || WINDOWS_UWP || UAP || NETSTANDARD
             Task.Factory.StartNew(() =>
             {
                 this.savedCallback = callback;
@@ -60,7 +60,7 @@ namespace PubnubApi.EndPoint
 
         internal void Retry()
         {
-#if NETFX_CORE || WINDOWS_UWP || UAP || NETSTANDARD10 || NETSTANDARD11 || NETSTANDARD12
+#if NETFX_CORE || WINDOWS_UWP || UAP || NETSTANDARD
             Task.Factory.StartNew(() =>
             {
                 DeleteChannelGroup(this.channelGroupName, this.queryParam, savedCallback);

--- a/src/Api/PubnubApi/EndPoint/ChannelGroup/ListAllChannelGroupOperation.cs
+++ b/src/Api/PubnubApi/EndPoint/ChannelGroup/ListAllChannelGroupOperation.cs
@@ -35,7 +35,7 @@ namespace PubnubApi.EndPoint
 
         public void Async(PNCallback<PNChannelGroupsListAllResult> callback)
         {
-#if NETFX_CORE || WINDOWS_UWP || UAP || NETSTANDARD10 || NETSTANDARD11 || NETSTANDARD12
+#if NETFX_CORE || WINDOWS_UWP || UAP || NETSTANDARD
             Task.Factory.StartNew(() =>
             {
                 this.savedCallback = callback;
@@ -53,7 +53,7 @@ namespace PubnubApi.EndPoint
 
         internal void Retry()
         {
-#if NETFX_CORE || WINDOWS_UWP || UAP || NETSTANDARD10 || NETSTANDARD11 || NETSTANDARD12
+#if NETFX_CORE || WINDOWS_UWP || UAP || NETSTANDARD
             Task.Factory.StartNew(() =>
             {
                 GetAllChannelGroup(this.queryParam, savedCallback);

--- a/src/Api/PubnubApi/EndPoint/ChannelGroup/ListChannelsForChannelGroupOperation.cs
+++ b/src/Api/PubnubApi/EndPoint/ChannelGroup/ListChannelsForChannelGroupOperation.cs
@@ -43,7 +43,7 @@ namespace PubnubApi.EndPoint
 
         public void Async(PNCallback<PNChannelGroupsAllChannelsResult> callback)
         {
-#if NETFX_CORE || WINDOWS_UWP || UAP || NETSTANDARD10 || NETSTANDARD11 || NETSTANDARD12
+#if NETFX_CORE || WINDOWS_UWP || UAP || NETSTANDARD
             Task.Factory.StartNew(() =>
             {
                 this.savedCallback = callback;
@@ -61,7 +61,7 @@ namespace PubnubApi.EndPoint
 
         internal void Retry()
         {
-#if NETFX_CORE || WINDOWS_UWP || UAP || NETSTANDARD10 || NETSTANDARD11 || NETSTANDARD12
+#if NETFX_CORE || WINDOWS_UWP || UAP || NETSTANDARD
             Task.Factory.StartNew(() =>
             {
                 GetChannelsForChannelGroup(this.channelGroupName, this.queryParam, savedCallback);

--- a/src/Api/PubnubApi/EndPoint/ChannelGroup/RemoveChannelsFromChannelGroupOperation.cs
+++ b/src/Api/PubnubApi/EndPoint/ChannelGroup/RemoveChannelsFromChannelGroupOperation.cs
@@ -50,7 +50,7 @@ namespace PubnubApi.EndPoint
 
         public void Async(PNCallback<PNChannelGroupsRemoveChannelResult> callback)
         {
-#if NETFX_CORE || WINDOWS_UWP || UAP || NETSTANDARD10 || NETSTANDARD11 || NETSTANDARD12
+#if NETFX_CORE || WINDOWS_UWP || UAP || NETSTANDARD
             Task.Factory.StartNew(() =>
             {
                 this.savedCallback = callback;
@@ -68,7 +68,7 @@ namespace PubnubApi.EndPoint
 
         internal void Retry()
         {
-#if NETFX_CORE || WINDOWS_UWP || UAP || NETSTANDARD10 || NETSTANDARD11 || NETSTANDARD12
+#if NETFX_CORE || WINDOWS_UWP || UAP || NETSTANDARD
             Task.Factory.StartNew(() =>
             {
                 RemoveChannelsFromChannelGroup(this.channelNames, "", this.channelGroupName, this.queryParam, savedCallback);

--- a/src/Api/PubnubApi/EndPoint/DeleteMessageOperation.cs
+++ b/src/Api/PubnubApi/EndPoint/DeleteMessageOperation.cs
@@ -64,7 +64,7 @@ namespace PubnubApi.EndPoint
                 throw new MissingMemberException("Invalid Subscribe Key");
             }
 
-#if NETFX_CORE || WINDOWS_UWP || UAP || NETSTANDARD10 || NETSTANDARD11 || NETSTANDARD12
+#if NETFX_CORE || WINDOWS_UWP || UAP || NETSTANDARD
             Task.Factory.StartNew(() =>
             {
                 this.savedCallback = callback;
@@ -82,7 +82,7 @@ namespace PubnubApi.EndPoint
 
         internal void Retry()
         {
-#if NETFX_CORE || WINDOWS_UWP || UAP || NETSTANDARD10 || NETSTANDARD11 || NETSTANDARD12
+#if NETFX_CORE || WINDOWS_UWP || UAP || NETSTANDARD
             Task.Factory.StartNew(() =>
             {
                 DeleteMessage(this.channelName, this.startTimetoken, this.endTimetoken, this.queryParam, savedCallback);

--- a/src/Api/PubnubApi/EndPoint/HistoryOperation.cs
+++ b/src/Api/PubnubApi/EndPoint/HistoryOperation.cs
@@ -85,7 +85,7 @@ namespace PubnubApi.EndPoint
                 throw new MissingMemberException("Invalid Subscribe Key");
             }
 
-#if NETFX_CORE || WINDOWS_UWP || UAP || NETSTANDARD10 || NETSTANDARD11 || NETSTANDARD12
+#if NETFX_CORE || WINDOWS_UWP || UAP || NETSTANDARD
             Task.Factory.StartNew(() =>
             {
                 this.savedCallback = callback;
@@ -103,7 +103,7 @@ namespace PubnubApi.EndPoint
 
         internal void Retry()
         {
-#if NETFX_CORE || WINDOWS_UWP || UAP || NETSTANDARD10 || NETSTANDARD11 || NETSTANDARD12
+#if NETFX_CORE || WINDOWS_UWP || UAP || NETSTANDARD
             Task.Factory.StartNew(() =>
             {
                 History(this.channelName, this.startTimetoken, this.endTimetoken, this.historyCount, this.reverseOption, this.includeTimetokenOption, this.queryParam, savedCallback);

--- a/src/Api/PubnubApi/EndPoint/MessageCountsOperation.cs
+++ b/src/Api/PubnubApi/EndPoint/MessageCountsOperation.cs
@@ -57,7 +57,7 @@ namespace PubnubApi.EndPoint
                 throw new MissingMemberException("Invalid Subscribe Key");
             }
 
-#if NETFX_CORE || WINDOWS_UWP || UAP || NETSTANDARD10 || NETSTANDARD11 || NETSTANDARD12
+#if NETFX_CORE || WINDOWS_UWP || UAP || NETSTANDARD
             Task.Factory.StartNew(() =>
             {
                 this.savedCallback = callback;
@@ -75,7 +75,7 @@ namespace PubnubApi.EndPoint
 
         internal void Retry()
         {
-#if NETFX_CORE || WINDOWS_UWP || UAP || NETSTANDARD10 || NETSTANDARD11 || NETSTANDARD12
+#if NETFX_CORE || WINDOWS_UWP || UAP || NETSTANDARD
             Task.Factory.StartNew(() =>
             {
                 MessageCounts(this.channelNames, this.msgCountArrayTimetoken, this.queryParam, savedCallback);

--- a/src/Api/PubnubApi/EndPoint/Presence/GetStateOperation.cs
+++ b/src/Api/PubnubApi/EndPoint/Presence/GetStateOperation.cs
@@ -58,7 +58,7 @@ namespace PubnubApi.EndPoint
 
         public void Async(PNCallback<PNGetStateResult> callback)
         {
-#if NETFX_CORE || WINDOWS_UWP || UAP || NETSTANDARD10 || NETSTANDARD11 || NETSTANDARD12
+#if NETFX_CORE || WINDOWS_UWP || UAP || NETSTANDARD
             Task.Factory.StartNew(() =>
             {
                 this.savedCallback = callback;
@@ -76,7 +76,7 @@ namespace PubnubApi.EndPoint
 
         internal void Retry()
         {
-#if NETFX_CORE || WINDOWS_UWP || UAP || NETSTANDARD10 || NETSTANDARD11 || NETSTANDARD12
+#if NETFX_CORE || WINDOWS_UWP || UAP || NETSTANDARD
             Task.Factory.StartNew(() =>
             {
                 GetUserState(this.channelNames, this.channelGroupNames, this.channelUUID, this.queryParam, savedCallback);

--- a/src/Api/PubnubApi/EndPoint/Presence/HereNowOperation.cs
+++ b/src/Api/PubnubApi/EndPoint/Presence/HereNowOperation.cs
@@ -65,7 +65,7 @@ namespace PubnubApi.EndPoint
 
         public void Async(PNCallback<PNHereNowResult> callback)
         {
-#if NETFX_CORE || WINDOWS_UWP || UAP || NETSTANDARD10 || NETSTANDARD11 || NETSTANDARD12
+#if NETFX_CORE || WINDOWS_UWP || UAP || NETSTANDARD
             Task.Factory.StartNew(() =>
             {
                 this.savedCallback = callback;
@@ -83,7 +83,7 @@ namespace PubnubApi.EndPoint
 
         internal void Retry()
         {
-#if NETFX_CORE || WINDOWS_UWP || UAP || NETSTANDARD10 || NETSTANDARD11 || NETSTANDARD12
+#if NETFX_CORE || WINDOWS_UWP || UAP || NETSTANDARD
             Task.Factory.StartNew(() =>
             {
                 HereNow(this.channelNames, this.channelGroupNames, this.includeChannelUUIDs, this.includeUserState, this.queryParam, savedCallback);

--- a/src/Api/PubnubApi/EndPoint/Presence/SetStateOperation.cs
+++ b/src/Api/PubnubApi/EndPoint/Presence/SetStateOperation.cs
@@ -65,7 +65,7 @@ namespace PubnubApi.EndPoint
 
         public void Async(PNCallback<PNSetStateResult> callback)
         {
-#if NETFX_CORE || WINDOWS_UWP || UAP || NETSTANDARD10 || NETSTANDARD11 || NETSTANDARD12
+#if NETFX_CORE || WINDOWS_UWP || UAP || NETSTANDARD
             Task.Factory.StartNew(() =>
             {
                 this.savedCallback = callback;
@@ -85,7 +85,7 @@ namespace PubnubApi.EndPoint
 
         internal void Retry()
         {
-#if NETFX_CORE || WINDOWS_UWP || UAP || NETSTANDARD10 || NETSTANDARD11 || NETSTANDARD12
+#if NETFX_CORE || WINDOWS_UWP || UAP || NETSTANDARD
             Task.Factory.StartNew(() =>
             {
                 string serializedState = jsonLibrary.SerializeToJsonString(this.userState);

--- a/src/Api/PubnubApi/EndPoint/Presence/WhereNowOperation.cs
+++ b/src/Api/PubnubApi/EndPoint/Presence/WhereNowOperation.cs
@@ -44,7 +44,7 @@ namespace PubnubApi.EndPoint
 
         public void Async(PNCallback<PNWhereNowResult> callback)
         {
-#if NETFX_CORE || WINDOWS_UWP || UAP || NETSTANDARD10 || NETSTANDARD11 || NETSTANDARD12
+#if NETFX_CORE || WINDOWS_UWP || UAP || NETSTANDARD
             Task.Factory.StartNew(() =>
             {
                 this.savedCallback = callback;
@@ -62,7 +62,7 @@ namespace PubnubApi.EndPoint
 
         internal void Retry()
         {
-#if NETFX_CORE || WINDOWS_UWP || UAP || NETSTANDARD10 || NETSTANDARD11 || NETSTANDARD12
+#if NETFX_CORE || WINDOWS_UWP || UAP || NETSTANDARD
             Task.Factory.StartNew(() =>
             {
                 WhereNow(this.whereNowUUID, this.queryParam, savedCallback);

--- a/src/Api/PubnubApi/EndPoint/PubSub/FireOperation.cs
+++ b/src/Api/PubnubApi/EndPoint/PubSub/FireOperation.cs
@@ -67,7 +67,7 @@ namespace PubnubApi.EndPoint
 
         public void Async(PNCallback<PNPublishResult> callback)
         {
-#if NETFX_CORE || WINDOWS_UWP || UAP || NETSTANDARD10 || NETSTANDARD11 || NETSTANDARD12
+#if NETFX_CORE || WINDOWS_UWP || UAP || NETSTANDARD
             Task.Factory.StartNew(() =>
             {
                 syncRequest = false;
@@ -104,7 +104,7 @@ namespace PubnubApi.EndPoint
 
         internal void Retry()
         {
-#if NETFX_CORE || WINDOWS_UWP || UAP || NETSTANDARD10 || NETSTANDARD11 || NETSTANDARD12
+#if NETFX_CORE || WINDOWS_UWP || UAP || NETSTANDARD
             Task.Factory.StartNew(() =>
             {
                 if (!syncRequest)

--- a/src/Api/PubnubApi/EndPoint/PubSub/PublishOperation.cs
+++ b/src/Api/PubnubApi/EndPoint/PubSub/PublishOperation.cs
@@ -101,7 +101,7 @@ namespace PubnubApi.EndPoint
                 throw new ArgumentException("Missing userCallback");
             }
 
-#if NETFX_CORE || WINDOWS_UWP || UAP || NETSTANDARD10 || NETSTANDARD11 || NETSTANDARD12
+#if NETFX_CORE || WINDOWS_UWP || UAP || NETSTANDARD
             Task.Factory.StartNew(() =>
             {
                 syncRequest = false;
@@ -148,7 +148,7 @@ namespace PubnubApi.EndPoint
 
         internal void Retry()
         {
-#if NETFX_CORE || WINDOWS_UWP || UAP || NETSTANDARD10 || NETSTANDARD11 || NETSTANDARD12
+#if NETFX_CORE || WINDOWS_UWP || UAP || NETSTANDARD
             Task.Factory.StartNew(() =>
             {
                 if (!syncRequest)

--- a/src/Api/PubnubApi/EndPoint/PubSub/SubscribeOperation.cs
+++ b/src/Api/PubnubApi/EndPoint/PubSub/SubscribeOperation.cs
@@ -130,7 +130,7 @@ namespace PubnubApi.EndPoint
                 initialSubscribeUrlParams.Add("filter-expr", UriUtil.EncodeUriComponent(false, config.FilterExpression, PNOperationType.PNSubscribeOperation, false, false, false));
             }
 
-#if NETFX_CORE || WINDOWS_UWP || UAP || NETSTANDARD10 || NETSTANDARD11 || NETSTANDARD12
+#if NETFX_CORE || WINDOWS_UWP || UAP || NETSTANDARD
             Task.Factory.StartNew(() =>
             {
                 manager = new SubscribeManager(config, jsonLibrary, unit, pubnubLog, pubnubTelemetryMgr, PubnubInstance);

--- a/src/Api/PubnubApi/EndPoint/PubSub/UnsubscribeAllOperation.cs
+++ b/src/Api/PubnubApi/EndPoint/PubSub/UnsubscribeAllOperation.cs
@@ -35,7 +35,7 @@ namespace PubnubApi.EndPoint
 
         private void UnsubscribeAll()
         {
-#if NETFX_CORE || WINDOWS_UWP || UAP || NETSTANDARD10 || NETSTANDARD11 || NETSTANDARD12
+#if NETFX_CORE || WINDOWS_UWP || UAP || NETSTANDARD
             Task.Factory.StartNew(() =>
             {
                 SubscribeManager manager = new SubscribeManager(config, jsonLibrary, unit, pubnubLog, pubnubTelemetryMgr, PubnubInstance);

--- a/src/Api/PubnubApi/EndPoint/PubSub/UnsubscribeOperation.cs
+++ b/src/Api/PubnubApi/EndPoint/PubSub/UnsubscribeOperation.cs
@@ -64,7 +64,7 @@ namespace PubnubApi.EndPoint
 
             LoggingMethod.WriteToLog(pubnubLog, string.Format("DateTime {0}, requested unsubscribe for channel(s)={1}, cg(s)={2}", DateTime.Now.ToString(CultureInfo.InvariantCulture), channel, channelGroup), config.LogVerbosity);
 
-#if NETFX_CORE || WINDOWS_UWP || UAP || NETSTANDARD10 || NETSTANDARD11 || NETSTANDARD12
+#if NETFX_CORE || WINDOWS_UWP || UAP || NETSTANDARD
             Task.Factory.StartNew(() =>
             {
                 SubscribeManager manager = new SubscribeManager(config, jsonLibrary, unit, pubnubLog, pubnubTelemetryMgr, PubnubInstance);

--- a/src/Api/PubnubApi/EndPoint/Push/AddPushChannelOperation.cs
+++ b/src/Api/PubnubApi/EndPoint/Push/AddPushChannelOperation.cs
@@ -57,7 +57,7 @@ namespace PubnubApi.EndPoint
 
         public void Async(PNCallback<PNPushAddChannelResult> callback)
         {
-#if NETFX_CORE || WINDOWS_UWP || UAP || NETSTANDARD10 || NETSTANDARD11 || NETSTANDARD12
+#if NETFX_CORE || WINDOWS_UWP || UAP || NETSTANDARD
             Task.Factory.StartNew(() =>
             {
                 this.savedCallback = callback;
@@ -75,7 +75,7 @@ namespace PubnubApi.EndPoint
 
         internal void Retry()
         {
-#if NETFX_CORE || WINDOWS_UWP || UAP || NETSTANDARD10 || NETSTANDARD11 || NETSTANDARD12
+#if NETFX_CORE || WINDOWS_UWP || UAP || NETSTANDARD
             Task.Factory.StartNew(() =>
             {
                 RegisterDevice(this.channelNames, this.pubnubPushType, this.deviceTokenId, this.queryParam, savedCallback);

--- a/src/Api/PubnubApi/EndPoint/Push/AuditPushChannelOperation.cs
+++ b/src/Api/PubnubApi/EndPoint/Push/AuditPushChannelOperation.cs
@@ -49,7 +49,7 @@ namespace PubnubApi.EndPoint
 
         public void Async(PNCallback<PNPushListProvisionsResult> callback)
         {
-#if NETFX_CORE || WINDOWS_UWP || UAP || NETSTANDARD10 || NETSTANDARD11 || NETSTANDARD12
+#if NETFX_CORE || WINDOWS_UWP || UAP || NETSTANDARD
             Task.Factory.StartNew(() =>
             {
                 this.savedCallback = callback;
@@ -67,7 +67,7 @@ namespace PubnubApi.EndPoint
 
         internal void Retry()
         {
-#if NETFX_CORE || WINDOWS_UWP || UAP || NETSTANDARD10 || NETSTANDARD11 || NETSTANDARD12
+#if NETFX_CORE || WINDOWS_UWP || UAP || NETSTANDARD
             Task.Factory.StartNew(() =>
             {
                 GetChannelsForDevice(this.pubnubPushType, this.deviceTokenId, this.queryParam, savedCallback);

--- a/src/Api/PubnubApi/EndPoint/Push/RemoveAllPushChannelsOperation.cs
+++ b/src/Api/PubnubApi/EndPoint/Push/RemoveAllPushChannelsOperation.cs
@@ -49,7 +49,7 @@ namespace PubnubApi.EndPoint
 
         public void Async(PNCallback<PNPushRemoveAllChannelsResult> callback)
         {
-#if NETFX_CORE || WINDOWS_UWP || UAP || NETSTANDARD10 || NETSTANDARD11 || NETSTANDARD12
+#if NETFX_CORE || WINDOWS_UWP || UAP || NETSTANDARD
             Task.Factory.StartNew(() =>
             {
                 this.savedCallback = callback;
@@ -67,7 +67,7 @@ namespace PubnubApi.EndPoint
 
         internal void Retry()
         {
-#if NETFX_CORE || WINDOWS_UWP || UAP || NETSTANDARD10 || NETSTANDARD11 || NETSTANDARD12
+#if NETFX_CORE || WINDOWS_UWP || UAP || NETSTANDARD
             Task.Factory.StartNew(() =>
             {
                 RemoveAllChannelsForDevice(this.pubnubPushType, this.deviceTokenId, this.queryParam, savedCallback);

--- a/src/Api/PubnubApi/EndPoint/Push/RemovePushChannelOperation.cs
+++ b/src/Api/PubnubApi/EndPoint/Push/RemovePushChannelOperation.cs
@@ -57,7 +57,7 @@ namespace PubnubApi.EndPoint
 
         public void Async(PNCallback<PNPushRemoveChannelResult> callback)
         {
-#if NETFX_CORE || WINDOWS_UWP || UAP || NETSTANDARD10 || NETSTANDARD11 || NETSTANDARD12
+#if NETFX_CORE || WINDOWS_UWP || UAP || NETSTANDARD
             Task.Factory.StartNew(() =>
             {
                 this.savedCallback = callback;
@@ -75,7 +75,7 @@ namespace PubnubApi.EndPoint
 
         internal void Retry()
         {
-#if NETFX_CORE || WINDOWS_UWP || UAP || NETSTANDARD10 || NETSTANDARD11 || NETSTANDARD12
+#if NETFX_CORE || WINDOWS_UWP || UAP || NETSTANDARD
             Task.Factory.StartNew(() =>
             {
                 RemoveChannelForDevice(this.channelNames, this.pubnubPushType, this.deviceTokenId, this.queryParam, savedCallback);

--- a/src/Api/PubnubApi/EndPoint/TimeOperation.cs
+++ b/src/Api/PubnubApi/EndPoint/TimeOperation.cs
@@ -38,7 +38,7 @@ namespace PubnubApi.EndPoint
 
         public void Async(PNCallback<PNTimeResult> callback)
         {
-#if NETFX_CORE || WINDOWS_UWP || UAP || NETSTANDARD10 || NETSTANDARD11 || NETSTANDARD12
+#if NETFX_CORE || WINDOWS_UWP || UAP || NETSTANDARD
             Task.Factory.StartNew(() =>
             {
                 this.savedCallback = callback;
@@ -56,7 +56,7 @@ namespace PubnubApi.EndPoint
 
         internal void Retry()
         {
-#if NETFX_CORE || WINDOWS_UWP || UAP || NETSTANDARD10 || NETSTANDARD11 || NETSTANDARD12
+#if NETFX_CORE || WINDOWS_UWP || UAP || NETSTANDARD
             Task.Factory.StartNew(() =>
             {
                 Time(this.queryParam, savedCallback);

--- a/src/Api/PubnubApi/NewtonsoftJsonDotNet.cs
+++ b/src/Api/PubnubApi/NewtonsoftJsonDotNet.cs
@@ -168,7 +168,7 @@ namespace PubnubApi
                 ret = true;
             }
             LoggingMethod.WriteToLog(pubnubLog, string.Format("DateTime: {0}, NET35/40 IsGenericTypeForMessage = {1}", DateTime.Now.ToString(CultureInfo.InvariantCulture), ret.ToString()), config.LogVerbosity);
-#elif (NETSTANDARD10 || NETSTANDARD11 || NETSTANDARD12 || NETSTANDARD13 || NETSTANDARD14 || NETSTANDARD20 || UAP || NETFX_CORE || WINDOWS_UWP)
+#elif (NETSTANDARD || NETSTANDARD13 || NETSTANDARD14 || NETSTANDARD20 || UAP || NETFX_CORE || WINDOWS_UWP)
             if (typeof(T).GetTypeInfo().IsGenericType && typeof(T).GetGenericTypeDefinition() == typeof(PNMessageResult<>))
             {
                 ret = true;
@@ -261,7 +261,7 @@ namespace PubnubApi
 
                 ret = (T)Convert.ChangeType(message, specific, CultureInfo.InvariantCulture);
             }
-#elif NETSTANDARD10 || NETSTANDARD11 || NETSTANDARD12 || NETSTANDARD13 || NETSTANDARD14 || NETSTANDARD20 || UAP || NETFX_CORE || WINDOWS_UWP
+#elif NETSTANDARD || NETSTANDARD13 || NETSTANDARD14 || NETSTANDARD20 || UAP || NETFX_CORE || WINDOWS_UWP
             Type dataType = typeof(T).GetTypeInfo().GenericTypeArguments[0];
             Type generic = typeof(PNMessageResult<>);
             Type specific = generic.MakeGenericType(dataType);

--- a/src/Api/PubnubApiPCL/PubnubApiPCL.csproj
+++ b/src/Api/PubnubApiPCL/PubnubApiPCL.csproj
@@ -425,23 +425,23 @@
   </ItemGroup>
 
   <PropertyGroup Condition=" '$(TargetFramework)' == 'netstandard1.0' ">
-    <DefineConstants>$(DefineConstants);NETSTANDARD10</DefineConstants>
+    <DefineConstants>$(DefineConstants);NETSTANDARD;NETSTANDARD10</DefineConstants>
   </PropertyGroup>
 
   <PropertyGroup Condition=" '$(TargetFramework)' == 'netstandard1.1' ">
-    <DefineConstants>$(DefineConstants);NETSTANDARD11</DefineConstants>
+    <DefineConstants>$(DefineConstants);NETSTANDARD;NETSTANDARD11</DefineConstants>
   </PropertyGroup>
 
   <PropertyGroup Condition=" '$(TargetFramework)' == 'netstandard1.3' ">
-    <DefineConstants>$(DefineConstants);NETSTANDARD13</DefineConstants>
+    <DefineConstants>$(DefineConstants);NETSTANDARD;NETSTANDARD13</DefineConstants>
   </PropertyGroup>
 
   <PropertyGroup Condition=" '$(TargetFramework)' == 'netstandard1.4' ">
-    <DefineConstants>$(DefineConstants);NETSTANDARD14</DefineConstants>
+    <DefineConstants>$(DefineConstants);NETSTANDARD;NETSTANDARD14</DefineConstants>
   </PropertyGroup>
 
   <PropertyGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
-    <DefineConstants>$(DefineConstants);NETSTANDARD20</DefineConstants>
+    <DefineConstants>$(DefineConstants);NETSTANDARD;NETSTANDARD20</DefineConstants>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
This is important because there is a significant overhead in creating a brand new thread. Which happens even on publishing a single message asynchronously.

These API's will be present in all future versions of NETSTANDARD so it makes sense not to have to update `if` compile declarations every time a new supported NETSTANDARD version is created