### PR TITLE
PubNub C# SDK 4.14.0 Release

### DIFF
--- a/.pubnub.yml
+++ b/.pubnub.yml
@@ -1,8 +1,15 @@
 name: c-sharp
-version: "4.13.0.0"
+version: "4.14.0.0"
 schema: 1
 scm: github.com/pubnub/c-sharp
 changelog: 
+  - version: 4.14.0.0
+    date: May 18, 2021
+    changes:
+      - type: bug
+        text: Refactored code to handle malformed message for re-subscribe.
+      - type: improvement
+        text: Upgraded System.Net.Http minimum version to 4.3.4, to address security advisory CVE-2018-8292 in PubnubPCL.
   - version: 4.13.0.0
     date: January 18, 2021
     changes:
@@ -554,7 +561,7 @@ features:
     - QUERY-PARAM    
 supported-platforms:
   - 
-    version: Pubnub 'C#' 4.13.0.0
+    version: Pubnub 'C#' 4.14.0.0
     platforms:
       - Windows 10 and up
       - Windows Server 2008 and up
@@ -564,7 +571,7 @@ supported-platforms:
       - .Net Framework 4.5
       - .Net Framework 4.6.1+
   - 
-    version: PubnubPCL 'C#' 4.13.0.0
+    version: PubnubPCL 'C#' 4.14.0.0
     platforms:
       - Xamarin.Android
       - Xamarin.iOS
@@ -583,7 +590,7 @@ supported-platforms:
       - .Net Standard 2.1
       - .Net Core
   - 
-    version: PubnubUWP 'C#' 4.13.0.0
+    version: PubnubUWP 'C#' 4.14.0.0
     platforms:
       - Windows Phone 10
       - Universal Windows Apps

