### PR TITLE
Switch deployment to GitHub Actions

### DIFF
--- a/.github/workflows/commands-handler.yml
+++ b/.github/workflows/commands-handler.yml
@@ -24,3 +24,4 @@ jobs:
         with:
           token: ${{ secrets.GH_TOKEN }}
           listener: client-engineering-bot
+          jira-api-key: ${{ secrets.JIRA_API_KEY }}

--- a/.github/workflows/commands-handler.yml
+++ b/.github/workflows/commands-handler.yml
@@ -1,0 +1,26 @@
+name: Commands processor
+
+on:
+  issue_comment:
+    types: [created]
+
+jobs:
+  process:
+    name: Process command
+    if: ${{ github.event.issue.pull_request && endsWith(github.repository, '-private') != true && startsWith(github.event.comment.body, '@client-engineering-bot ') }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+      - name: Checkout release actions
+        uses: actions/checkout@v2
+        with:
+          repository: pubnub/client-engineering-deployment-tools
+          ref: v1
+          token: ${{ secrets.GH_TOKEN }}
+          path: .github/.release/actions
+      - name: Process changelog entries
+        uses: ./.github/.release/actions/actions/commands
+        with:
+          token: ${{ secrets.GH_TOKEN }}
+          listener: client-engineering-bot

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -83,4 +83,5 @@ jobs:
         uses: ./.github/.release/actions/actions/services/github-release
         with:
           token: ${{ secrets.GH_TOKEN }}
+          jira-api-key: ${{ secrets.JIRA_API_KEY }}
           last-service: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,47 +40,26 @@ jobs:
       - name: Add msbuild to PATH
         uses: microsoft/setup-msbuild@v1.0.3
       - name: Build packages
-        run: |
-          $RELEASES_PATH = "${{ github.workspace }}\.github\.release"
-          mkdir "$RELEASES_PATH"
-          mkdir "$RELEASES_PATH\Api"
-          mkdir "$RELEASES_PATH\PCL"
-          mkdir "$RELEASES_PATH\UWP"
-
-          # Build Api package.
-          cd "${{ github.workspace }}\src\Api\PubnubApi"
-          dotnet pack -o "$RELEASES_PATH\Api" -c Release
-
-          # Build PCL package.
-          cd "${{ github.workspace }}\src\Api\PubnubApiPCL"
-          dotnet pack -o "$RELEASES_PATH\PCL" -c Release
-
-          # Build UWP package.
-          cd "${{ github.workspace }}\src\Api\PubnubApiUWP"
-          dotnet restore
-          msbuild PubnubApiUWP.csproj /t:Pack /p:Configuration=Release /p:PackageOutputPath="$RELEASES_PATH\UWP" /v:n
+        env:
+          WORKSPACE_PATH: ${{ github.workspace }}
+        run: .\\.github\\workflows\\build-packages.ps1
+        shell: powershell
       - name: Publish packages
-        run: |
-          $RELEASES_PATH = "${{ github.workspace }}\.github\.release"
-
-          # Publish package
-          $PACKAGE_NAME = Get-ChildItem -Name -Path "$RELEASES_PATH\Api\*" -Include *.nupkg
-          $PACKAGE_PATH = "$RELEASES_PATH\Api\$PACKAGE_NAME"
-          nuget.exe push $PACKAGE_PATH -Source "https://www.nuget.org" -ApiKey ${{ secrets.NUGET_API_KEY }}
-
-          # Publish PCL package.
-          $PCL_PACKAGE_NAME = Get-ChildItem -Name -Path "$RELEASES_PATH\PCL\*" -Include *.nupkg
-          $PCL_PACKAGE_PATH = "$RELEASES_PATH\PCL\$PCL_PACKAGE_NAME"
-          nuget.exe push $PCL_PACKAGE_PATH -Source "https://www.nuget.org" -ApiKey ${{ secrets.NUGET_API_KEY }}
-          
-          # Publish UWP package.
-          $UWP_PACKAGE_NAME = Get-ChildItem -Name -Path "$RELEASES_PATH\UWP\*" -Include *.nupkg
-          $UWP_PACKAGE_PATH = "$RELEASES_PATH\UWP\$UWP_PACKAGE_NAME"
-          nuget.exe push $UWP_PACKAGE_PATH -Source "https://www.nuget.org" -ApiKey ${{ secrets.NUGET_API_KEY }}
+        env:
+          WORKSPACE_PATH: ${{ github.workspace }}
+          NUGET_API_KEY: ${{ secrets.NUGET_API_KEY }}
+        run: .\\.github\\workflows\\publish-packages.ps1
+        shell: powershell
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v2
+        with:
+          name: nuget-packages
+          path: ${{ github.workspace }}\.github\.release\artifacts\*.nupkg
+          retention-days: 1
   publish:
     name: Publish package
     runs-on: ubuntu-latest
-    needs: check-release
+    needs: publish-nuget
     if: ${{ needs.check-release.outputs.release == 'true' }}
     steps:
       - name: Checkout repository
@@ -95,6 +74,11 @@ jobs:
           ref: v1
           token: ${{ secrets.GH_TOKEN }}
           path: .github/.release/actions
+      - name: Download artifacts
+        uses: actions/download-artifact@v2
+        with:
+          name: nuget-packages
+          path: ${{ github.workspace }}/.github/.release/artifacts
       - name: Create Release
         uses: ./.github/.release/actions/actions/services/github-release
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,102 @@
+name: Automated product release
+
+on:
+  pull_request:
+    branches: [ master ]
+    types: [ closed ]
+
+
+jobs:
+  check-release:
+    name: Check release required
+    runs-on: ubuntu-latest
+    if: ${{ github.event.pull_request.merged && endsWith(github.repository, '-private') != true }}
+    outputs:
+      release: ${{ steps.check.outputs.ready }}
+    steps:
+      - name: Checkout actions
+        uses: actions/checkout@v2
+        with:
+          repository: pubnub/client-engineering-deployment-tools
+          ref: v1
+          token: ${{ secrets.GH_TOKEN }}
+          path: .github/.release/actions
+      - id: check
+        name: Check pre-release completed
+        uses: ./.github/.release/actions/actions/checks/release
+        with:
+          token: ${{ secrets.GH_TOKEN }}
+  publish-nuget:
+    name: Publish to NuGet
+    runs-on: windows-latest
+    needs: check-release
+    if: ${{ needs.check-release.outputs.release == 'true' }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+        with:
+          # This should be the same as the one specified for on.pull_request.branches
+          ref: master
+      - name: Add msbuild to PATH
+        uses: microsoft/setup-msbuild@v1.0.3
+      - name: Build packages
+        run: |
+          $RELEASES_PATH = "${{ github.workspace }}\.github\.release"
+          mkdir "$RELEASES_PATH"
+          mkdir "$RELEASES_PATH\Api"
+          mkdir "$RELEASES_PATH\PCL"
+          mkdir "$RELEASES_PATH\UWP"
+
+          # Build Api package.
+          cd "${{ github.workspace }}\src\Api\PubnubApi"
+          dotnet pack -o "$RELEASES_PATH\Api" -c Release
+
+          # Build PCL package.
+          cd "${{ github.workspace }}\src\Api\PubnubApiPCL"
+          dotnet pack -o "$RELEASES_PATH\PCL" -c Release
+
+          # Build UWP package.
+          cd "${{ github.workspace }}\src\Api\PubnubApiUWP"
+          dotnet restore
+          msbuild PubnubApiUWP.csproj /t:Pack /p:Configuration=Release /p:PackageOutputPath="$RELEASES_PATH\UWP" /v:n
+      - name: Publish packages
+        run: |
+          $RELEASES_PATH = "${{ github.workspace }}\.github\.release"
+
+          # Publish package
+          $PACKAGE_NAME = Get-ChildItem -Name -Path "$RELEASES_PATH\Api\*" -Include *.nupkg
+          $PACKAGE_PATH = "$RELEASES_PATH\Api\$PACKAGE_NAME"
+          nuget.exe push $PACKAGE_PATH -Source "https://www.nuget.org" -ApiKey ${{ secrets.NUGET_API_KEY }}
+
+          # Publish PCL package.
+          $PCL_PACKAGE_NAME = Get-ChildItem -Name -Path "$RELEASES_PATH\PCL\*" -Include *.nupkg
+          $PCL_PACKAGE_PATH = "$RELEASES_PATH\PCL\$PCL_PACKAGE_NAME"
+          nuget.exe push $PCL_PACKAGE_PATH -Source "https://www.nuget.org" -ApiKey ${{ secrets.NUGET_API_KEY }}
+          
+          # Publish UWP package.
+          $UWP_PACKAGE_NAME = Get-ChildItem -Name -Path "$RELEASES_PATH\UWP\*" -Include *.nupkg
+          $UWP_PACKAGE_PATH = "$RELEASES_PATH\UWP\$UWP_PACKAGE_NAME"
+          nuget.exe push $UWP_PACKAGE_PATH -Source "https://www.nuget.org" -ApiKey ${{ secrets.NUGET_API_KEY }}
+  publish:
+    name: Publish package
+    runs-on: ubuntu-latest
+    needs: check-release
+    if: ${{ needs.check-release.outputs.release == 'true' }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+        with:
+          # This should be the same as the one specified for on.pull_request.branches
+          ref: master
+      - name: Checkout actions
+        uses: actions/checkout@v2
+        with:
+          repository: pubnub/client-engineering-deployment-tools
+          ref: v1
+          token: ${{ secrets.GH_TOKEN }}
+          path: .github/.release/actions
+      - name: Create Release
+        uses: ./.github/.release/actions/actions/services/github-release
+        with:
+          token: ${{ secrets.GH_TOKEN }}
+          last-service: true

--- a/.github/workflows/release/build-packages.ps1
+++ b/.github/workflows/release/build-packages.ps1
@@ -1,0 +1,35 @@
+$githubWorkspace = $env:WORKSPACE_PATH
+
+
+# Create required directory structure.
+$RELEASES_PATH = "$githubWorkspace\.github\.release"
+$ARTIFACTS_PATH = "$RELEASES_PATH\artifacts"
+mkdir "$RELEASES_PATH"
+mkdir "$ARTIFACTS_PATH"
+
+# Build Api package.
+cd "$githubWorkspace\src\Api\PubnubApi"
+dotnet pack -o "$RELEASES_PATH\Api" -c Release
+
+# Build PCL package.
+cd "$githubWorkspace\src\Api\PubnubApiPCL"
+dotnet pack -o "$RELEASES_PATH\PCL" -c Release
+
+# Build UWP package.
+cd "$githubWorkspace\src\Api\PubnubApiUWP"
+dotnet restore
+msbuild PubnubApiUWP.csproj /t:Pack /p:Configuration=Release /p:PackageOutputPath="$RELEASES_PATH\UWP" /v:n
+
+
+# Copy built packages to artifacts folder.
+$PACKAGE_NAME = Get-ChildItem -Name -Path "$RELEASES_PATH\Api\*" -Include *.nupkg
+$PACKAGE_PATH = "$RELEASES_PATH\Api\$PACKAGE_NAME"
+cp "$PACKAGE_PATH" "$ARTIFACTS_PATH\$PACKAGE_NAME"
+
+$PCL_PACKAGE_NAME = Get-ChildItem -Name -Path "$RELEASES_PATH\PCL\*" -Include *.nupkg
+$PCL_PACKAGE_PATH = "$RELEASES_PATH\PCL\$PCL_PACKAGE_NAME"
+cp "$PCL_PACKAGE_PATH" "$ARTIFACTS_PATH\$PCL_PACKAGE_NAME"
+
+$UWP_PACKAGE_NAME = Get-ChildItem -Name -Path "$RELEASES_PATH\UWP\*" -Include *.nupkg
+$UWP_PACKAGE_PATH = "$RELEASES_PATH\UWP\$UWP_PACKAGE_NAME"
+cp "$UWP_PACKAGE_PATH" "$ARTIFACTS_PATH\$UWP_PACKAGE_NAME"

--- a/.github/workflows/release/pre-publish.js
+++ b/.github/workflows/release/pre-publish.js
@@ -1,0 +1,96 @@
+const process = require('process');
+const path = require('path');
+const fs = require('fs');
+
+
+
+/**
+ * Capitalize first character of passed string.
+ *
+ * @param {string} str Source string for which first letter should be capitalized.
+ *
+ * @return {string} Capitalized string.
+ */
+function capitalizedString(str) {
+  return `${str.replace(/^./, str[0].toUpperCase())}`;
+}
+
+/**
+ * Replace specified
+ * @param {string} src Source string in which replacement should be done.
+ * @param {string} str String which should be replaced.
+ * @param {string} replacement String which should be used to replace `str`.
+ * @param {number|undefined} index Index in string starting from which replacement should happen.
+ *
+ * @return {string} Modified string with replaced pieces.
+ */
+function replaceString(src, str, replacement, index) {
+  if (index === undefined) return src.replace(new RegExp(str, 'g'), replacement)
+  else return src.substring(0, index) + replacement + src.substring(index + str.length)
+}
+
+
+
+// Build change log entries suitable for project files update.
+const changelogPath = path.join(process.env['GITHUB_WORKSPACE'], '.github/.release', 'changelog.json');
+const changelogContent = fs.readFileSync(changelogPath).toString('utf8');
+let changeEntries = [];
+let changelog;
+
+if (changelogContent) {
+	try {
+    changelog = JSON.parse(changelogContent);
+
+	} catch (error) {
+    console.error(`Unable to parse changelog file content: '${error}'`);
+    process.exit(1);
+	}
+} else {
+  console.error(`Changelog information is missing: '${changelogPath}'`);
+  process.exit(2);
+}
+
+
+if (changelog && changelog.entries.length === 0) {
+  console.error('Changelog doesn\'t contain any changes.');
+  process.exit(3);
+}
+
+
+// Iterate over list of entries to compose final list of changes.
+for (let change of changelog.entries) {
+  let description = change.description || change.title;
+  if (description.endsWith('.'))
+    description = description.slice(0, description.length - 1);
+  if (change.isBreaking) description = `BREAKING CHANGES: ${description}`;
+
+  changeEntries.push(`${capitalizedString(description)}.`);
+}
+
+
+
+// Update C# project files 'PackageReleaseNotes' nodes.
+const nodeMatcher = new RegExp('<PackageReleaseNotes>((.|[\r\n])+)</PackageReleaseNotes>', 'gm');
+const nodeChangelog = changeEntries.join('\n');
+const projectPaths = [
+  'src/Api/PubnubApi/PubnubApi.csproj',
+  'src/Api/PubnubApiPCL/PubnubApiPCL.csproj',
+  'src/Api/PubnubApiUWP/PubnubApiUWP.csproj'
+];
+
+for (var projectIdx = projectPaths.length - 1; projectIdx >= 0; projectIdx--) {
+	const projectFilePath = path.join(process.env['GITHUB_WORKSPACE'], projectPaths[projectIdx]);
+  let match;
+
+	if (fs.existsSync(projectFilePath)) {
+    let projectContent = fs.readFileSync(projectFilePath).toString('utf8');
+
+    if (projectContent) {
+      while ((match = nodeMatcher.exec(projectContent)) !== null) {
+      	const updated = match[0].replace(match[1], nodeChangelog)
+        projectContent = replaceString(projectContent, match[0], updated, match.index)
+        fs.writeFileSync(projectFilePath, projectContent, {encoding: 'utf8'})
+      }
+    }
+	}
+}

--- a/.github/workflows/release/publish-packages.ps1
+++ b/.github/workflows/release/publish-packages.ps1
@@ -1,0 +1,19 @@
+$githubWorkspace = $env:WORKSPACE_PATH
+$nugetApiKey = $env:NUGET_API_KEY
+
+$RELEASES_PATH = "$githubWorkspace\.github\.release"
+
+# Publish package
+$PACKAGE_NAME = Get-ChildItem -Name -Path "$RELEASES_PATH\Api\*" -Include *.nupkg
+$PACKAGE_PATH = "$RELEASES_PATH\Api\$PACKAGE_NAME"
+nuget.exe push $PACKAGE_PATH -Source "https://www.nuget.org" -ApiKey $nugetApiKey
+
+# Publish PCL package.
+$PCL_PACKAGE_NAME = Get-ChildItem -Name -Path "$RELEASES_PATH\PCL\*" -Include *.nupkg
+$PCL_PACKAGE_PATH = "$RELEASES_PATH\PCL\$PCL_PACKAGE_NAME"
+nuget.exe push $PCL_PACKAGE_PATH -Source "https://www.nuget.org" -ApiKey $nugetApiKey
+
+# Publish UWP package.
+$UWP_PACKAGE_NAME = Get-ChildItem -Name -Path "$RELEASES_PATH\UWP\*" -Include *.nupkg
+$UWP_PACKAGE_PATH = "$RELEASES_PATH\UWP\$UWP_PACKAGE_NAME"
+nuget.exe push $UWP_PACKAGE_PATH -Source "https://www.nuget.org" -ApiKey $nugetApiKey

--- a/.github/workflows/release/versions.json
+++ b/.github/workflows/release/versions.json
@@ -1,0 +1,48 @@
+{
+  ".pubnub.yml": [
+    { 
+      "pattern": "\/c-sharp\/releases/tag\/(v?(\\d+\\.?){2,}([a-zA-Z0-9-]+(\\.?\\d+)?)?)$",
+      "versionComponents": 3, 
+      "cleared": false
+    },
+    { 
+      "pattern": "^version: \"(v?(\\d+\\.?){2,}([a-zA-Z0-9-]+(\\.?\\d+)?)?)\"$",
+      "versionComponents": 3, 
+      "cleared": false 
+    },
+    { 
+      "pattern": "^\\s{2,}version: Pubnub.*'C#' (v?(\\d+\\.?){2,}([a-zA-Z0-9-]+(\\.?\\d+)?)?)$",
+      "versionComponents": 3,
+      "clearedPrefix": true,
+      "clearedSuffix": false
+    }
+  ],
+  "src/Api/PubnubApi/Properties/AssemblyInfo.cs": [
+    { "pattern": "AssemblyVersion\\(\"(v?(\\d+\\.?){2,}([a-zA-Z0-9-]+(\\.?\\d+)?)?)\"\\)", "cleared": true },
+    { "pattern": "AssemblyFileVersion\\(\"(v?(\\d+\\.?){2,}([a-zA-Z0-9-]+(\\.?\\d+)?)?)\"\\)", "cleared": true }
+  ],
+  "src/Api/PubnubApi/PubnubApi.csproj": [
+    {
+      "pattern": "^\\s{2,}<PackageVersion>(v?(\\d+\\.?){2,}([a-zA-Z0-9-]+(\\.?\\d+)?)?)<\/PackageVersion>$",
+      "versionComponents": 3,
+      "clearedPrefix": true,
+      "clearedSuffix": false
+    }
+  ],
+  "src/Api/PubnubApiPCL/PubnubApiPCL.csproj": [
+    {
+      "pattern": "^\\s{2,}<PackageVersion>(v?(\\d+\\.?){2,}([a-zA-Z0-9-]+(\\.?\\d+)?)?)<\/PackageVersion>$",
+      "versionComponents": 3,
+      "clearedPrefix": true,
+      "clearedSuffix": false
+    }
+  ],
+  "src/Api/PubnubApiUWP/PubnubApiUWP.csproj": [
+    {
+      "pattern": "^\\s{2,}<PackageVersion>(v?(\\d+\\.?){2,}([a-zA-Z0-9-]+(\\.?\\d+)?)?)<\/PackageVersion>$",
+      "versionComponents": 3,
+      "clearedPrefix": true,
+      "clearedSuffix": false
+    }
+  ]
+}

--- a/.gitignore
+++ b/.gitignore
@@ -155,3 +155,8 @@ src/Examples/PubnubApiPCL.XamariniMacExample/obj/*
 *.suo
 src/UnitTests/MockServer/bin/*
 src/UnitTests/MockServer/obj/*
+
+
+# GitHub Actions #
+##################
+.github/.release


### PR DESCRIPTION
## Switch deployment to GitHub Actions

Switch product deployment to GitHub Actions.

_Note: Custom NuGet action not possible at this moment. Commands specified directly in release workflow._