### PR TITLE
Dispose RandomNumberGenerator

### DIFF
--- a/src/Api/PubnubApi/Security/PubnubCrypto.cs
+++ b/src/Api/PubnubApi/Security/PubnubCrypto.cs
@@ -93,7 +93,20 @@ namespace PubnubApi
 #if NETSTANDARD10 || NETSTANDARD11
                     new Random().NextBytes(ivBytes);
 #else
-                    RandomNumberGenerator.Create().GetBytes(ivBytes);
+                    var rng = RandomNumberGenerator.Create();
+
+                    try
+                    {
+                        rng.GetBytes(ivBytes);
+                    }
+                    finally
+                    {
+                        var disposable = rng as IDisposable;
+                        if (disposable != null)
+                        {
+                            disposable.Dispose();
+                        }
+                    }
 #endif
                 }
                 else


### PR DESCRIPTION
`RandomNumberGenerator` implements `IDisposable` from .NET 4.0, .NET Core 1.0 and .NET Standard 1.3 ([docs](https://docs.microsoft.com/en-us/dotnet/api/system.security.cryptography.randomnumbergenerator.dispose)), so should be disposed of after use.

The `as` pattern is used to remove the need for a third conditional compilation block to handle .NET 3.5 where it does not implement `IDisposable`.