--- a/src/Api/PubnubApi/EndPoint/PubSub/SubscribeManager.cs
+++ b/src/Api/PubnubApi/EndPoint/PubSub/SubscribeManager.cs
@@ -1033,11 +1033,11 @@ namespace PubnubApi.EndPoint
                     if (networkConnection && PubnubInstance != null && SubscribeRequestTracker.ContainsKey(PubnubInstance.InstanceId))
                     {
                         DateTime lastSubscribeRequestTime = SubscribeRequestTracker[PubnubInstance.InstanceId];
-                        if ((DateTime.Now - lastSubscribeRequestTime).TotalSeconds <= config.SubscribeTimeout)
+                        if ((DateTime.Now - lastSubscribeRequestTime).TotalSeconds < config.SubscribeTimeout)
                         {
                             LoggingMethod.WriteToLog(pubnubLog, string.Format("DateTime {0}, SubscribeManager - ok. expected subscribe within threshold limit of SubscribeTimeout. No action needed", DateTime.Now.ToString(CultureInfo.InvariantCulture)), config.LogVerbosity);
                         }
-                        else if ((DateTime.Now - lastSubscribeRequestTime).TotalSeconds > 2 * config.SubscribeTimeout)
+                        else if ((DateTime.Now - lastSubscribeRequestTime).TotalSeconds > 2 * (config.SubscribeTimeout - config.SubscribeTimeout/2))
                         {
                             LoggingMethod.WriteToLog(pubnubLog, string.Format("DateTime {0}, SubscribeManager - **No auto subscribe within threshold limit of SubscribeTimeout**. Calling MultiChannelSubscribeRequest", DateTime.Now.ToString(CultureInfo.InvariantCulture)), config.LogVerbosity);
                             Task.Factory.StartNew(() =>

--- a/src/Api/PubnubApi/Properties/AssemblyInfo.cs
+++ b/src/Api/PubnubApi/Properties/AssemblyInfo.cs
@@ -9,10 +9,10 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyTitle("Pubnub C# SDK")]
 [assembly: AssemblyCompany("PubNub")]
 [assembly: AssemblyProduct("Pubnub C# SDK")]
-[assembly: AssemblyCopyright("Copyright ©  2020")]
+[assembly: AssemblyCopyright("Copyright ©  2021")]
 [assembly: AssemblyTrademark("")]
-[assembly: AssemblyVersion("4.13.0.0")]
-[assembly: AssemblyFileVersion("4.13.0.0")]
+[assembly: AssemblyVersion("4.14.0.0")]
+[assembly: AssemblyFileVersion("4.14.0.0")]
 // Setting ComVisible to false makes the types in this assembly not visible
 // to COM components.  If you need to access a type in this assembly from
 // COM, set the ComVisible attribute to true on that type.

--- a/src/Api/PubnubApi/PubnubApi.csproj
+++ b/src/Api/PubnubApi/PubnubApi.csproj
@@ -13,7 +13,7 @@
 
   <PropertyGroup>
     <PackageId>Pubnub</PackageId>
-    <PackageVersion>4.13.0.0</PackageVersion>
+    <PackageVersion>4.14.0.0</PackageVersion>
     <Title>PubNub C# .NET - Web Data Push API</Title>
     <Authors>Pandu Masabathula</Authors>
     <Owners>PubNub</Owners>
@@ -21,11 +21,12 @@
     <PackageIconUrl>http://pubnub.s3.amazonaws.com/2011/powered-by-pubnub/pubnub-icon-600x600.png</PackageIconUrl>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
     <RepositoryUrl>https://github.com/pubnub/c-sharp/</RepositoryUrl>
-    <PackageReleaseNotes>Increase message count default limit for History v3 api call to 100 for single channel.</PackageReleaseNotes>
+    <PackageReleaseNotes>Added code to handle malformed message.
+Upgraded System.Net.Http minimum version to 4.3.4, to address security advisory CVE-2018-8292 in PubnubPCL</PackageReleaseNotes>
     <PackageTags>Web Data Push Real-time Notifications ESB Message Broadcasting Distributed Computing</PackageTags>
     <!--<Summary>PubNub is a Massively Scalable Web Push Service for Web and Mobile Games.  This is a cloud-based service for broadcasting messages to thousands of web and mobile clients simultaneously</Summary>-->
     <Description>PubNub is a Massively Scalable Web Push Service for Web and Mobile Games.  This is a cloud-based service for broadcasting messages to thousands of web and mobile clients simultaneously</Description>
-    <Copyright>PubNub 2012-2020</Copyright>
+    <Copyright>PubNub 2012-2021</Copyright>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
   </PropertyGroup>
 

--- a/src/Api/PubnubApi/PubnubCoreBase.cs
+++ b/src/Api/PubnubApi/PubnubCoreBase.cs
@@ -1640,7 +1640,7 @@ namespace PubnubApi
         protected void ProcessResponseCallbacks<T>(List<object> result, RequestState<T> asyncRequestState)
         {
             bool callbackAvailable = false;
-            if (result != null && result.Count >= 1 && asyncRequestState.PubnubCallback != null || SubscribeCallbackListenerList.Count >= 1)
+            if (result != null && result.Count >= 1 && (asyncRequestState.PubnubCallback != null || SubscribeCallbackListenerList.Count >= 1))
             {
                 callbackAvailable = true;
             }

--- a/src/Api/PubnubApiPCL/PubnubApiPCL.csproj
+++ b/src/Api/PubnubApiPCL/PubnubApiPCL.csproj
@@ -14,7 +14,7 @@
 
   <PropertyGroup>
     <PackageId>PubnubPCL</PackageId>
-    <PackageVersion>4.13.0.0</PackageVersion>
+    <PackageVersion>4.14.0.0</PackageVersion>
     <Title>PubNub C# .NET - Web Data Push API</Title>
     <Authors>Pandu Masabathula</Authors>
     <Owners>PubNub</Owners>
@@ -22,11 +22,12 @@
     <PackageIconUrl>http://pubnub.s3.amazonaws.com/2011/powered-by-pubnub/pubnub-icon-600x600.png</PackageIconUrl>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
     <RepositoryUrl>https://github.com/pubnub/c-sharp/</RepositoryUrl>
-    <PackageReleaseNotes>Increase message count default limit for History v3 api call to 100 for single channel.</PackageReleaseNotes>
+    <PackageReleaseNotes>Added code to handle malformed message.
+Upgraded System.Net.Http minimum version to 4.3.4, to address security advisory CVE-2018-8292 in PubnubPCL</PackageReleaseNotes>
     <PackageTags>Web Data Push Real-time Notifications ESB Message Broadcasting Distributed Computing</PackageTags>
     <!--<Summary>PubNub is a Massively Scalable Web Push Service for Web and Mobile Games.  This is a cloud-based service for broadcasting messages to thousands of web and mobile clients simultaneously</Summary>-->
     <Description>PubNub is a Massively Scalable Web Push Service for Web and Mobile Games.  This is a cloud-based service for broadcasting messages to thousands of web and mobile clients simultaneously</Description>
-    <Copyright>PubNub 2012-2020</Copyright>
+    <Copyright>PubNub 2012-2021</Copyright>
 
     <PackageTargetFallback Condition=" '$(TargetFramework)' == 'netstandard1.0' ">$(PackageTargetFallback);dnxcore50</PackageTargetFallback>
     <!--<NetStandardImplicitPackageVersion Condition=" '$(TargetFramework)' == 'netstandard1.0' ">1.6.1</NetStandardImplicitPackageVersion>-->
@@ -665,7 +666,7 @@
     <PackageReference Include="System.Text.Encoding.Extensions" Version="4.3.0">
       <PrivateAssets>None</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="System.Net.Http" Version="4.3.0">
+    <PackageReference Include="System.Net.Http" Version="4.3.4">
       <PrivateAssets>None</PrivateAssets>
     </PackageReference>
     <PackageReference Include="System.Net.Primitives" Version="4.3.0">
@@ -717,7 +718,7 @@
     <PackageReference Include="System.Text.Encoding.Extensions" Version="4.3.0">
       <PrivateAssets>None</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="System.Net.Http" Version="4.3.0">
+    <PackageReference Include="System.Net.Http" Version="4.3.4">
       <PrivateAssets>None</PrivateAssets>
     </PackageReference>
     <PackageReference Include="System.Net.Primitives" Version="4.3.0">
@@ -756,7 +757,7 @@
     <PackageReference Include="System.Text.Encoding.Extensions" Version="4.3.0">
       <PrivateAssets>None</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="System.Net.Http" Version="4.3.0">
+    <PackageReference Include="System.Net.Http" Version="4.3.4">
       <PrivateAssets>None</PrivateAssets>
     </PackageReference>
     <PackageReference Include="System.Net.Primitives" Version="4.3.0">

--- a/src/Api/PubnubApiUWP/PubnubApiUWP.csproj
+++ b/src/Api/PubnubApiUWP/PubnubApiUWP.csproj
@@ -15,7 +15,7 @@
 
   <PropertyGroup>
     <PackageId>PubnubUWP</PackageId>
-    <PackageVersion>4.13.0.0</PackageVersion>
+    <PackageVersion>4.14.0.0</PackageVersion>
     <Title>PubNub C# .NET - Web Data Push API</Title>
     <Authors>Pandu Masabathula</Authors>
     <Owners>PubNub</Owners>
@@ -23,11 +23,12 @@
     <PackageIconUrl>http://pubnub.s3.amazonaws.com/2011/powered-by-pubnub/pubnub-icon-600x600.png</PackageIconUrl>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
     <RepositoryUrl>https://github.com/pubnub/c-sharp/</RepositoryUrl>
-    <PackageReleaseNotes>Increase message count default limit for History v3 api call to 100 for single channel.</PackageReleaseNotes>
+    <PackageReleaseNotes>Added code to handle malformed message.
+Upgraded System.Net.Http minimum version to 4.3.4, to address security advisory CVE-2018-8292 in PubnubPCL</PackageReleaseNotes>
     <PackageTags>Web Data Push Real-time Notifications ESB Message Broadcasting Distributed Computing</PackageTags>
     <!--<Summary>PubNub is a Massively Scalable Web Push Service for Web and Mobile Games.  This is a cloud-based service for broadcasting messages to thousands of web and mobile clients simultaneously</Summary>-->
     <Description>PubNub is a Massively Scalable Web Push Service for Web and Mobile Games.  This is a cloud-based service for broadcasting messages to thousands of web and mobile clients simultaneously</Description>
-    <Copyright>PubNub 2012-2020</Copyright>
+    <Copyright>PubNub 2012-2021</Copyright>
 
     <!--<PackageTargetFallback Condition=" '$(TargetFramework)' == 'netstandard1.0' ">$(PackageTargetFallback);dnxcore50</PackageTargetFallback>-->
     <!--<NetStandardImplicitPackageVersion Condition=" '$(TargetFramework)' == 'netstandard1.0' ">1.6.1</NetStandardImplicitPackageVersion>-->

--- a/src/Examples/PubnubApi.ConsoleExample/PubnubApi.ConsoleExample.csproj
+++ b/src/Examples/PubnubApi.ConsoleExample/PubnubApi.ConsoleExample.csproj
@@ -45,8 +45,8 @@
     <Reference Include="Newtonsoft.Json, Version=9.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Newtonsoft.Json.9.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
-    <Reference Include="Pubnub, Version=4.13.0.0, Culture=neutral, PublicKeyToken=dc66f52ce6619f44, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Pubnub.4.13.0\lib\net461\Pubnub.dll</HintPath>
+    <Reference Include="Pubnub, Version=4.14.0.0, Culture=neutral, PublicKeyToken=dc66f52ce6619f44, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Pubnub.4.14.0\lib\net461\Pubnub.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.ComponentModel.Composition" />

--- a/src/Examples/PubnubApi.ConsoleExample/packages.config
+++ b/src/Examples/PubnubApi.ConsoleExample/packages.config
@@ -2,7 +2,7 @@
 <packages>
   <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net461" />
   <package id="Portable.BouncyCastle" version="1.8.1.2" targetFramework="net461" />
-  <package id="Pubnub" version="4.13.0" targetFramework="net461" />
+  <package id="Pubnub" version="4.14.0" targetFramework="net461" />
   <package id="System.Collections" version="4.0.11" targetFramework="net461" />
   <package id="System.Diagnostics.Debug" version="4.0.11" targetFramework="net461" />
   <package id="System.Globalization" version="4.0.11" targetFramework="net461" />


### PR DESCRIPTION
## 🐛: Resubscribe fix for malformed message.

Refactored code to handle malformed message for re-subscribe.

## 🐛: Security Advisory Fix.

Upgraded System.Net.Http minimum version to 4.3.4, to address security
advisory CVE-2018-8292 in PubnubPCL.