### PR TITLE
throw exception when uuid is not set

### DIFF
--- a/.pubnub.yml
+++ b/.pubnub.yml
@@ -1,8 +1,13 @@
 name: c-sharp
-version: "5.4.0"
+version: "6.0.0"
 schema: 1
 scm: github.com/pubnub/c-sharp
 changelog:
+  - date: 2022-01-12
+    version: v6.0.0
+    changes:
+      - type: improvement
+        text: "BREAKING CHANGES: UUID is mandatory to use SDK."
   - date: 2021-12-16
     version: v5.4.0
     changes:
@@ -621,7 +626,7 @@ features:
     - QUERY-PARAM
 supported-platforms:
   -
-    version: Pubnub 'C#' 5.4.0
+    version: Pubnub 'C#' 6.0.0
     platforms:
       - Windows 10 and up
       - Windows Server 2008 and up
@@ -631,7 +636,7 @@ supported-platforms:
       - .Net Framework 4.5
       - .Net Framework 4.6.1+
   -
-    version: PubnubPCL 'C#' 5.4.0
+    version: PubnubPCL 'C#' 6.0.0
     platforms:
       - Xamarin.Android
       - Xamarin.iOS
@@ -650,7 +655,7 @@ supported-platforms:
       - .Net Standard 2.1
       - .Net Core
   -
-    version: PubnubUWP 'C#' 5.4.0
+    version: PubnubUWP 'C#' 6.0.0
     platforms:
       - Windows Phone 10
       - Universal Windows Apps
@@ -674,7 +679,7 @@ sdks:
             distribution-type: source
             distribution-repository: GitHub
             package-name: Pubnub
-            location: https://github.com/pubnub/c-sharp/releases/tag/v5.4.0.0
+            location: https://github.com/pubnub/c-sharp/releases/tag/v6.0.0.0
             requires:
               -
                 name: ".Net"
@@ -971,7 +976,7 @@ sdks:
             distribution-type: source
             distribution-repository: GitHub
             package-name: PubNubPCL
-            location: https://github.com/pubnub/c-sharp/releases/tag/v5.4.0.0
+            location: https://github.com/pubnub/c-sharp/releases/tag/v6.0.0.0
             requires:
               -
                 name: ".Net Core"
@@ -1344,7 +1349,7 @@ sdks:
             distribution-type: source
             distribution-repository: GitHub
             package-name: PubnubUWP
-            location: https://github.com/pubnub/c-sharp/releases/tag/v5.4.0.0
+            location: https://github.com/pubnub/c-sharp/releases/tag/v6.0.0.0
             requires:
               -
                 name: "Universal Windows Platform Development"

--- a/.pubnub.yml
+++ b/.pubnub.yml
@@ -672,7 +672,7 @@ sdks:
         distributions:
           -
             distribution-type: source
-            distribution-repository: Github
+            distribution-repository: GitHub
             package-name: Pubnub
             location: https://github.com/pubnub/c-sharp/releases/tag/v5.4.0.0
             requires:
@@ -1342,7 +1342,7 @@ sdks:
         distributions:
           -
             distribution-type: source
-            distribution-repository: Github
+            distribution-repository: GitHub
             package-name: PubnubUWP
             location: https://github.com/pubnub/c-sharp/releases/tag/v5.4.0.0
             requires:

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+v6.0.0 - January 12 2022
+-----------------------------
+- BREAKING CHANGES: UUID is mandatory to use SDK.
+
 v5.4.0 - December 16 2021
 -----------------------------
 - Fixed: replaced BouncyCastle lib with System.Security.Cryptography.Algorithms.

--- a/src/Api/PubnubApi/PNConfiguration.cs
+++ b/src/Api/PubnubApi/PNConfiguration.cs
@@ -102,8 +102,13 @@ namespace PubnubApi
         public bool UseRandomInitializationVector { get; set; }
         public int FileMessagePublishRetryLimit { get; set; }
 
-        public PNConfiguration()
+        public PNConfiguration(string uuid)
         {
+            if (string.IsNullOrEmpty(uuid) || string.IsNullOrEmpty(uuid.Trim()))
+            {
+                throw new ArgumentException("Missing or Incorrect uuid value");
+            }
+
             this.Origin = "ps.pndsn.com";
             this.presenceHeartbeatTimeout = 300;
             this.NonSubscribeRequestTimeout = 10;
@@ -123,6 +128,7 @@ namespace PubnubApi
             this.SuppressLeaveEvents = false;
             this.UseRandomInitializationVector = true;
             this.FileMessagePublishRetryLimit = 5;
+            this.Uuid = uuid;
         }
 
         public PNConfiguration SetPresenceTimeoutWithCustomInterval(int timeout, int interval)

--- a/src/Api/PubnubApi/PNConfiguration.cs
+++ b/src/Api/PubnubApi/PNConfiguration.cs
@@ -106,7 +106,6 @@ namespace PubnubApi
         {
             this.Origin = "ps.pndsn.com";
             this.presenceHeartbeatTimeout = 300;
-            this.uuid = string.Format("pn-{0}", Guid.NewGuid().ToString());
             this.NonSubscribeRequestTimeout = 10;
             this.SubscribeTimeout = 310;
             this.LogVerbosity = PNLogVerbosity.NONE;

--- a/src/Api/PubnubApi/Properties/AssemblyInfo.cs
+++ b/src/Api/PubnubApi/Properties/AssemblyInfo.cs
@@ -11,8 +11,8 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyProduct("Pubnub C# SDK")]
 [assembly: AssemblyCopyright("Copyright ©  2021")]
 [assembly: AssemblyTrademark("")]
-[assembly: AssemblyVersion("5.4.0.0")]
-[assembly: AssemblyFileVersion("5.4.0.0")]
+[assembly: AssemblyVersion("6.0.0.0")]
+[assembly: AssemblyFileVersion("6.0.0.0")]
 // Setting ComVisible to false makes the types in this assembly not visible
 // to COM components.  If you need to access a type in this assembly from
 // COM, set the ComVisible attribute to true on that type.

--- a/src/Api/PubnubApi/Pubnub.cs
+++ b/src/Api/PubnubApi/Pubnub.cs
@@ -412,8 +412,8 @@ namespace PubnubApi
 			return Guid.NewGuid();
 		}
 
-		public void ChangeUUID(string newUUID)
-		{
+        public void ChangeUUID(string newUUID)
+        {
             if (newUUID != null && string.IsNullOrEmpty(newUUID.Trim()))
             {
                 if (pubnubLog != null)
@@ -425,9 +425,9 @@ namespace PubnubApi
             EndPoint.OtherOperation endPoint = new EndPoint.OtherOperation(pubnubConfig, JsonPluggableLibrary, pubnubUnitTest, pubnubLog, telemetryManager, tokenManager, this);
             endPoint.CurrentPubnubInstance(this);
             endPoint.ChangeUUID(newUUID);
-		}
+        }
 
-		public static long TranslateDateTimeToPubnubUnixNanoSeconds(DateTime dotNetUTCDateTime)
+        public static long TranslateDateTimeToPubnubUnixNanoSeconds(DateTime dotNetUTCDateTime)
 		{
 			return EndPoint.OtherOperation.TranslateDateTimeToPubnubUnixNanoSeconds(dotNetUTCDateTime);
 		}

--- a/src/Api/PubnubApi/Pubnub.cs
+++ b/src/Api/PubnubApi/Pubnub.cs
@@ -428,19 +428,19 @@ namespace PubnubApi
         }
 
         public static long TranslateDateTimeToPubnubUnixNanoSeconds(DateTime dotNetUTCDateTime)
-		{
-			return EndPoint.OtherOperation.TranslateDateTimeToPubnubUnixNanoSeconds(dotNetUTCDateTime);
-		}
+        {
+            return EndPoint.OtherOperation.TranslateDateTimeToPubnubUnixNanoSeconds(dotNetUTCDateTime);
+        }
 
-		public static DateTime TranslatePubnubUnixNanoSecondsToDateTime(long unixNanoSecondTime)
-		{
-			return EndPoint.OtherOperation.TranslatePubnubUnixNanoSecondsToDateTime(unixNanoSecondTime);
-		}
+        public static DateTime TranslatePubnubUnixNanoSecondsToDateTime(long unixNanoSecondTime)
+        {
+            return EndPoint.OtherOperation.TranslatePubnubUnixNanoSecondsToDateTime(unixNanoSecondTime);
+        }
 
-		public static DateTime TranslatePubnubUnixNanoSecondsToDateTime(string unixNanoSecondTime)
-		{
-			return EndPoint.OtherOperation.TranslatePubnubUnixNanoSecondsToDateTime(unixNanoSecondTime);
-		}
+        public static DateTime TranslatePubnubUnixNanoSecondsToDateTime(string unixNanoSecondTime)
+        {
+            return EndPoint.OtherOperation.TranslatePubnubUnixNanoSecondsToDateTime(unixNanoSecondTime);
+        }
 
         public List<string> GetSubscribedChannels()
         {

--- a/src/Api/PubnubApi/Pubnub.cs
+++ b/src/Api/PubnubApi/Pubnub.cs
@@ -416,9 +416,9 @@ namespace PubnubApi
         {
             if (newUUID != null && string.IsNullOrEmpty(newUUID.Trim()))
             {
-                if (pubnubLog != null)
+                if (pubnubLog != null && pubnubConfig != null)
                 {
-                    LoggingMethod.WriteToLog(pubnubLog, string.Format("DateTime: {0}, UUID cannot be null/empty.", DateTime.Now.ToString(CultureInfo.InvariantCulture)), config.LogVerbosity);
+                    LoggingMethod.WriteToLog(pubnubLog, string.Format("DateTime: {0}, UUID cannot be null/empty.", DateTime.Now.ToString(CultureInfo.InvariantCulture)), pubnubConfig.LogVerbosity);
                 }
                 throw new MissingMemberException("UUID cannot be null/empty");
             }

--- a/src/Api/PubnubApi/Pubnub.cs
+++ b/src/Api/PubnubApi/Pubnub.cs
@@ -833,7 +833,7 @@ namespace PubnubApi
                     LoggingMethod.WriteToLog(pubnubLog, string.Format("DateTime: {0}, WARNING: The PresenceTimeout cannot be less than 20, defaulting the value to 20. Please update the settings in your code.", DateTime.Now.ToString(CultureInfo.InvariantCulture)), config.LogVerbosity);
                 }
             }
-            if (config != null && string.IsNullOrEmpty(config.Uuid) && string.IsNullOrEmpty(config.Uuid.Trim()))
+            if (config != null && (string.IsNullOrEmpty(config.Uuid) || string.IsNullOrEmpty(config.Uuid.Trim())))
             {
                 if (pubnubLog != null)
                 {

--- a/src/Api/PubnubApi/Pubnub.cs
+++ b/src/Api/PubnubApi/Pubnub.cs
@@ -414,6 +414,14 @@ namespace PubnubApi
 
 		public void ChangeUUID(string newUUID)
 		{
+            if (newUUID != null && string.IsNullOrEmpty(newUUID.Trim()))
+            {
+                if (pubnubLog != null)
+                {
+                    LoggingMethod.WriteToLog(pubnubLog, string.Format("DateTime: {0}, UUID cannot be null/empty.", DateTime.Now.ToString(CultureInfo.InvariantCulture)), config.LogVerbosity);
+                }
+                throw new MissingMemberException("UUID cannot be null/empty");
+            }
             EndPoint.OtherOperation endPoint = new EndPoint.OtherOperation(pubnubConfig, JsonPluggableLibrary, pubnubUnitTest, pubnubLog, telemetryManager, tokenManager, this);
             endPoint.CurrentPubnubInstance(this);
             endPoint.ChangeUUID(newUUID);
@@ -825,7 +833,7 @@ namespace PubnubApi
                     LoggingMethod.WriteToLog(pubnubLog, string.Format("DateTime: {0}, WARNING: The PresenceTimeout cannot be less than 20, defaulting the value to 20. Please update the settings in your code.", DateTime.Now.ToString(CultureInfo.InvariantCulture)), config.LogVerbosity);
                 }
             }
-            if (config != null && string.IsNullOrEmpty(config.Uuid))
+            if (config != null && string.IsNullOrEmpty(config.Uuid) && string.IsNullOrEmpty(config.Uuid.Trim()))
             {
                 if (pubnubLog != null)
                 {

--- a/src/Api/PubnubApi/Pubnub.cs
+++ b/src/Api/PubnubApi/Pubnub.cs
@@ -825,6 +825,15 @@ namespace PubnubApi
                     LoggingMethod.WriteToLog(pubnubLog, string.Format("DateTime: {0}, WARNING: The PresenceTimeout cannot be less than 20, defaulting the value to 20. Please update the settings in your code.", DateTime.Now.ToString(CultureInfo.InvariantCulture)), config.LogVerbosity);
                 }
             }
+            if (config != null && string.IsNullOrEmpty(config.Uuid))
+            {
+                if (pubnubLog != null)
+                {
+                    LoggingMethod.WriteToLog(pubnubLog, string.Format("DateTime: {0}, PNConfiguration.Uuid is required to use the SDK.", DateTime.Now.ToString(CultureInfo.InvariantCulture)), config.LogVerbosity);
+                }
+                throw new MissingMemberException("PNConfiguration.Uuid is required to use the SDK");
+            }
+
         }
 
         private void CheckRequiredConfigValues()

--- a/src/Api/PubnubApi/PubnubApi.csproj
+++ b/src/Api/PubnubApi/PubnubApi.csproj
@@ -13,7 +13,7 @@
 
   <PropertyGroup>
     <PackageId>Pubnub</PackageId>
-    <PackageVersion>5.4.0.0</PackageVersion>
+    <PackageVersion>6.0.0.0</PackageVersion>
     <Title>PubNub C# .NET - Web Data Push API</Title>
     <Authors>Pandu Masabathula</Authors>
     <Owners>PubNub</Owners>
@@ -21,8 +21,7 @@
     <PackageIconUrl>http://pubnub.s3.amazonaws.com/2011/powered-by-pubnub/pubnub-icon-600x600.png</PackageIconUrl>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
     <RepositoryUrl>https://github.com/pubnub/c-sharp/</RepositoryUrl>
-    <PackageReleaseNotes>Replaced BouncyCastle lib with System.Security.Cryptography.Algorithms.
-Added try/catch for publish operation to catch exceptions.</PackageReleaseNotes>
+    <PackageReleaseNotes>BREAKING CHANGES: UUID is mandatory to use SDK.</PackageReleaseNotes>
     <PackageTags>Web Data Push Real-time Notifications ESB Message Broadcasting Distributed Computing</PackageTags>
     <!--<Summary>PubNub is a Massively Scalable Web Push Service for Web and Mobile Games.  This is a cloud-based service for broadcasting messages to thousands of web and mobile clients simultaneously</Summary>-->
     <Description>PubNub is a Massively Scalable Web Push Service for Web and Mobile Games.  This is a cloud-based service for broadcasting messages to thousands of web and mobile clients simultaneously</Description>

--- a/src/Api/PubnubApiPCL/PubnubApiPCL.csproj
+++ b/src/Api/PubnubApiPCL/PubnubApiPCL.csproj
@@ -14,7 +14,7 @@
 
   <PropertyGroup>
     <PackageId>PubnubPCL</PackageId>
-    <PackageVersion>5.4.0.0</PackageVersion>
+    <PackageVersion>6.0.0.0</PackageVersion>
     <Title>PubNub C# .NET - Web Data Push API</Title>
     <Authors>Pandu Masabathula</Authors>
     <Owners>PubNub</Owners>
@@ -22,8 +22,7 @@
     <PackageIconUrl>http://pubnub.s3.amazonaws.com/2011/powered-by-pubnub/pubnub-icon-600x600.png</PackageIconUrl>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
     <RepositoryUrl>https://github.com/pubnub/c-sharp/</RepositoryUrl>
-    <PackageReleaseNotes>Replaced BouncyCastle lib with System.Security.Cryptography.Algorithms.
-Added try/catch for publish operation to catch exceptions.</PackageReleaseNotes>
+    <PackageReleaseNotes>BREAKING CHANGES: UUID is mandatory to use SDK.</PackageReleaseNotes>
     <PackageTags>Web Data Push Real-time Notifications ESB Message Broadcasting Distributed Computing</PackageTags>
     <!--<Summary>PubNub is a Massively Scalable Web Push Service for Web and Mobile Games.  This is a cloud-based service for broadcasting messages to thousands of web and mobile clients simultaneously</Summary>-->
     <Description>PubNub is a Massively Scalable Web Push Service for Web and Mobile Games.  This is a cloud-based service for broadcasting messages to thousands of web and mobile clients simultaneously</Description>

--- a/src/Api/PubnubApiUWP/PubnubApiUWP.csproj
+++ b/src/Api/PubnubApiUWP/PubnubApiUWP.csproj
@@ -15,7 +15,7 @@
 
   <PropertyGroup>
     <PackageId>PubnubUWP</PackageId>
-    <PackageVersion>5.4.0.0</PackageVersion>
+    <PackageVersion>6.0.0.0</PackageVersion>
     <Title>PubNub C# .NET - Web Data Push API</Title>
     <Authors>Pandu Masabathula</Authors>
     <Owners>PubNub</Owners>
@@ -23,8 +23,7 @@
     <PackageIconUrl>http://pubnub.s3.amazonaws.com/2011/powered-by-pubnub/pubnub-icon-600x600.png</PackageIconUrl>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
     <RepositoryUrl>https://github.com/pubnub/c-sharp/</RepositoryUrl>
-    <PackageReleaseNotes>Replaced BouncyCastle lib with System.Security.Cryptography.Algorithms.
-Added try/catch for publish operation to catch exceptions.</PackageReleaseNotes>
+    <PackageReleaseNotes>BREAKING CHANGES: UUID is mandatory to use SDK.</PackageReleaseNotes>
     <PackageTags>Web Data Push Real-time Notifications ESB Message Broadcasting Distributed Computing</PackageTags>
     <!--<Summary>PubNub is a Massively Scalable Web Push Service for Web and Mobile Games.  This is a cloud-based service for broadcasting messages to thousands of web and mobile clients simultaneously</Summary>-->
     <Description>PubNub is a Massively Scalable Web Push Service for Web and Mobile Games.  This is a cloud-based service for broadcasting messages to thousands of web and mobile clients simultaneously</Description>

--- a/src/Examples/PubnubApi.ConsoleExample/PubnubAsyncAwaitExample.cs
+++ b/src/Examples/PubnubApi.ConsoleExample/PubnubAsyncAwaitExample.cs
@@ -62,8 +62,6 @@ namespace PubnubApiAsyncAwaitDemo
             string EnvSubscribeKey = System.Environment.GetEnvironmentVariable("PN_SUB_KEY", EnvironmentVariableTarget.Machine);
             string EnvSecretKey = System.Environment.GetEnvironmentVariable("PN_SEC_KEY", EnvironmentVariableTarget.Machine);
 
-
-            PNConfiguration config = new PNConfiguration();
             AppDomain.CurrentDomain.UnhandledException += UnhandledExceptionTrapper;
 
             StringBuilder hintStringBuilder = new StringBuilder();
@@ -93,6 +91,20 @@ namespace PubnubApiAsyncAwaitDemo
             }
             Console.ResetColor();
             Console.WriteLine();
+
+            Console.WriteLine("ENTER Custom Session UUID. Without it, you cannot consume Pubnub SDK");
+            string sessionUUID = Console.ReadLine();
+            if (string.IsNullOrEmpty(sessionUUID) || sessionUUID.Trim().Length == 0)
+            {
+                Console.WriteLine("Invalid UUID. Random GUID value  will be set for this example");
+                sessionUUID = "pn-" + Guid.NewGuid().ToString();
+            }
+            Console.ForegroundColor = ConsoleColor.Blue;
+            Console.WriteLine("Accepted Custom Session UUID.");
+            Console.ResetColor();
+            Console.WriteLine();
+
+            PNConfiguration config = new PNConfiguration(sessionUUID);
 
             Console.WriteLine("Enable SSL? ENTER Y for Yes, else N. (Default N)");
             string enableSSL = Console.ReadLine();
@@ -172,31 +184,6 @@ namespace PubnubApiAsyncAwaitDemo
             Console.ResetColor();
             Console.WriteLine();
 
-            Console.WriteLine("Use Custom Session UUID? ENTER Y for Yes, else N");
-            string enableCustomUUID = Console.ReadLine();
-            if (enableCustomUUID.Trim().ToLowerInvariant() == "y")
-            {
-                Console.WriteLine("ENTER Session UUID.");
-                string sessionUUID = Console.ReadLine();
-                if (string.IsNullOrEmpty(sessionUUID) || sessionUUID.Trim().Length == 0)
-                {
-                    Console.WriteLine("Invalid UUID. Default value will be set.");
-                }
-                else
-                {
-                    config.Uuid = sessionUUID;
-                }
-                Console.ForegroundColor = ConsoleColor.Blue;
-                Console.WriteLine("Accepted Custom Session UUID.");
-                Console.ResetColor();
-            }
-            else
-            {
-                Console.ForegroundColor = ConsoleColor.Blue;
-                Console.WriteLine("Default Session UUID opted.");
-                Console.ResetColor();
-            }
-            Console.WriteLine();
 
             Console.WriteLine("Enter Auth Key. If you don't want to use Auth Key, Press ENTER Key");
             authKey = Console.ReadLine();
@@ -1188,11 +1175,18 @@ namespace PubnubApiAsyncAwaitDemo
                         break;
                     case "17":
                         Console.WriteLine("ENTER UUID.");
-                        string sessionUUID = Console.ReadLine();
-                        pubnub.ChangeUUID(sessionUUID);
-                        Console.ForegroundColor = ConsoleColor.Blue;
-                        Console.WriteLine("UUID = {0}", config.Uuid);
-                        Console.ResetColor();
+                        string newsessionUUID = Console.ReadLine();
+                        try 
+                        {
+                            pubnub.ChangeUUID(newsessionUUID);
+                            Console.ForegroundColor = ConsoleColor.Blue;
+                            Console.WriteLine("UUID = {0}", config.Uuid);
+                            Console.ResetColor();
+                        }
+                        catch (Exception ex)
+                        {
+                            Console.WriteLine(ex.ToString());
+                        }
                         break;
                     case "18":
                         Console.WriteLine("Disconnect");

--- a/src/Examples/PubnubApi.ConsoleExample/PubnubExample.cs
+++ b/src/Examples/PubnubApi.ConsoleExample/PubnubExample.cs
@@ -55,8 +55,6 @@ namespace PubnubApiDemo
             string EnvSubscribeKey = System.Environment.GetEnvironmentVariable("PN_SUB_KEY", EnvironmentVariableTarget.Machine);
             string EnvSecretKey = System.Environment.GetEnvironmentVariable("PN_SEC_KEY", EnvironmentVariableTarget.Machine);
 
-
-            PNConfiguration config = new PNConfiguration();
             AppDomain.CurrentDomain.UnhandledException += UnhandledExceptionTrapper;
 
             StringBuilder hintStringBuilder = new StringBuilder();
@@ -86,6 +84,20 @@ namespace PubnubApiDemo
             }
             Console.ResetColor();
             Console.WriteLine();
+
+            Console.WriteLine("ENTER Custom Session UUID. Without it, you cannot consume Pubnub SDK");
+            string sessionUUID = Console.ReadLine();
+            if (string.IsNullOrEmpty(sessionUUID) || sessionUUID.Trim().Length == 0)
+            {
+                Console.WriteLine("Invalid UUID. Random GUID value  will be set for this example");
+                sessionUUID = "pn-" + Guid.NewGuid().ToString();
+            }
+            Console.ForegroundColor = ConsoleColor.Blue;
+            Console.WriteLine("Accepted Custom Session UUID.");
+            Console.ResetColor();
+            Console.WriteLine();
+
+            PNConfiguration config = new PNConfiguration(sessionUUID);
 
             Console.WriteLine("Enable SSL? ENTER Y for Yes, else N. (Default N)");
             string enableSSL = Console.ReadLine();
@@ -165,31 +177,6 @@ namespace PubnubApiDemo
             Console.ResetColor();
             Console.WriteLine();
 
-            Console.WriteLine("Use Custom Session UUID? ENTER Y for Yes, else N");
-            string enableCustomUUID = Console.ReadLine();
-            if (enableCustomUUID.Trim().ToLowerInvariant() == "y")
-            {
-                Console.WriteLine("ENTER Session UUID.");
-                string sessionUUID = Console.ReadLine();
-                if (string.IsNullOrEmpty(sessionUUID) || sessionUUID.Trim().Length == 0)
-                {
-                    Console.WriteLine("Invalid UUID. Default value will be set.");
-                }
-                else
-                {
-                    config.Uuid = sessionUUID;
-                }
-                Console.ForegroundColor = ConsoleColor.Blue;
-                Console.WriteLine("Accepted Custom Session UUID.");
-                Console.ResetColor();
-            }
-            else
-            {
-                Console.ForegroundColor = ConsoleColor.Blue;
-                Console.WriteLine("Default Session UUID opted.");
-                Console.ResetColor();
-            }
-            Console.WriteLine();
 
             Console.WriteLine("Enter Auth Key. If you don't want to use Auth Key, Press ENTER Key");
             authKey = Console.ReadLine();
@@ -1191,11 +1178,18 @@ namespace PubnubApiDemo
                         break;
                     case "17":
                         Console.WriteLine("ENTER UUID.");
-                        string sessionUUID = Console.ReadLine();
-                        pubnub.ChangeUUID(sessionUUID);
-                        Console.ForegroundColor = ConsoleColor.Blue;
-                        Console.WriteLine("UUID = {0}", config.Uuid);
-                        Console.ResetColor();
+                        string newsessionUUID = Console.ReadLine();
+                        try
+                        {
+                            pubnub.ChangeUUID(newsessionUUID);
+                            Console.ForegroundColor = ConsoleColor.Blue;
+                            Console.WriteLine("UUID = {0}", config.Uuid);
+                            Console.ResetColor();
+                        }
+                        catch (Exception ex)
+                        {
+                            Console.WriteLine(ex.ToString());
+                        }
                         break;
                     case "18":
                         Console.WriteLine("Disconnect");

--- a/src/UnitTests/AcceptanceTests/Steps/GrantTokenSteps.cs
+++ b/src/UnitTests/AcceptanceTests/Steps/GrantTokenSteps.cs
@@ -154,13 +154,12 @@ namespace AcceptanceTests.Steps
         [Given(@"I have a keyset with access manager enabled")]
         public void GivenIHaveAKeysetWithAccessManagerEnabled()
         {
-            config = new PNConfiguration();
+            config = new PNConfiguration("pn-csharp-acceptance-test-uuid");
             config.Origin = acceptance_test_origin;
             config.Secure = false;
             config.PublishKey = System.Environment.GetEnvironmentVariable("PN_PUB_KEY");
             config.SubscribeKey = System.Environment.GetEnvironmentVariable("PN_SUB_KEY");
             config.SecretKey = System.Environment.GetEnvironmentVariable("PN_SEC_KEY");
-            config.Uuid = "pn-csharp-acceptance-test-uuid";
 
             pn = new Pubnub(config);
         }

--- a/src/UnitTests/PubnubApi.Tests/CleanupGrant.cs
+++ b/src/UnitTests/PubnubApi.Tests/CleanupGrant.cs
@@ -28,13 +28,12 @@ namespace PubNubMessaging.Tests
             if (!PubnubCommon.EnableStubTest)
             {
                 receivedAuditMessage = false;
-                PNConfiguration config = new PNConfiguration
+                PNConfiguration config = new PNConfiguration("mytestuuid")
                 {
                     PublishKey = PubnubCommon.PublishKey,
                     SubscribeKey = PubnubCommon.SubscribeKey,
                     SecretKey = PubnubCommon.SecretKey,
-                    Secure = false,
-                    Uuid = "mytestuuid"
+                    Secure = false
                 };
 
                 pubnub = createPubNubInstance(config);
@@ -124,13 +123,12 @@ namespace PubNubMessaging.Tests
             {
                 receivedAuditMessage = false;
 
-                PNConfiguration config = new PNConfiguration
+                PNConfiguration config = new PNConfiguration("mytestuuid")
                 {
                     PublishKey = PubnubCommon.PublishKey,
                     SubscribeKey = PubnubCommon.SubscribeKey,
                     SecretKey = PubnubCommon.SecretKey,
                     Secure = false,
-                    Uuid = "mytestuuid"
                 };
 
                 pubnub = createPubNubInstance(config);

--- a/src/UnitTests/PubnubApi.Tests/EncryptionTests.cs
+++ b/src/UnitTests/PubnubApi.Tests/EncryptionTests.cs
@@ -155,6 +155,7 @@ namespace PubNubMessaging.Tests
                 {
                     SubscribeKey = PubnubCommon.SubscribeKey,
                     PublishKey = PubnubCommon.PublishKey,
+                    Uuid = "unit-test-uuid"
                 };
                 Pubnub pubnub = new Pubnub(config);
                 PNTokenContent pnGrant = pubnub.ParseToken(token);
@@ -315,6 +316,7 @@ namespace PubNubMessaging.Tests
                 System.IO.File.Delete(destFile);
             }
             PNConfiguration config = new PNConfiguration();
+            config.Uuid = "unit-test-uuid";
             Pubnub pn = new Pubnub(config);
             pn.EncryptFile(sourceFile, destFile, "enigma");
             Assert.IsTrue(System.IO.File.Exists(destFile));
@@ -331,6 +333,7 @@ namespace PubNubMessaging.Tests
                 System.IO.File.Delete(destFile);
             }
             PNConfiguration config = new PNConfiguration();
+            config.Uuid = "unit-test-uuid";
             Pubnub pn = new Pubnub(config);
             pn.DecryptFile(sourceFile, destFile, "enigma");
             Assert.IsTrue(System.IO.File.Exists(destFile));

--- a/src/UnitTests/PubnubApi.Tests/EncryptionTests.cs
+++ b/src/UnitTests/PubnubApi.Tests/EncryptionTests.cs
@@ -151,11 +151,10 @@ namespace PubNubMessaging.Tests
             //string token = "qEF2AkF0GmFLd-NDdHRsGQWgQ3Jlc6VEY2hhbqFjY2gxGP9DZ3JwoWNjZzEY_0N1c3KgQ3NwY6BEdXVpZKFldXVpZDEY_0NwYXSlRGNoYW6gQ2dycKBDdXNyoENzcGOgRHV1aWShYl4kAURtZXRho2VzY29yZRhkZWNvbG9yY3JlZGZhdXRob3JlcGFuZHVEdXVpZGtteWF1dGh1dWlkMUNzaWdYIP2vlxHik0EPZwtgYxAW3-LsBaX_WgWdYvtAXpYbKll3";
             try
             {
-                PNConfiguration config = new PNConfiguration
+                PNConfiguration config = new PNConfiguration("unit-test-uuid")
                 {
                     SubscribeKey = PubnubCommon.SubscribeKey,
                     PublishKey = PubnubCommon.PublishKey,
-                    Uuid = "unit-test-uuid"
                 };
                 Pubnub pubnub = new Pubnub(config);
                 PNTokenContent pnGrant = pubnub.ParseToken(token);
@@ -226,7 +225,7 @@ namespace PubNubMessaging.Tests
         [Test]
         public void TestYayDecryptionBasicWithDynamicIV()
         {
-            PNConfiguration config = new PNConfiguration { UseRandomInitializationVector = true };
+            PNConfiguration config = new PNConfiguration("uuid") { UseRandomInitializationVector = true };
             PubnubCrypto pc = new PubnubCrypto("enigma", config, null, null);
             string message = "MTIzNDU2Nzg5MDEyMzQ1NjdnONoCgo0wbuMGGMmfMX0=";
             
@@ -250,7 +249,7 @@ namespace PubNubMessaging.Tests
         [Test]
         public void TestYayByteArrayDecryptionBasicWithDynamicIV()
         {
-            PNConfiguration config = new PNConfiguration { UseRandomInitializationVector = true };
+            PNConfiguration config = new PNConfiguration("uuid") { UseRandomInitializationVector = true };
             PubnubCrypto pc = new PubnubCrypto("enigma", config, null, null);
             byte[] messageBytes = new byte[] { 49, 50, 51, 52, 53, 54, 55, 56, 57, 48, 49, 50, 51, 52, 53, 54, 55, 103, 56, 218, 2, 130, 141, 48, 110, 227, 6, 24, 201, 159, 49, 125 };
             
@@ -262,7 +261,7 @@ namespace PubNubMessaging.Tests
         //[Test]
         public void TestMoonImageDecryption()
         {
-            PNConfiguration config = new PNConfiguration { UseRandomInitializationVector = true };
+            PNConfiguration config = new PNConfiguration("uuid") { UseRandomInitializationVector = true };
             PubnubCrypto pc = new PubnubCrypto("enigma", config, null, null);
             string base64str = "TOAFyhNC/hcs8Hr0/A1KPf9HFXZe10sIs5GN5IL6CmB1Li+4xo00RxLgNR36al200s50iGiaCUvuiwT/r0aggSUq/+mx2Zfw1zSLVV8Lih/xbWS/2yMem9E4Pw1pBcO5A/pZIoE7rcc7HjBIJCS4kCLwBmyT+C8+b10dta/MJT///lhg9JEjEaNWbf4E52pod03Rz34ECnmu8y6X9GYWTDZHEGYbXRBb+viegbstoz0bqIqMdOyu7lD/YQZn1mQxQb9rcEDmTxpaEz52UE8/dVq0Fb/2uSHJtxs+PDaWcNy59p7XyadfaXCJmAR/HKU7R/LIvU1BHh20cs9t9UD9kWQbtgeicDqyxBxhdZmW9nuZXg9pM8ICELYDWGw8oEPG3bjNZ2pvZ/ho9zCcLD3GV+Q/Pflt9zXKmqUKvNOHGvOj4EePEl92Az5fCC91dfHjct1V/i7FJTUPvUPFs47RUmz9cPYH87W1RPvNs6tJGDUnfrwpzt84YZCln7PSZflqQzG3cnWweKN6V+2zVFSu5zrws3wHWzpfyidhxZiKnV+NiqCQrv6naWzI+o6txqGBpDsisvtGkWV8E3pO3nizzzw3jmGwgv0RC1FyulQri0wiJ66U9W9QcAiS3Li/3kWGfW8AorGBbxVuEPiiaMmP3a8aiwaJpd9t8Nr1MuXQcQt8Gl8HTiWBzxqjA1RQWRI5XBZcoN5kcJuDm3W+ks4CsSqYI45hCDbPkHER/+V1vu2e9oDyyKW6LU3tVV5fa7Av0W9leq9aWc7BnTGo7SXMzlqaYf+HQdjz9NvIyO6utRu38m3VmsORjFKEh7w2w6J59c0kK1adftp1wzcsFZQdRKHKwfh9fkIrwbBSAIzOmj5CXRBcS62czR8dsN4EF1309mSR1KB59J7TGnL6EOn7f3fV84bx05om+GXfWAL6avGzKDzV7SyRE3nCgHmgRKJYjIO+FnO5AI2w6CxnGevcNAahDkdy9mxHj6ayRuzxz4Feizemy1bvhB6Q1n5JQhl5cMW0Mhwv5xbQRaNMAqvVOxM8Z8V8ba3sKbjRv+SDp4fL7qF1Xt6Kg2XfQAtgkz+fqQDv9fQAnb95Yk05l62ac8xlWL0V4OOwVsyLH/e04kWNGb16Yezzp/9U659b9QeH7A7xCqT4QS2J5w9SUWAjBm9Nn3t7UDTsOr23+zuv4cWTanGjBH3Uv16sfzOS4cpSyzQDp3f/jD8tFJTC+TGm+INxx1W7gO7buQdekv9nmSjwLvLx1PZa9puxujP6x3eFo8ZT/qj/g1EN8miiD2n9bn1KzFMcRv1FispP73naqGKopbXyFNGDi8FYYI98QJiSooi7Zea2sTr/uSJETO0X5Ebwrq6GTPT9PhkVFNJ6JGrQnCwdDAHyMzDXfktT6pfKsaS52SELw+mUXIXA5fOl9qac4iqM549R0S0gLX10bNnZ+xWCwwjp7soo2XHlFlW4GazLimI7HnuM/SqQaLD0PGb1rbLm9hbto/6h4W3+nQAOIwMkOxAh8jW5gqSpIJ9oNFdAUdTmRXUdlLOwwIiom/KN65AVgZuLFs0yppTANYOdFKYIt0wYTy2FyQfzYnTqEovXWbcAxLFqry/NknTPArp+uBQ4BwZOmPjpzJ769WeAtxpbImQVDUvtDbZyrJ9LeHCtfiRuwPgmRUE5pukPgaZ4eA1YddkKb1guiA73QOhhtJinDzZ+T93MfqH6CyKJs1ozvu3mEPpZpvqjxDP2BdMh561KLSVt0BhW0DdwDGiRyKCalOwh92S9dT31x1BldGJWHf6h+WEupZS+fH8ZbHYqDppy6lbPJEOP/IVFXsdAA30aUzjQHHm+UOtbxvzU4Lzs6kBFsxc24uFL1tkv/5aTyoWjxcQxU0b2aX8voiITtLUL7lsSAG58Lsd1G5lt/jWCtA6bKZLdfwJrJR/Qc9HZMlzbd+WCpVz+1ALaf5dRZtiIZRtR95VCiqsBhExMZIxLLVmaDfRFRZM0KF/eqXQmFz6+gAXdkcLgRTWGQPj1Lv5ybfSGmkMEKkOZ86djuGlnfZlj4LsuTUUn1IHeYD+DfJ9PUy5EAuXINXdYgAm16DOQp385xf6c0DeNhDhS/OBIhFWkW9XA7rmX0JjsNaVQLScRe6YSzo2GQ28EkGfrpOL74PwI72FHTNKqkftu";
             byte[] messageBytes = Convert.FromBase64CharArray(base64str.ToCharArray(), 0, base64str.Length);
@@ -279,7 +278,7 @@ namespace PubNubMessaging.Tests
         {
             IPubnubUnitTest pubnubUnitTest = new PubnubUnitTest();
             pubnubUnitTest.IV = new byte[16] { 21, 113, 108, 52, 211, 105, 24, 46, 175, 249, 87, 111, 60, 71, 232, 107 };
-            PNConfiguration config = new PNConfiguration { UseRandomInitializationVector = true, LogVerbosity= PNLogVerbosity.BODY };
+            PNConfiguration config = new PNConfiguration("uuid") { UseRandomInitializationVector = true, LogVerbosity= PNLogVerbosity.BODY };
             PubnubCrypto pc = new PubnubCrypto("enigma", config, null, pubnubUnitTest);
             byte[] fileByteArray = System.IO.File.ReadAllBytes(@"C:\Pandu\temp\new\input\word_test.txt");
 
@@ -289,20 +288,6 @@ namespace PubNubMessaging.Tests
             Assert.AreEqual(expectedBytes, decryptedBytes);
 
         }
-
-        //[Test]
-        //public void TestLocalFileDecryptionFromPath()
-        //{
-        //    PNConfiguration config = new PNConfiguration { UseRandomInitializationVector = true };
-        //    PubnubCrypto pc = new PubnubCrypto("enigma", config, null, null);
-        //    byte[] fileByteArray = System.IO.File.ReadAllBytes(@"C:\Pandu\temp\new\input\word_test_enc.txt");
-
-        //    byte[] decryptedBytes = pc.Decrypt(fileByteArray, true);
-        //    System.IO.File.WriteAllBytes(@"C:\Pandu\temp\new\input\word_test_decrypted.txt", decryptedBytes);
-        //    byte[] expectedBytes = new byte[] { 104, 101, 108, 108, 111, 32, 119, 111, 114, 108, 100, 33, 33 };
-        //    Assert.AreEqual(expectedBytes, decryptedBytes);
-
-        //}
 
         [Test]
         public void TestLocalFileEncryptionFromPath()
@@ -315,8 +300,7 @@ namespace PubNubMessaging.Tests
             {
                 System.IO.File.Delete(destFile);
             }
-            PNConfiguration config = new PNConfiguration();
-            config.Uuid = "unit-test-uuid";
+            PNConfiguration config = new PNConfiguration("uuid");
             Pubnub pn = new Pubnub(config);
             pn.EncryptFile(sourceFile, destFile, "enigma");
             Assert.IsTrue(System.IO.File.Exists(destFile));
@@ -332,8 +316,7 @@ namespace PubNubMessaging.Tests
             {
                 System.IO.File.Delete(destFile);
             }
-            PNConfiguration config = new PNConfiguration();
-            config.Uuid = "unit-test-uuid";
+            PNConfiguration config = new PNConfiguration("unit-test-uuid");
             Pubnub pn = new Pubnub(config);
             pn.DecryptFile(sourceFile, destFile, "enigma");
             Assert.IsTrue(System.IO.File.Exists(destFile));
@@ -361,7 +344,7 @@ namespace PubNubMessaging.Tests
         {
             IPubnubUnitTest pubnubUnitTest = new PubnubUnitTest();
             pubnubUnitTest.IV = new byte[16] { 49, 50, 51, 52, 53, 54, 55, 56, 57, 48, 49, 50, 51, 52, 53, 54 };
-            PNConfiguration config = new PNConfiguration { UseRandomInitializationVector = true };
+            PNConfiguration config = new PNConfiguration("uuid") { UseRandomInitializationVector = true };
             PubnubCrypto pc = new PubnubCrypto("enigma", config, null, pubnubUnitTest);
             ////deserialized string
             string message = "yay!";
@@ -394,7 +377,7 @@ namespace PubNubMessaging.Tests
         {
             IPubnubUnitTest pubnubUnitTest = new PubnubUnitTest();
             pubnubUnitTest.IV = new byte[16] { 49, 50, 51, 52, 53, 54, 55, 56, 57, 48, 49, 50, 51, 52, 53, 54 };
-            PNConfiguration config = new PNConfiguration { UseRandomInitializationVector = true };
+            PNConfiguration config = new PNConfiguration("uuid") { UseRandomInitializationVector = true };
             PubnubCrypto pc = new PubnubCrypto("enigma", config, null, pubnubUnitTest);
             ////deserialized string
             string message = "yay!";

--- a/src/UnitTests/PubnubApi.Tests/GenerateSampleGrant.cs
+++ b/src/UnitTests/PubnubApi.Tests/GenerateSampleGrant.cs
@@ -49,13 +49,12 @@ namespace PubNubMessaging.Tests
 
             receivedGrantMessage = false;
 
-            PNConfiguration config = new PNConfiguration
+            PNConfiguration config = new PNConfiguration("mytestuuid")
             {
                 PublishKey = PubnubCommon.PublishKey,
                 SubscribeKey = PubnubCommon.SubscribeKey,
                 SecretKey = PubnubCommon.SecretKey,
                 Secure = false,
-                Uuid = "mytestuuid",
             };
 
             pubnub = createPubNubInstance(config);
@@ -111,13 +110,12 @@ namespace PubNubMessaging.Tests
 
             receivedGrantMessage = false;
 
-            PNConfiguration config = new PNConfiguration
+            PNConfiguration config = new PNConfiguration("mytestuuid")
             {
                 PublishKey = PubnubCommon.PublishKey,
                 SubscribeKey = PubnubCommon.SubscribeKey,
                 SecretKey = PubnubCommon.SecretKey,
                 Secure = false,
-                Uuid = "mytestuuid",
             };
 
             pubnub = createPubNubInstance(config);

--- a/src/UnitTests/PubnubApi.Tests/WhenAClientIsPresented.cs
+++ b/src/UnitTests/PubnubApi.Tests/WhenAClientIsPresented.cs
@@ -43,12 +43,11 @@ namespace PubNubMessaging.Tests
             bool receivedGrantMessage = false;
             string channel = "hello_my_channel";
 
-            PNConfiguration config = new PNConfiguration
+            PNConfiguration config = new PNConfiguration("mytestuuid")
             {
                 PublishKey = PubnubCommon.PublishKey,
                 SubscribeKey = PubnubCommon.SubscribeKey,
                 SecretKey = PubnubCommon.SecretKey,
-                Uuid = "mytestuuid",
                 Secure = false
             };
             server.RunOnHttps(false);
@@ -134,11 +133,10 @@ namespace PubNubMessaging.Tests
 
             bool receivedPresenceMessage = false;
 
-            PNConfiguration config = new PNConfiguration
+            PNConfiguration config = new PNConfiguration("mytestuuid")
             {
                 PublishKey = PubnubCommon.PublishKey,
                 SubscribeKey = PubnubCommon.SubscribeKey,
-                Uuid = "mytestuuid",
                 Secure = false
             };
             if (PubnubCommon.PAMServerSideRun)
@@ -229,11 +227,10 @@ namespace PubNubMessaging.Tests
 
             bool receivedPresenceMessage = false;
 
-            PNConfiguration config = new PNConfiguration
+            PNConfiguration config = new PNConfiguration("mytestuuid")
             {
                 PublishKey = PubnubCommon.PublishKey,
                 SubscribeKey = PubnubCommon.SubscribeKey,
-                Uuid = "mytestuuid",
                 Secure = true,
                 LogVerbosity = PNLogVerbosity.BODY,
                 PubnubLog = new TestLog()
@@ -326,11 +323,10 @@ namespace PubNubMessaging.Tests
             string customUUID = "mylocalmachine.mydomain.com";
             bool receivedCustomUUID = false;
 
-            PNConfiguration config = new PNConfiguration
+            PNConfiguration config = new PNConfiguration("mytestuuid")
             {
                 PublishKey = PubnubCommon.PublishKey,
                 SubscribeKey = PubnubCommon.SubscribeKey,
-                Uuid = "mytestuuid",
                 Secure = false
             };
             if (PubnubCommon.PAMServerSideRun)
@@ -423,11 +419,10 @@ namespace PubNubMessaging.Tests
             bool receivedHereNowMessage = false;
             bool receivedErrorMessage = false;
 
-            PNConfiguration config = new PNConfiguration
+            PNConfiguration config = new PNConfiguration("mytestuuid")
             {
                 PublishKey = PubnubCommon.PublishKey,
                 SubscribeKey = PubnubCommon.SubscribeKey,
-                Uuid = "mytestuuid",
                 Secure = false
             };
             if (PubnubCommon.PAMServerSideRun)
@@ -548,11 +543,10 @@ namespace PubNubMessaging.Tests
             bool receivedHereNowMessage = false;
             bool receivedErrorMessage = false;
 
-            PNConfiguration config = new PNConfiguration
+            PNConfiguration config = new PNConfiguration("mytestuuid")
             {
                 PublishKey = PubnubCommon.PublishKey,
                 SubscribeKey = PubnubCommon.SubscribeKey,
-                Uuid = "mytestuuid",
                 Secure = false
             };
             if (PubnubCommon.PAMServerSideRun)
@@ -671,12 +665,11 @@ namespace PubNubMessaging.Tests
             bool receivedHereNowMessage = false;
             bool receivedErrorMessage = false;
 
-            PNConfiguration config = new PNConfiguration
+            PNConfiguration config = new PNConfiguration("mytestuuid")
             {
                 PublishKey = PubnubCommon.PublishKey,
                 SubscribeKey = PubnubCommon.SubscribeKey,
                 CipherKey = "enigma",
-                Uuid = "mytestuuid",
                 Secure = false
             };
             if (PubnubCommon.PAMServerSideRun)
@@ -793,13 +786,12 @@ namespace PubNubMessaging.Tests
 
             bool receivedHereNowMessage = false;
 
-            PNConfiguration config = new PNConfiguration
+            PNConfiguration config = new PNConfiguration("mytestuuid")
             {
                 PublishKey = PubnubCommon.PublishKey,
                 SubscribeKey = PubnubCommon.SubscribeKey,
                 Secure = false,
                 CipherKey = "enigma",
-                Uuid = "mytestuuid"
             };
             if (PubnubCommon.PAMServerSideRun)
             {
@@ -913,12 +905,11 @@ namespace PubNubMessaging.Tests
 
             bool receivedHereNowMessage = false;
 
-            PNConfiguration config = new PNConfiguration
+            PNConfiguration config = new PNConfiguration("mytestuuid")
             {
                 PublishKey = PubnubCommon.PublishKey,
                 SubscribeKey = PubnubCommon.SubscribeKey,
                 CipherKey = "enigma",
-                Uuid = "mytestuuid",
                 Secure = true
             };
             if (PubnubCommon.PAMServerSideRun)
@@ -1034,12 +1025,11 @@ namespace PubNubMessaging.Tests
             bool receivedHereNowMessage = false;
             bool receivedErrorMessage = false;
 
-            PNConfiguration config = new PNConfiguration
+            PNConfiguration config = new PNConfiguration("mytestuuid")
             {
                 PublishKey = PubnubCommon.PublishKey,
                 SubscribeKey = PubnubCommon.SubscribeKey,
                 CipherKey = "enigma",
-                Uuid = "mytestuuid",
                 Secure = true
             };
             if (PubnubCommon.PAMServerSideRun)
@@ -1155,11 +1145,10 @@ namespace PubNubMessaging.Tests
 
             bool receivedHereNowMessage = false;
 
-            PNConfiguration config = new PNConfiguration
+            PNConfiguration config = new PNConfiguration("mytestuuid")
             {
                 PublishKey = PubnubCommon.PublishKey,
                 SubscribeKey = PubnubCommon.SubscribeKey,
-                Uuid = "mytestuuid",
                 Secure = false
             };
             if (PubnubCommon.PAMServerSideRun)
@@ -1274,11 +1263,10 @@ namespace PubNubMessaging.Tests
 
             bool receivedHereNowMessage = false;
 
-            PNConfiguration config = new PNConfiguration
+            PNConfiguration config = new PNConfiguration("mytestuuid")
             {
                 PublishKey = PubnubCommon.PublishKey,
                 SubscribeKey = PubnubCommon.SubscribeKey,
-                Uuid = "mytestuuid",
                 Secure = true
             };
             if (PubnubCommon.PAMServerSideRun)
@@ -1394,11 +1382,10 @@ namespace PubNubMessaging.Tests
             bool receivedHereNowMessage = false;
             bool receivedErrorMessage = false;
 
-            PNConfiguration config = new PNConfiguration
+            PNConfiguration config = new PNConfiguration("mytestuuid")
             {
                 PublishKey = PubnubCommon.PublishKey,
                 SubscribeKey = PubnubCommon.SubscribeKey,
-                Uuid = "mytestuuid",
                 Secure = true
             };
             if (PubnubCommon.PAMServerSideRun)
@@ -1516,11 +1503,10 @@ namespace PubNubMessaging.Tests
             bool receivedHereNowMessage = false;
             bool receivedErrorMessage = false;
 
-            PNConfiguration config = new PNConfiguration
+            PNConfiguration config = new PNConfiguration("mytestuuid")
             {
                 PublishKey = PubnubCommon.PublishKey,
                 SubscribeKey = PubnubCommon.SubscribeKey,
-                Uuid = "mytestuuid",
                 Secure = false
             };
             if (PubnubCommon.PAMServerSideRun)
@@ -1674,11 +1660,10 @@ namespace PubNubMessaging.Tests
 
             bool receivedHereNowMessage = false;
 
-            PNConfiguration config = new PNConfiguration
+            PNConfiguration config = new PNConfiguration("mytestuuid")
             {
                 PublishKey = PubnubCommon.PublishKey,
                 SubscribeKey = PubnubCommon.SubscribeKey,
-                Uuid = "mytestuuid",
                 Secure = false
             };
 
@@ -1810,11 +1795,10 @@ namespace PubNubMessaging.Tests
 
             bool receivedHereNowMessage = false;
 
-            PNConfiguration config = new PNConfiguration
+            PNConfiguration config = new PNConfiguration("mytestuuid")
             {
                 PublishKey = PubnubCommon.PublishKey,
                 SubscribeKey = PubnubCommon.SubscribeKey,
-                Uuid = "mytestuuid",
                 Secure = false
             };
             if (PubnubCommon.PAMServerSideRun)
@@ -1962,11 +1946,10 @@ namespace PubNubMessaging.Tests
 
             bool receivedWhereNowMessage = false;
 
-            PNConfiguration config = new PNConfiguration
+            PNConfiguration config = new PNConfiguration("mytestuuid")
             {
                 PublishKey = PubnubCommon.PublishKey,
                 SubscribeKey = PubnubCommon.SubscribeKey,
-                Uuid = "mytestuuid",
                 Secure = false
             };
             if (PubnubCommon.PAMServerSideRun)
@@ -2085,11 +2068,10 @@ namespace PubNubMessaging.Tests
 
             bool receivedWhereNowMessage = false;
 
-            PNConfiguration config = new PNConfiguration
+            PNConfiguration config = new PNConfiguration("mytestuuid")
             {
                 PublishKey = PubnubCommon.PublishKey,
                 SubscribeKey = PubnubCommon.SubscribeKey,
-                Uuid = "mytestuuid",
                 Secure = false
             };
             if (PubnubCommon.PAMServerSideRun)
@@ -2208,11 +2190,10 @@ namespace PubNubMessaging.Tests
             string customUUID = "mylocalmachine.mydomain.com";
             bool receivedUserStateMessage = false;
 
-            PNConfiguration config = new PNConfiguration
+            PNConfiguration config = new PNConfiguration("mytestuuid")
             {
                 PublishKey = PubnubCommon.PublishKey,
                 SubscribeKey = PubnubCommon.SubscribeKey,
-                Uuid = "mytestuuid",
                 Secure = false
             };
             if (PubnubCommon.PAMServerSideRun)
@@ -2294,11 +2275,10 @@ namespace PubNubMessaging.Tests
             Request getRequest = new Request();
             bool receivedUserStateMessage = false;
 
-            PNConfiguration config = new PNConfiguration
+            PNConfiguration config = new PNConfiguration("mytestuuid")
             {
                 PublishKey = PubnubCommon.PublishKey,
                 SubscribeKey = PubnubCommon.SubscribeKey,
-                Uuid = "mytestuuid",
                 Secure = false
             };
             if (PubnubCommon.PAMServerSideRun)
@@ -2450,11 +2430,10 @@ namespace PubNubMessaging.Tests
 
             bool receivedPresenceMessage = false;
 
-            PNConfiguration config = new PNConfiguration
+            PNConfiguration config = new PNConfiguration("mytestuuid")
             {
                 PublishKey = PubnubCommon.PublishKey,
                 SubscribeKey = PubnubCommon.SubscribeKey,
-                Uuid = "mytestuuid",
                 Secure = false
             };
             if (PubnubCommon.PAMServerSideRun)

--- a/src/UnitTests/PubnubApi.Tests/WhenAMessageIsPublished.cs
+++ b/src/UnitTests/PubnubApi.Tests/WhenAMessageIsPublished.cs
@@ -1176,7 +1176,7 @@ namespace PubNubMessaging.Tests
         }
 
         [Test]
-        public static void ThenPubnubShouldGenerateUniqueIdentifier()
+        public static void ThenPubnubShouldFailOnWithoutSettingUuid()
         {
             PNConfiguration config = new PNConfiguration
             {
@@ -1184,9 +1184,11 @@ namespace PubNubMessaging.Tests
                 SubscribeKey = PubnubCommon.SubscribeKey,
             };
 
-            pubnub = createPubNubInstance(config);
+            Assert.Throws<MissingMemberException>(() =>
+            {
+                pubnub = createPubNubInstance(config);
+            });
 
-            Assert.IsNotNull(pubnub.GenerateGuid());
             pubnub = null;
         }
 
@@ -1197,6 +1199,7 @@ namespace PubNubMessaging.Tests
             {
                 PublishKey = "",
                 SubscribeKey = PubnubCommon.SubscribeKey,
+                Uuid = "nunit-demo-uuid"
             };
 
             pubnub = createPubNubInstance(config);
@@ -1293,6 +1296,7 @@ namespace PubNubMessaging.Tests
             {
                 PublishKey = PubnubCommon.PublishKey,
                 SubscribeKey = PubnubCommon.SubscribeKey,
+                Uuid = "nunit-demo-uuid"
             };
             if (PubnubCommon.PAMServerSideRun)
             {

--- a/src/UnitTests/PubnubApi.Tests/WhenAMessageIsPublished.cs
+++ b/src/UnitTests/PubnubApi.Tests/WhenAMessageIsPublished.cs
@@ -40,13 +40,12 @@ namespace PubNubMessaging.Tests
             bool receivedGrantMessage = false;
             string channel = "hello_my_channel";
 
-            PNConfiguration config = new PNConfiguration
+            PNConfiguration config = new PNConfiguration("mytestuuid")
             {
                 PublishKey = PubnubCommon.PublishKey,
                 SubscribeKey = PubnubCommon.SubscribeKey,
                 SecretKey = PubnubCommon.SecretKey,
                 AuthKey = authKey,
-                Uuid = "mytestuuid",
                 Secure = false
             };
             server.RunOnHttps(false);
@@ -122,11 +121,10 @@ namespace PubNubMessaging.Tests
             string channel = "hello_my_channel";
             object message = null;
 
-            PNConfiguration config = new PNConfiguration
+            PNConfiguration config = new PNConfiguration("mytestuuid")
             {
                 PublishKey = PubnubCommon.PublishKey,
                 SubscribeKey = PubnubCommon.SubscribeKey,
-                Uuid = "mytestuuid",
             };
             if (PubnubCommon.PAMServerSideRun)
             {
@@ -176,12 +174,11 @@ namespace PubNubMessaging.Tests
             string channel = "hello_my_channel";
             string message = messageForUnencryptPublish;
 
-            PNConfiguration config = new PNConfiguration
+            PNConfiguration config = new PNConfiguration("mytestuuid")
             {
                 PublishKey = PubnubCommon.PublishKey,
                 SubscribeKey = PubnubCommon.SubscribeKey,
                 Secure = false,
-                Uuid = "mytestuuid"
             };
             if (PubnubCommon.PAMServerSideRun)
             {
@@ -283,12 +280,11 @@ namespace PubNubMessaging.Tests
             string channel = "hello_my_channel";
             string message = messageForUnencryptPublish;
 
-            PNConfiguration config = new PNConfiguration
+            PNConfiguration config = new PNConfiguration("mytestuuid")
             {
                 PublishKey = PubnubCommon.PublishKey,
                 SubscribeKey = PubnubCommon.SubscribeKey,
                 Secure = false,
-                Uuid = "mytestuuid"
             };
             if (PubnubCommon.PAMServerSideRun)
             {
@@ -385,12 +381,11 @@ namespace PubNubMessaging.Tests
             string channel = "hello_my_channel";
             string message = messageForUnencryptPublish;
 
-            PNConfiguration config = new PNConfiguration
+            PNConfiguration config = new PNConfiguration("mytestuuid")
             {
                 PublishKey = PubnubCommon.PublishKey,
                 SubscribeKey = PubnubCommon.SubscribeKey,
                 Secure = false,
-                Uuid = "mytestuuid"
             };
             if (PubnubCommon.PAMServerSideRun)
             {
@@ -449,12 +444,11 @@ namespace PubNubMessaging.Tests
             string channel = "hello_my_channel";
             string message = messageForUnencryptPublish;
 
-            PNConfiguration config = new PNConfiguration
+            PNConfiguration config = new PNConfiguration("mytestuuid")
             {
                 PublishKey = PubnubCommon.PublishKey,
                 SubscribeKey = PubnubCommon.SubscribeKey,
                 Secure = false,
-                Uuid = "mytestuuid"
             };
             if (PubnubCommon.PAMServerSideRun)
             {
@@ -552,11 +546,10 @@ namespace PubNubMessaging.Tests
             string channel = "hello_my_channel";
             object message = new CustomClass();
 
-            PNConfiguration config = new PNConfiguration
+            PNConfiguration config = new PNConfiguration("mytestuuid")
             {
                 PublishKey = PubnubCommon.PublishKey,
                 SubscribeKey = PubnubCommon.SubscribeKey,
-                Uuid = "mytestuuid",
             };
             if (PubnubCommon.PAMServerSideRun)
             {
@@ -654,12 +647,11 @@ namespace PubNubMessaging.Tests
             string channel = "hello_my_channel";
             object message = new SecretCustomClass();
 
-            PNConfiguration config = new PNConfiguration
+            PNConfiguration config = new PNConfiguration("mytestuuid")
             {
                 PublishKey = PubnubCommon.PublishKey,
                 SubscribeKey = PubnubCommon.SubscribeKey,
                 CipherKey = "enigma",
-                Uuid = "mytestuuid",
                 Secure = false
             };
             if (PubnubCommon.PAMServerSideRun)
@@ -757,12 +749,11 @@ namespace PubNubMessaging.Tests
             string channel = "hello_my_channel";
             object message = new SecretCustomClass();
 
-            PNConfiguration config = new PNConfiguration
+            PNConfiguration config = new PNConfiguration("mytestuuid")
             {
                 PublishKey = PubnubCommon.PublishKey,
                 SubscribeKey = PubnubCommon.SubscribeKey,
                 CipherKey = "enigma",
-                Uuid = "mytestuuid",
                 Secure = true
             };
             if (PubnubCommon.PAMServerSideRun)
@@ -860,12 +851,11 @@ namespace PubNubMessaging.Tests
             string channel = "hello_my_channel";
             string message = messageForEncryptPublish;
 
-            PNConfiguration config = new PNConfiguration
+            PNConfiguration config = new PNConfiguration("mytestuuid")
             {
                 PublishKey = PubnubCommon.PublishKey,
                 SubscribeKey = PubnubCommon.SubscribeKey,
                 CipherKey = "enigma",
-                Uuid = "mytestuuid",
                 Secure = false
             };
             if (PubnubCommon.PAMServerSideRun)
@@ -972,12 +962,11 @@ namespace PubNubMessaging.Tests
             string channel = "hello_my_channel";
             string message = messageForSecretEncryptPublish;
 
-            PNConfiguration config = new PNConfiguration
+            PNConfiguration config = new PNConfiguration("mytestuuid")
             {
                 PublishKey = PubnubCommon.PublishKey,
                 SubscribeKey = PubnubCommon.SubscribeKey,
                 CipherKey = "enigma",
-                Uuid = "mytestuuid",
                 Secure = false
             };
             if (PubnubCommon.PAMServerSideRun)
@@ -1081,11 +1070,10 @@ namespace PubNubMessaging.Tests
             string channel = "hello_my_channel";
             object message = new PubnubDemoObject();
 
-            PNConfiguration config = new PNConfiguration
+            PNConfiguration config = new PNConfiguration("mytestuuid")
             {
                 PublishKey = PubnubCommon.PublishKey,
                 SubscribeKey = PubnubCommon.SubscribeKey,
-                Uuid = "mytestuuid4",
                 Secure = false
             };
             if (PubnubCommon.PAMServerSideRun)
@@ -1178,7 +1166,7 @@ namespace PubNubMessaging.Tests
         [Test]
         public static void ThenPubnubShouldFailOnWithoutSettingUuid()
         {
-            PNConfiguration config = new PNConfiguration
+            PNConfiguration config = new PNConfiguration("mytestuuid")
             {
                 PublishKey = PubnubCommon.PublishKey,
                 SubscribeKey = PubnubCommon.SubscribeKey,
@@ -1195,11 +1183,10 @@ namespace PubNubMessaging.Tests
         [Test]
         public static void ThenPublishKeyShouldNotBeEmpty()
         {
-            PNConfiguration config = new PNConfiguration
+            PNConfiguration config = new PNConfiguration("mytestuuid")
             {
                 PublishKey = "",
                 SubscribeKey = PubnubCommon.SubscribeKey,
-                Uuid = "nunit-demo-uuid"
             };
 
             pubnub = createPubNubInstance(config);
@@ -1225,12 +1212,11 @@ namespace PubNubMessaging.Tests
             bool receivedPublishMessage = false;
             long publishTimetoken = 0;
 
-            PNConfiguration config = new PNConfiguration
+            PNConfiguration config = new PNConfiguration("mytestuuid")
             {
                 PublishKey = PubnubCommon.PublishKey,
                 SubscribeKey = PubnubCommon.SubscribeKey,
                 Secure = false,
-                Uuid = "mytestuuid"
             };
             if (PubnubCommon.PAMServerSideRun)
             {
@@ -1292,11 +1278,10 @@ namespace PubNubMessaging.Tests
             string channel = "hello_my_channel";
             string message = "Pubnub API Usage Example";
 
-            PNConfiguration config = new PNConfiguration
+            PNConfiguration config = new PNConfiguration("mytestuuid")
             {
                 PublishKey = PubnubCommon.PublishKey,
                 SubscribeKey = PubnubCommon.SubscribeKey,
-                Uuid = "nunit-demo-uuid"
             };
             if (PubnubCommon.PAMServerSideRun)
             {
@@ -1509,15 +1494,12 @@ namespace PubNubMessaging.Tests
             bool receivedPublishMessage = false;
             long publishTimetoken = 0;
 
-            //string channel = "hello_my_channel ~!@#$%^&()+=[]{}|;\"<>?-_.aA1©®€™₹😜🎉";
             string channel = "hello_my_channel";
 
-            PNConfiguration config = new PNConfiguration
+            PNConfiguration config = new PNConfiguration("myuuid")
             {
                 PublishKey = PubnubCommon.PublishKey,
                 SubscribeKey = PubnubCommon.SubscribeKey,
-                //Uuid = "my ~`!@#$%^&*()+=[]\\{}|;':\",/<>?-_.aA1©®€™₹😜🎉uuid",
-                Uuid = "myuuid",
                 Secure = false,
                 IncludeRequestIdentifier = false,
             };
@@ -1587,12 +1569,11 @@ namespace PubNubMessaging.Tests
             string channel = "hello_my_channel ~!@#$%^&()+=[]{}|;\"<>?-_.aA1©®€™₹😜🎉";
             string message = " ~`!@#$%^&*()+=[]\\{}|;':\",/<>?-_.aA1©®€™₹😜🎉";
 
-            PNConfiguration config = new PNConfiguration
+            PNConfiguration config = new PNConfiguration("my ~`!@#$%^&*()+=[]\\{}|;':\",/<>?-_.aA1©®€™₹😜🎉uuid")
             {
                 PublishKey = PubnubCommon.PublishKey,
                 SubscribeKey = PubnubCommon.SubscribeKey,
                 CipherKey = "enigma",
-                Uuid = "my ~`!@#$%^&*()+=[]\\{}|;':\",/<>?-_.aA1©®€™₹😜🎉uuid",
                 Secure = false,
                 IncludeRequestIdentifier = false,
             };
@@ -1668,12 +1649,10 @@ namespace PubNubMessaging.Tests
             //var message = new { a="!" };
             //":";
 
-            PNConfiguration config = new PNConfiguration
+            PNConfiguration config = new PNConfiguration("my ~`!@#$%^&*()+=[]\\{}|;':\",/<>?-_.aA1©®€™₹😜🎉uuid")
             {
                 PublishKey = PubnubCommon.PublishKey,
                 SubscribeKey = PubnubCommon.SubscribeKey,
-                Uuid = "my ~`!@#$%^&*()+=[]\\{}|;':\",/<>?-_.aA1©®€™₹😜🎉uuid",
-                //Uuid = "myuuid",
                 Secure = false,
                 IncludeRequestIdentifier = false,
             };
@@ -1742,12 +1721,11 @@ namespace PubNubMessaging.Tests
             string channel = "hello_my_channel ~!@#$%^&()+=[]{}|;\"<>?-_.aA1©®€™₹😜🎉";
             string message = " ~`!@#$%^&*()+=[]\\{}|;':\",/<>?-_.aA1©®€™₹😜🎉";
 
-            PNConfiguration config = new PNConfiguration
+            PNConfiguration config = new PNConfiguration("my ~`!@#$%^&*()+=[]\\{}|;':\",/<>?-_.aA1©®€™₹😜🎉uuid")
             {
                 PublishKey = PubnubCommon.PublishKey,
                 SubscribeKey = PubnubCommon.SubscribeKey,
                 CipherKey = "enigma",
-                Uuid = "my ~`!@#$%^&*()+=[]\\{}|;':\",/<>?-_.aA1©®€™₹😜🎉uuid",
                 Secure = false,
                 IncludeRequestIdentifier = false,
             };

--- a/src/UnitTests/PubnubApi.Tests/WhenAMessageIsSignaled.cs
+++ b/src/UnitTests/PubnubApi.Tests/WhenAMessageIsSignaled.cs
@@ -32,13 +32,12 @@ namespace PubNubMessaging.Tests
             bool receivedGrantMessage = false;
             string channel = "hello_my_channel";
 
-            PNConfiguration config = new PNConfiguration
+            PNConfiguration config = new PNConfiguration("mytestuuid")
             {
                 PublishKey = PubnubCommon.PublishKey,
                 SubscribeKey = PubnubCommon.SubscribeKey,
                 SecretKey = PubnubCommon.SecretKey,
                 AuthKey = authKey,
-                Uuid = "mytestuuid",
                 Secure = false
             };
             server.RunOnHttps(false);
@@ -124,12 +123,11 @@ namespace PubNubMessaging.Tests
             string channel = "hello_my_channel";
             string message = messageForUnencryptSignal;
 
-            PNConfiguration config = new PNConfiguration
+            PNConfiguration config = new PNConfiguration("mytestuuid")
             {
                 PublishKey = PubnubCommon.PublishKey,
                 SubscribeKey = PubnubCommon.SubscribeKey,
                 CipherKey = "test",
-                Uuid = "mytestuuid",
                 Secure = false
             };
             if (PubnubCommon.PAMServerSideRun)
@@ -200,12 +198,11 @@ namespace PubNubMessaging.Tests
             string channel = "hello_my_channel";
             string message = messageForUnencryptSignal;
 
-            PNConfiguration config = new PNConfiguration
+            PNConfiguration config = new PNConfiguration("mytestuuid")
             {
                 PublishKey = PubnubCommon.PublishKey,
                 SubscribeKey = PubnubCommon.SubscribeKey,
                 CipherKey = "test",
-                Uuid = "mytestuuid",
                 Secure = false
             };
             if (PubnubCommon.PAMServerSideRun)
@@ -268,11 +265,10 @@ namespace PubNubMessaging.Tests
                 return;
             }
 
-            PNConfiguration config = new PNConfiguration
+            PNConfiguration config = new PNConfiguration("mytestuuid")
             {
                 PublishKey = PubnubCommon.PublishKey,
                 SubscribeKey = PubnubCommon.SubscribeKey,
-                Uuid = "mytestuuid",
                 Secure = false
             };
             if (PubnubCommon.PAMServerSideRun)
@@ -380,11 +376,10 @@ namespace PubNubMessaging.Tests
                 return;
             }
 
-            PNConfiguration config = new PNConfiguration
+            PNConfiguration config = new PNConfiguration("mytestuuid")
             {
                 PublishKey = PubnubCommon.PublishKey,
                 SubscribeKey = PubnubCommon.SubscribeKey,
-                Uuid = "mytestuuid",
                 Secure = false
             };
             if (PubnubCommon.PAMServerSideRun)
@@ -485,12 +480,11 @@ namespace PubNubMessaging.Tests
                 return;
             }
 
-            PNConfiguration config = new PNConfiguration
+            PNConfiguration config = new PNConfiguration("mytestuuid")
             {
                 PublishKey = PubnubCommon.PublishKey,
                 SubscribeKey = PubnubCommon.SubscribeKey,
                 CipherKey = "testcipherkey",
-                Uuid = "mytestuuid",
                 Secure = false
             };
             if (PubnubCommon.PAMServerSideRun)
@@ -597,12 +591,11 @@ namespace PubNubMessaging.Tests
                 return;
             }
 
-            PNConfiguration config = new PNConfiguration
+            PNConfiguration config = new PNConfiguration("mytestuuid")
             {
                 PublishKey = PubnubCommon.PublishKey,
                 SubscribeKey = PubnubCommon.SubscribeKey,
                 CipherKey = "testcipherkey",
-                Uuid = "mytestuuid",
                 Secure = false
             };
             if (PubnubCommon.PAMServerSideRun)

--- a/src/UnitTests/PubnubApi.Tests/WhenAuditIsRequested.cs
+++ b/src/UnitTests/PubnubApi.Tests/WhenAuditIsRequested.cs
@@ -42,12 +42,11 @@ namespace PubNubMessaging.Tests
             currentUnitTestCase = "ThenSubKeyLevelShouldReturnSuccess";
             receivedAuditMessage = false;
 
-            PNConfiguration config = new PNConfiguration
+            PNConfiguration config = new PNConfiguration("mytestuuid")
             {
                 PublishKey = PubnubCommon.PublishKey,
                 SubscribeKey = PubnubCommon.SubscribeKey,
                 SecretKey = PubnubCommon.SecretKey,
-                Uuid = "mytestuuid",
             };
 
             pubnub = createPubNubInstance(config);
@@ -96,12 +95,11 @@ namespace PubNubMessaging.Tests
 
             receivedAuditMessage = false;
 
-            PNConfiguration config = new PNConfiguration
+            PNConfiguration config = new PNConfiguration("mytestuuid")
             {
                 PublishKey = PubnubCommon.PublishKey,
                 SubscribeKey = PubnubCommon.SubscribeKey,
                 SecretKey = PubnubCommon.SecretKey,
-                Uuid = "mytestuuid",
             };
 
             pubnub = createPubNubInstance(config);
@@ -150,12 +148,11 @@ namespace PubNubMessaging.Tests
             string channelgroup = "hello_my_group";
             receivedAuditMessage = false;
 
-            PNConfiguration config = new PNConfiguration
+            PNConfiguration config = new PNConfiguration("mytestuuid")
             {
                 PublishKey = PubnubCommon.PublishKey,
                 SubscribeKey = PubnubCommon.SubscribeKey,
                 SecretKey = PubnubCommon.SecretKey,
-                Uuid = "mytestuuid",
             };
 
             pubnub = createPubNubInstance(config);

--- a/src/UnitTests/PubnubApi.Tests/WhenChannelGroupIsRequested.cs
+++ b/src/UnitTests/PubnubApi.Tests/WhenChannelGroupIsRequested.cs
@@ -42,13 +42,12 @@ namespace PubNubMessaging.Tests
 
             receivedGrantMessage = false;
 
-            PNConfiguration config = new PNConfiguration
+            PNConfiguration config = new PNConfiguration("mytestuuid")
             {
                 PublishKey = PubnubCommon.PublishKey,
                 SubscribeKey = PubnubCommon.SubscribeKey,
                 SecretKey = PubnubCommon.SecretKey,
                 AuthKey = authKey,
-                Uuid = "mytestuuid",
             };
 
             pubnub = createPubNubInstance(config);
@@ -98,11 +97,10 @@ namespace PubNubMessaging.Tests
             currentUnitTestCase = "ThenAddChannelShouldReturnSuccess";
             receivedChannelGroupMessage = false;
 
-            PNConfiguration config = new PNConfiguration
+            PNConfiguration config = new PNConfiguration("mytestuuid")
             {
                 PublishKey = PubnubCommon.PublishKey,
                 SubscribeKey = PubnubCommon.SubscribeKey,
-                Uuid = "mytestuuid",
             };
             if (PubnubCommon.PAMServerSideRun)
             {
@@ -154,11 +152,10 @@ namespace PubNubMessaging.Tests
             currentUnitTestCase = "ThenAddChannelShouldReturnSuccess";
             receivedChannelGroupMessage = false;
 
-            PNConfiguration config = new PNConfiguration
+            PNConfiguration config = new PNConfiguration("mytestuuid")
             {
                 PublishKey = PubnubCommon.PublishKey,
                 SubscribeKey = PubnubCommon.SubscribeKey,
-                Uuid = "mytestuuid",
             };
             if (PubnubCommon.PAMServerSideRun)
             {
@@ -218,11 +215,10 @@ namespace PubNubMessaging.Tests
             string channelName = "hello_my_channel";
             receivedChannelGroupMessage = false;
 
-            PNConfiguration config = new PNConfiguration
+            PNConfiguration config = new PNConfiguration("mytestuuid")
             {
                 PublishKey = PubnubCommon.PublishKey,
                 SubscribeKey = PubnubCommon.SubscribeKey,
-                Uuid = "mytestuuid",
             };
             if (PubnubCommon.PAMServerSideRun)
             {
@@ -276,11 +272,10 @@ namespace PubNubMessaging.Tests
             string channelName = "hello_my_channel";
             receivedChannelGroupMessage = false;
 
-            PNConfiguration config = new PNConfiguration
+            PNConfiguration config = new PNConfiguration("mytestuuid")
             {
                 PublishKey = PubnubCommon.PublishKey,
                 SubscribeKey = PubnubCommon.SubscribeKey,
-                Uuid = "mytestuuid",
             };
             if (PubnubCommon.PAMServerSideRun)
             {
@@ -343,11 +338,10 @@ namespace PubNubMessaging.Tests
 
             receivedChannelGroupMessage = false;
 
-            PNConfiguration config = new PNConfiguration
+            PNConfiguration config = new PNConfiguration("mytestuuid")
             {
                 PublishKey = PubnubCommon.PublishKey,
                 SubscribeKey = PubnubCommon.SubscribeKey,
-                Uuid = "mytestuuid",
             };
             if (PubnubCommon.PAMServerSideRun)
             {
@@ -399,11 +393,10 @@ namespace PubNubMessaging.Tests
 
             receivedChannelGroupMessage = false;
 
-            PNConfiguration config = new PNConfiguration
+            PNConfiguration config = new PNConfiguration("mytestuuid")
             {
                 PublishKey = PubnubCommon.PublishKey,
                 SubscribeKey = PubnubCommon.SubscribeKey,
-                Uuid = "mytestuuid",
             };
             if (PubnubCommon.PAMServerSideRun)
             {
@@ -466,11 +459,10 @@ namespace PubNubMessaging.Tests
 
             receivedChannelGroupMessage = false;
 
-            PNConfiguration config = new PNConfiguration
+            PNConfiguration config = new PNConfiguration("mytestuuid")
             {
                 PublishKey = PubnubCommon.PublishKey,
                 SubscribeKey = PubnubCommon.SubscribeKey,
-                Uuid = "mytestuuid",
             };
             if (PubnubCommon.PAMServerSideRun)
             {
@@ -525,11 +517,10 @@ namespace PubNubMessaging.Tests
 
             receivedChannelGroupMessage = false;
 
-            PNConfiguration config = new PNConfiguration
+            PNConfiguration config = new PNConfiguration("mytestuuid")
             {
                 PublishKey = PubnubCommon.PublishKey,
                 SubscribeKey = PubnubCommon.SubscribeKey,
-                Uuid = "mytestuuid",
             };
             if (PubnubCommon.PAMServerSideRun)
             {

--- a/src/UnitTests/PubnubApi.Tests/WhenDetailedHistoryIsRequested.cs
+++ b/src/UnitTests/PubnubApi.Tests/WhenDetailedHistoryIsRequested.cs
@@ -33,13 +33,12 @@ namespace PubNubMessaging.Tests
             bool receivedGrantMessage = false;
             string channel = "hello_my_channel";
 
-            PNConfiguration config = new PNConfiguration
+            PNConfiguration config = new PNConfiguration("mytestuuid")
             {
                 PublishKey = PubnubCommon.PublishKey,
                 SubscribeKey = PubnubCommon.SubscribeKey,
                 SecretKey = PubnubCommon.SecretKey,
                 AuthKey = authKey,
-                Uuid = "mytestuuid",
                 Secure = false
             };
             server.RunOnHttps(false);
@@ -114,11 +113,10 @@ namespace PubNubMessaging.Tests
             bool receivedMessage = true;
             long publishTimetoken = 0;
 
-            PNConfiguration config = new PNConfiguration
+            PNConfiguration config = new PNConfiguration("mytestuuid")
             {
                 PublishKey = PubnubCommon.PublishKey,
                 SubscribeKey = PubnubCommon.SubscribeKey,
-                Uuid = "mytestuuid",
                 Secure = false
             };
             if (PubnubCommon.PAMServerSideRun)
@@ -222,12 +220,11 @@ namespace PubNubMessaging.Tests
             bool receivedMessage = false;
             long publishTimetoken = 0;
 
-            PNConfiguration config = new PNConfiguration
+            PNConfiguration config = new PNConfiguration("mytestuuid")
             {
                 PublishKey = PubnubCommon.PublishKey,
                 SubscribeKey = PubnubCommon.SubscribeKey,
                 CipherKey = "enigma",
-                Uuid = "mytestuuid",
                 Secure = false
             };
             if (PubnubCommon.PAMServerSideRun)
@@ -337,11 +334,10 @@ namespace PubNubMessaging.Tests
 
             bool receivedMessage = false;
 
-            PNConfiguration config = new PNConfiguration
+            PNConfiguration config = new PNConfiguration("mytestuuid")
             {
                 PublishKey = PubnubCommon.PublishKey,
                 SubscribeKey = PubnubCommon.SubscribeKey,
-                Uuid = "mytestuuid",
                 Secure = false
             };
             if (PubnubCommon.PAMServerSideRun)
@@ -402,11 +398,10 @@ namespace PubNubMessaging.Tests
 
             bool receivedMessage = false;
 
-            PNConfiguration config = new PNConfiguration
+            PNConfiguration config = new PNConfiguration("mytestuuid")
             {
                 PublishKey = PubnubCommon.PublishKey,
                 SubscribeKey = PubnubCommon.SubscribeKey,
-                Uuid = "mytestuuid",
                 Secure = false
             };
             if (PubnubCommon.PAMServerSideRun)
@@ -469,11 +464,10 @@ namespace PubNubMessaging.Tests
             bool receivedMessage = false;
             long publishTimetoken = 0;
 
-            PNConfiguration config = new PNConfiguration
+            PNConfiguration config = new PNConfiguration("mytestuuid")
             {
                 PublishKey = PubnubCommon.PublishKey,
                 SubscribeKey = PubnubCommon.SubscribeKey,
-                Uuid = "mytestuuid",
                 Secure = false
             };
             if (PubnubCommon.PAMServerSideRun)
@@ -600,13 +594,12 @@ namespace PubNubMessaging.Tests
 
             bool receivedMessage = false;
 
-            PNConfiguration config = new PNConfiguration
+            PNConfiguration config = new PNConfiguration("mytestuuid")
             {
                 PublishKey = null,
                 SubscribeKey = null,
                 SecretKey = null,
                 CipherKey = null,
-                Uuid = "mytestuuid",
                 Secure = false
             };
             server.RunOnHttps(false);
@@ -722,12 +715,11 @@ namespace PubNubMessaging.Tests
             long midtime = 0;
             long endtime = 0;
 
-            PNConfiguration config = new PNConfiguration
+            PNConfiguration config = new PNConfiguration("mytestuuid")
             {
                 PublishKey = PubnubCommon.PublishKey,
                 SubscribeKey = PubnubCommon.SubscribeKey,
                 CipherKey = cipherKey,
-                Uuid = "mytestuuid",
                 Secure = ssl
             };
             if (PubnubCommon.PAMServerSideRun)
@@ -1064,12 +1056,11 @@ namespace PubNubMessaging.Tests
                 Assert.Ignore("Ignored for Server side run");
             }
 
-            PNConfiguration config = new PNConfiguration
+            PNConfiguration config = new PNConfiguration("mytestuuid")
             {
                 PublishKey = PubnubCommon.PublishKey,
                 SubscribeKey = PubnubCommon.SubscribeKey,
                 CipherKey = cipherKey,
-                Uuid = "mytestuuid",
                 Secure = ssl
             };
             if (PubnubCommon.PAMServerSideRun)

--- a/src/UnitTests/PubnubApi.Tests/WhenFetchHistoryIsRequested.cs
+++ b/src/UnitTests/PubnubApi.Tests/WhenFetchHistoryIsRequested.cs
@@ -34,13 +34,12 @@ namespace PubNubMessaging.Tests
             bool receivedGrantMessage = false;
             string channel = "hello_my_channel";
 
-            PNConfiguration config = new PNConfiguration
+            PNConfiguration config = new PNConfiguration("mytestuuid")
             {
                 PublishKey = PubnubCommon.PublishKey,
                 SubscribeKey = PubnubCommon.SubscribeKey,
                 SecretKey = PubnubCommon.SecretKey,
                 AuthKey = authKey,
-                Uuid = "mytestuuid",
                 Secure = false
             };
             server.RunOnHttps(false);
@@ -115,11 +114,10 @@ namespace PubNubMessaging.Tests
             bool receivedMessage = true;
             long publishTimetoken = 0;
 
-            PNConfiguration config = new PNConfiguration
+            PNConfiguration config = new PNConfiguration("mytestuuid")
             {
                 PublishKey = PubnubCommon.PublishKey,
                 SubscribeKey = PubnubCommon.SubscribeKey,
-                Uuid = "mytestuuid",
                 Secure = false
             };
             if (PubnubCommon.PAMServerSideRun)
@@ -228,12 +226,11 @@ namespace PubNubMessaging.Tests
             bool receivedMessage = false;
             long publishTimetoken = 0;
 
-            PNConfiguration config = new PNConfiguration
+            PNConfiguration config = new PNConfiguration("mytestuuid")
             {
                 PublishKey = PubnubCommon.PublishKey,
                 SubscribeKey = PubnubCommon.SubscribeKey,
                 CipherKey = "enigma",
-                Uuid = "mytestuuid",
                 Secure = false
             };
             if (PubnubCommon.PAMServerSideRun)
@@ -352,12 +349,11 @@ namespace PubNubMessaging.Tests
             bool receivedMessage = false;
             long publishTimetoken = 0;
 
-            PNConfiguration config = new PNConfiguration
+            PNConfiguration config = new PNConfiguration("mytestuuid")
             {
                 PublishKey = PubnubCommon.PublishKey,
                 SubscribeKey = PubnubCommon.SubscribeKey,
                 CipherKey = "enigma",
-                Uuid = "mytestuuid",
                 Secure = false
             };
             if (PubnubCommon.PAMServerSideRun)
@@ -480,11 +476,10 @@ namespace PubNubMessaging.Tests
 
             bool receivedMessage = false;
 
-            PNConfiguration config = new PNConfiguration
+            PNConfiguration config = new PNConfiguration("mytestuuid")
             {
                 PublishKey = PubnubCommon.PublishKey,
                 SubscribeKey = PubnubCommon.SubscribeKey,
-                Uuid = "mytestuuid",
                 Secure = false
             };
             if (PubnubCommon.PAMServerSideRun)
@@ -551,11 +546,10 @@ namespace PubNubMessaging.Tests
 
             bool receivedMessage = false;
 
-            PNConfiguration config = new PNConfiguration
+            PNConfiguration config = new PNConfiguration("mytestuuid")
             {
                 PublishKey = PubnubCommon.PublishKey,
                 SubscribeKey = PubnubCommon.SubscribeKey,
-                Uuid = "mytestuuid",
                 Secure = false
             };
             if (PubnubCommon.PAMServerSideRun)
@@ -622,11 +616,10 @@ namespace PubNubMessaging.Tests
 
             bool receivedMessage = false;
 
-            PNConfiguration config = new PNConfiguration
+            PNConfiguration config = new PNConfiguration("mytestuuid")
             {
                 PublishKey = PubnubCommon.PublishKey,
                 SubscribeKey = PubnubCommon.SubscribeKey,
-                Uuid = "mytestuuid",
                 Secure = false
             };
             if (PubnubCommon.PAMServerSideRun)
@@ -689,11 +682,10 @@ namespace PubNubMessaging.Tests
 
             bool receivedMessage = false;
 
-            PNConfiguration config = new PNConfiguration
+            PNConfiguration config = new PNConfiguration("mytestuuid")
             {
                 PublishKey = PubnubCommon.PublishKey,
                 SubscribeKey = PubnubCommon.SubscribeKey,
-                Uuid = "mytestuuid",
                 Secure = false
             };
             if (PubnubCommon.PAMServerSideRun)
@@ -756,11 +748,10 @@ namespace PubNubMessaging.Tests
 
             bool receivedMessage = false;
 
-            PNConfiguration config = new PNConfiguration
+            PNConfiguration config = new PNConfiguration("mytestuuid")
             {
                 PublishKey = PubnubCommon.PublishKey,
                 SubscribeKey = PubnubCommon.SubscribeKey,
-                Uuid = "mytestuuid",
                 Secure = false
             };
             if (PubnubCommon.PAMServerSideRun)
@@ -823,11 +814,10 @@ namespace PubNubMessaging.Tests
             bool receivedMessage = false;
             long publishTimetoken = 0;
 
-            PNConfiguration config = new PNConfiguration
+            PNConfiguration config = new PNConfiguration("mytestuuid")
             {
                 PublishKey = PubnubCommon.PublishKey,
                 SubscribeKey = PubnubCommon.SubscribeKey,
-                Uuid = "mytestuuid",
                 Secure = false
             };
             if (PubnubCommon.PAMServerSideRun)
@@ -961,11 +951,10 @@ namespace PubNubMessaging.Tests
 
             bool receivedMessage = false;
 
-            PNConfiguration config = new PNConfiguration
+            PNConfiguration config = new PNConfiguration("mytestuuid")
             {
                 PublishKey = PubnubCommon.PublishKey,
                 SubscribeKey = PubnubCommon.SubscribeKey,
-                Uuid = "mytestuuid",
                 Secure = false
             };
             if (PubnubCommon.PAMServerSideRun)
@@ -1100,13 +1089,12 @@ namespace PubNubMessaging.Tests
 
             bool receivedMessage = false;
 
-            PNConfiguration config = new PNConfiguration
+            PNConfiguration config = new PNConfiguration("mytestuuid")
             {
                 PublishKey = null,
                 SubscribeKey = null,
                 SecretKey = null,
                 CipherKey = null,
-                Uuid = "mytestuuid",
                 Secure = false
             };
             server.RunOnHttps(false);
@@ -1376,12 +1364,11 @@ namespace PubNubMessaging.Tests
             long midtime = 0;
             long endtime = 0;
 
-            PNConfiguration config = new PNConfiguration
+            PNConfiguration config = new PNConfiguration("mytestuuid")
             {
                 PublishKey = PubnubCommon.PublishKey,
                 SubscribeKey = PubnubCommon.SubscribeKey,
                 CipherKey = cipherKey,
-                Uuid = "mytestuuid",
                 Secure = ssl
             };
             if (PubnubCommon.PAMServerSideRun)
@@ -1724,12 +1711,11 @@ namespace PubNubMessaging.Tests
             long midtime = 0;
             long endtime = 0;
 
-            PNConfiguration config = new PNConfiguration
+            PNConfiguration config = new PNConfiguration("mytestuuid")
             {
                 PublishKey = PubnubCommon.PublishKey,
                 SubscribeKey = PubnubCommon.SubscribeKey,
                 CipherKey = cipherKey,
-                Uuid = "mytestuuid",
                 Secure = ssl
             };
             if (PubnubCommon.PAMServerSideRun)
@@ -2042,12 +2028,11 @@ namespace PubNubMessaging.Tests
                 Assert.Ignore("Ignored for Server side run");
             }
 
-            PNConfiguration config = new PNConfiguration
+            PNConfiguration config = new PNConfiguration("mytestuuid")
             {
                 PublishKey = PubnubCommon.PublishKey,
                 SubscribeKey = PubnubCommon.SubscribeKey,
                 CipherKey = cipherKey,
-                Uuid = "mytestuuid",
                 Secure = ssl
             };
             if (PubnubCommon.PAMServerSideRun)
@@ -2401,12 +2386,11 @@ namespace PubNubMessaging.Tests
                 Assert.Ignore("Ignored for Server side run");
             }
 
-            PNConfiguration config = new PNConfiguration
+            PNConfiguration config = new PNConfiguration("mytestuuid")
             {
                 PublishKey = PubnubCommon.PublishKey,
                 SubscribeKey = PubnubCommon.SubscribeKey,
                 CipherKey = cipherKey,
-                Uuid = "mytestuuid",
                 Secure = ssl
             };
             if (PubnubCommon.PAMServerSideRun)
@@ -2724,10 +2708,10 @@ namespace PubNubMessaging.Tests
 
             bool receivedMessage = false;
 
-            PNConfiguration config = new PNConfiguration {
+            PNConfiguration config = new PNConfiguration("mytestuuid")
+            {
                 PublishKey = PubnubCommon.PublishKey,
                 SubscribeKey = PubnubCommon.SubscribeKey,
-                Uuid = "mytestuuid",
                 Secure = false
             };
             if (PubnubCommon.PAMServerSideRun) {
@@ -2784,10 +2768,10 @@ namespace PubNubMessaging.Tests
 
             bool receivedMessage = false;
 
-            PNConfiguration config = new PNConfiguration {
+            PNConfiguration config = new PNConfiguration("mytestuuid")
+            {
                 PublishKey = PubnubCommon.PublishKey,
                 SubscribeKey = PubnubCommon.SubscribeKey,
-                Uuid = "mytestuuid",
                 Secure = false
             };
             if (PubnubCommon.PAMServerSideRun) {
@@ -2844,10 +2828,10 @@ namespace PubNubMessaging.Tests
 
             bool receivedMessage = false;
 
-            PNConfiguration config = new PNConfiguration {
+            PNConfiguration config = new PNConfiguration("mytestuuid")
+            {
                 PublishKey = PubnubCommon.PublishKey,
                 SubscribeKey = PubnubCommon.SubscribeKey,
-                Uuid = "mytestuuid",
                 Secure = false
             };
             if (PubnubCommon.PAMServerSideRun) {
@@ -2905,10 +2889,10 @@ namespace PubNubMessaging.Tests
 
             bool receivedMessage = false;
 
-            PNConfiguration config = new PNConfiguration {
+            PNConfiguration config = new PNConfiguration("mytestuuid")
+            {
                 PublishKey = PubnubCommon.PublishKey,
                 SubscribeKey = PubnubCommon.SubscribeKey,
-                Uuid = "mytestuuid",
                 Secure = false
             };
             if (PubnubCommon.PAMServerSideRun) {

--- a/src/UnitTests/PubnubApi.Tests/WhenFileIsRequested.cs
+++ b/src/UnitTests/PubnubApi.Tests/WhenFileIsRequested.cs
@@ -57,7 +57,7 @@ namespace PubNubMessaging.Tests
             string expected = "{\"message\":\"Success\",\"payload\":{\"level\":\"channel-group\",\"subscribe_key\":\"demo-36\",\"ttl\":20,\"channel-groups\":{\"hello_my_group\":{\"r\":1,\"w\":0,\"m\":1}}},\"service\":\"Access Manager\",\"status\":200}";
 
 
-            pubnub.Grant().Channels(new[] { channelName }).AuthKeys(new[] { authKey }).Read(true).Write(true).Manage(true).Delete(true).TTL(20)
+            pubnub.Grant().Channels(new[] { channelName }).AuthKeys(new[] { authKey }).Read(true).Write(true).Manage(true).Delete(true).Update(true).TTL(20)
                 .Execute(new PNAccessManagerGrantResultExt((r,s)=> 
                 { 
                     if (r != null)

--- a/src/UnitTests/PubnubApi.Tests/WhenFileIsRequested.cs
+++ b/src/UnitTests/PubnubApi.Tests/WhenFileIsRequested.cs
@@ -42,13 +42,12 @@ namespace PubNubMessaging.Tests
 
             receivedGrantMessage = false;
 
-            PNConfiguration config = new PNConfiguration
+            PNConfiguration config = new PNConfiguration("mytestuuid")
             {
                 PublishKey = PubnubCommon.PublishKey,
                 SubscribeKey = PubnubCommon.SubscribeKey,
                 SecretKey = PubnubCommon.SecretKey,
                 AuthKey = authKey,
-                Uuid = "mytestuuid",
                 Secure = false
             };
 
@@ -103,12 +102,10 @@ namespace PubNubMessaging.Tests
                 }
                 );
 
-            PNConfiguration config = new PNConfiguration
+            PNConfiguration config = new PNConfiguration("mytestuuid")
             {
                 PublishKey = PubnubCommon.PublishKey,
                 SubscribeKey = PubnubCommon.SubscribeKey,
-                //CipherKey = "enigma",
-                Uuid = "mytestuuid",
                 Secure = false
             };
             if (PubnubCommon.PAMServerSideRun)
@@ -134,7 +131,6 @@ namespace PubNubMessaging.Tests
             string fileName = "";
             receivedMessage = false;
             string targetFileUpload = @"fileupload.txt";
-            //string targetFileDownload = @"c:\pandu\temp\pandu_test.gif";
             pubnub.SendFile().Channel(channelName).File(targetFileUpload).CipherKey("enigma").Message("This is my sample file")
                 .Execute(new PNFileUploadResultExt((result, status) =>
                 {
@@ -183,7 +179,6 @@ namespace PubNubMessaging.Tests
                     {
                         System.Diagnostics.Debug.WriteLine("DownloadFile result = " + result.FileBytes.Length);
                         receivedMessage = true;
-                        //System.IO.File.WriteAllBytes(targetFileDownload, result.FileBytes);
                     }
                     mre.Set();
                 }));
@@ -239,12 +234,10 @@ namespace PubNubMessaging.Tests
                 }
                 );
 
-            PNConfiguration config = new PNConfiguration
+            PNConfiguration config = new PNConfiguration("mytestuuid")
             {
                 PublishKey = PubnubCommon.PublishKey,
                 SubscribeKey = PubnubCommon.SubscribeKey,
-                //CipherKey = "enigma",
-                Uuid = "mytestuuid",
                 Secure = false
             };
             if (PubnubCommon.PAMServerSideRun)
@@ -351,12 +344,10 @@ namespace PubNubMessaging.Tests
 
             receivedMessage = false;
 
-            PNConfiguration config = new PNConfiguration
+            PNConfiguration config = new PNConfiguration("mytestuuid")
             {
                 PublishKey = PubnubCommon.PublishKey,
                 SubscribeKey = PubnubCommon.SubscribeKey,
-                //CipherKey = "enigma",
-                Uuid = "mytestuuid",
                 Secure = false
             };
             if (PubnubCommon.PAMServerSideRun)
@@ -404,12 +395,10 @@ namespace PubNubMessaging.Tests
 
             receivedMessage = false;
 
-            PNConfiguration config = new PNConfiguration
+            PNConfiguration config = new PNConfiguration("mytestuuid")
             {
                 PublishKey = PubnubCommon.PublishKey,
                 SubscribeKey = PubnubCommon.SubscribeKey,
-                //CipherKey = "enigma",
-                Uuid = "mytestuuid",
                 Secure = false
             };
             if (PubnubCommon.PAMServerSideRun)
@@ -456,12 +445,11 @@ namespace PubNubMessaging.Tests
 
             receivedMessage = false;
 
-            PNConfiguration config = new PNConfiguration
+            PNConfiguration config = new PNConfiguration("mytestuuid")
             {
                 PublishKey = PubnubCommon.PublishKey,
                 SubscribeKey = PubnubCommon.SubscribeKey,
                 CipherKey = "enigma",
-                Uuid = "mytestuuid",
                 Secure = false
             };
             if (PubnubCommon.PAMServerSideRun)
@@ -506,12 +494,11 @@ namespace PubNubMessaging.Tests
 
             receivedMessage = false;
 
-            PNConfiguration config = new PNConfiguration
+            PNConfiguration config = new PNConfiguration("mytestuuid")
             {
                 PublishKey = PubnubCommon.PublishKey,
                 SubscribeKey = PubnubCommon.SubscribeKey,
                 CipherKey = "enigma",
-                Uuid = "mytestuuid",
                 Secure = false
             };
             if (PubnubCommon.PAMServerSideRun)
@@ -587,12 +574,11 @@ namespace PubNubMessaging.Tests
 
             receivedMessage = false;
 
-            PNConfiguration config = new PNConfiguration
+            PNConfiguration config = new PNConfiguration("mytestuuid")
             {
                 PublishKey = PubnubCommon.PublishKey,
                 SubscribeKey = PubnubCommon.SubscribeKey,
                 CipherKey = "enigma",
-                Uuid = "mytestuuid",
                 Secure = false
             };
             if (PubnubCommon.PAMServerSideRun)

--- a/src/UnitTests/PubnubApi.Tests/WhenGetRequestServerTime.cs
+++ b/src/UnitTests/PubnubApi.Tests/WhenGetRequestServerTime.cs
@@ -48,11 +48,10 @@ namespace PubNubMessaging.Tests
             timeReceived = false;
             mreTime = new ManualResetEvent(false);
 
-            PNConfiguration config = new PNConfiguration
+            PNConfiguration config = new PNConfiguration("mytestuuid")
             {
                 PublishKey = PubnubCommon.PublishKey,
                 SubscribeKey = PubnubCommon.SubscribeKey,
-                Uuid = "mytestuuid",
                 Secure = false
             };
             server.RunOnHttps(false);
@@ -145,11 +144,10 @@ namespace PubNubMessaging.Tests
             timeReceived = false;
             mreTime = new ManualResetEvent(false);
 
-            PNConfiguration config = new PNConfiguration
+            PNConfiguration config = new PNConfiguration("mytestuuid")
             {
                 PublishKey = PubnubCommon.PublishKey,
                 SubscribeKey = PubnubCommon.SubscribeKey,
-                Uuid = "mytestuuid",
             };
 
             server.RunOnHttps(true);
@@ -189,11 +187,10 @@ namespace PubNubMessaging.Tests
             timeReceived = false;
             mreTime = new ManualResetEvent(false);
 
-            PNConfiguration config = new PNConfiguration
+            PNConfiguration config = new PNConfiguration("mytestuuid")
             {
                 PublishKey = PubnubCommon.PublishKey,
                 SubscribeKey = PubnubCommon.SubscribeKey,
-                Uuid = "mytestuuid",
                 Proxy = (PubnubCommon.EnableStubTest) ? proxy : null,
                 Secure = false
             };
@@ -243,11 +240,10 @@ namespace PubNubMessaging.Tests
             timeReceived = false;
             mreTime = new ManualResetEvent(false);
 
-            PNConfiguration config = new PNConfiguration
+            PNConfiguration config = new PNConfiguration("mytestuuid")
             {
                 PublishKey = PubnubCommon.PublishKey,
                 SubscribeKey = PubnubCommon.SubscribeKey,
-                Uuid = "mytestuuid",
                 Proxy = (PubnubCommon.EnableStubTest) ? proxy : null
             };
             server.RunOnHttps(true);

--- a/src/UnitTests/PubnubApi.Tests/WhenGetRequestServerTimeMultiInstance.cs
+++ b/src/UnitTests/PubnubApi.Tests/WhenGetRequestServerTimeMultiInstance.cs
@@ -38,18 +38,16 @@ namespace PubNubMessaging.Tests
             server.ClearRequests();
             bool timeReceived1 = false;
 
-            PNConfiguration config1 = new PNConfiguration
+            PNConfiguration config1 = new PNConfiguration("mytestuuid1")
             {
                 PublishKey = PubnubCommon.PublishKey,
                 SubscribeKey = PubnubCommon.SubscribeKey,
-                Uuid = "mytestuuid1",
                 Secure = false
             };
-            PNConfiguration config2 = new PNConfiguration
+            PNConfiguration config2 = new PNConfiguration("mytestuuid2")
             {
                 PublishKey = PubnubCommon.PublishKey,
                 SubscribeKey = PubnubCommon.SubscribeKey,
-                Uuid = "mytestuuid2",
                 Secure = false
             };
             server.RunOnHttps(false);
@@ -133,11 +131,10 @@ namespace PubNubMessaging.Tests
             server.ClearRequests();
             bool timeReceived1 = false;
 
-            PNConfiguration config = new PNConfiguration
+            PNConfiguration config = new PNConfiguration("mytestuuid")
             {
                 PublishKey = PubnubCommon.PublishKey,
                 SubscribeKey = PubnubCommon.SubscribeKey,
-                Uuid = "mytestuuid",
             };
 
             server.RunOnHttps(true);
@@ -189,11 +186,10 @@ namespace PubNubMessaging.Tests
 
             bool timeReceived1 = false;
 
-            PNConfiguration config = new PNConfiguration
+            PNConfiguration config = new PNConfiguration("mytestuuid")
             {
                 PublishKey = PubnubCommon.PublishKey,
                 SubscribeKey = PubnubCommon.SubscribeKey,
-                Uuid = "mytestuuid",
                 Proxy = (PubnubCommon.EnableStubTest) ? proxy : null,
                 Secure = false
             };
@@ -257,11 +253,10 @@ namespace PubNubMessaging.Tests
 
             bool timeReceived1 = false;
 
-            PNConfiguration config = new PNConfiguration
+            PNConfiguration config = new PNConfiguration("mytestuuid")
             {
                 PublishKey = PubnubCommon.PublishKey,
                 SubscribeKey = PubnubCommon.SubscribeKey,
-                Uuid = "mytestuuid",
                 Proxy = (PubnubCommon.EnableStubTest) ? proxy : null
             };
             server.RunOnHttps(true);

--- a/src/UnitTests/PubnubApi.Tests/WhenGrantIsRequested.cs
+++ b/src/UnitTests/PubnubApi.Tests/WhenGrantIsRequested.cs
@@ -73,12 +73,11 @@ namespace PubNubMessaging.Tests
 
             receivedGrantMessage = false;
 
-            PNConfiguration config = new PNConfiguration
+            PNConfiguration config = new PNConfiguration("mytestuuid")
             {
                 PublishKey = PubnubCommon.PublishKey,
                 SubscribeKey = PubnubCommon.SubscribeKey,
                 SecretKey = PubnubCommon.SecretKey,
-                Uuid = "mytestuuid",
             };
 
             pubnub = createPubNubInstance(config);
@@ -135,12 +134,11 @@ namespace PubNubMessaging.Tests
 
             receivedGrantMessage = false;
 
-            PNConfiguration config = new PNConfiguration
+            PNConfiguration config = new PNConfiguration("mytestuuid")
             {
                 PublishKey = PubnubCommon.PublishKey,
                 SubscribeKey = PubnubCommon.SubscribeKey,
                 SecretKey = PubnubCommon.SecretKey,
-                Uuid = "mytestuuid",
             };
 
             pubnub = createPubNubInstance(config);
@@ -203,12 +201,11 @@ namespace PubNubMessaging.Tests
 
             receivedGrantMessage = false;
 
-            PNConfiguration config = new PNConfiguration
+            PNConfiguration config = new PNConfiguration("mytestuuid")
             {
                 PublishKey = PubnubCommon.PublishKey,
                 SubscribeKey = PubnubCommon.SubscribeKey,
                 SecretKey = PubnubCommon.SecretKey,
-                Uuid = "mytestuuid",
             };
 
             pubnub = createPubNubInstance(config);
@@ -265,12 +262,11 @@ namespace PubNubMessaging.Tests
 
             receivedGrantMessage = false;
 
-            PNConfiguration config = new PNConfiguration
+            PNConfiguration config = new PNConfiguration("mytestuuid")
             {
                 PublishKey = PubnubCommon.PublishKey,
                 SubscribeKey = PubnubCommon.SubscribeKey,
                 SecretKey = PubnubCommon.SecretKey,
-                Uuid = "mytestuuid",
             };
 
             pubnub = createPubNubInstance(config);
@@ -333,12 +329,11 @@ namespace PubNubMessaging.Tests
 
             receivedGrantMessage = false;
 
-            PNConfiguration config = new PNConfiguration
+            PNConfiguration config = new PNConfiguration("mytestuuid")
             {
                 PublishKey = PubnubCommon.PublishKey,
                 SubscribeKey = PubnubCommon.SubscribeKey,
                 SecretKey = PubnubCommon.SecretKey,
-                Uuid = "mytestuuid",
             };
 
             pubnub = createPubNubInstance(config);
@@ -392,12 +387,11 @@ namespace PubNubMessaging.Tests
 
             receivedGrantMessage = false;
 
-            PNConfiguration config = new PNConfiguration
+            PNConfiguration config = new PNConfiguration("mytestuuid")
             {
                 PublishKey = PubnubCommon.PublishKey,
                 SubscribeKey = PubnubCommon.SubscribeKey,
                 SecretKey = PubnubCommon.SecretKey,
-                Uuid = "mytestuuid",
             };
 
             pubnub = createPubNubInstance(config);
@@ -457,12 +451,11 @@ namespace PubNubMessaging.Tests
 
             receivedGrantMessage = false;
 
-            PNConfiguration config = new PNConfiguration
+            PNConfiguration config = new PNConfiguration("mytestuuid")
             {
                 PublishKey = PubnubCommon.PublishKey,
                 SubscribeKey = PubnubCommon.SubscribeKey,
                 SecretKey = PubnubCommon.SecretKey,
-                Uuid = "mytestuuid",
             };
 
             pubnub = createPubNubInstance(config);
@@ -525,12 +518,11 @@ namespace PubNubMessaging.Tests
             receivedGrantMessage = false;
             receivedRevokeMessage = false;
 
-            PNConfiguration config = new PNConfiguration
+            PNConfiguration config = new PNConfiguration("mytestuuid")
             {
                 PublishKey = PubnubCommon.PublishKey,
                 SubscribeKey = PubnubCommon.SubscribeKey,
                 SecretKey = PubnubCommon.SecretKey,
-                Uuid = "mytestuuid",
             };
 
             pubnub = createPubNubInstance(config);
@@ -611,12 +603,11 @@ namespace PubNubMessaging.Tests
 
             receivedGrantMessage = false;
 
-            PNConfiguration config = new PNConfiguration
+            PNConfiguration config = new PNConfiguration("mytestuuid")
             {
                 PublishKey = PubnubCommon.PublishKey,
                 SubscribeKey = PubnubCommon.SubscribeKey,
                 SecretKey = PubnubCommon.SecretKey,
-                Uuid = "mytestuuid",
             };
 
             pubnub = createPubNubInstance(config);
@@ -669,12 +660,11 @@ namespace PubNubMessaging.Tests
 
             receivedGrantMessage = false;
 
-            PNConfiguration config = new PNConfiguration
+            PNConfiguration config = new PNConfiguration("mytestuuid")
             {
                 PublishKey = PubnubCommon.PublishKey,
                 SubscribeKey = PubnubCommon.SubscribeKey,
                 SecretKey = PubnubCommon.SecretKey,
-                Uuid = "mytestuuid",
             };
 
             pubnub = createPubNubInstance(config);
@@ -727,12 +717,11 @@ namespace PubNubMessaging.Tests
 
             receivedGrantMessage = false;
 
-            PNConfiguration config = new PNConfiguration
+            PNConfiguration config = new PNConfiguration("mytestuuid")
             {
                 PublishKey = PubnubCommon.PublishKey,
                 SubscribeKey = PubnubCommon.SubscribeKey,
                 SecretKey = PubnubCommon.SecretKey,
-                Uuid = "mytestuuid",
             };
 
             pubnub = createPubNubInstance(config);
@@ -774,12 +763,11 @@ namespace PubNubMessaging.Tests
 
             receivedGrantMessage = false;
 
-            PNConfiguration config = new PNConfiguration
+            PNConfiguration config = new PNConfiguration("mytestuuid")
             {
                 PublishKey = PubnubCommon.PublishKey,
                 SubscribeKey = PubnubCommon.SubscribeKey,
                 SecretKey = PubnubCommon.SecretKey,
-                Uuid = "mytestuuid",
             };
 
             pubnub = createPubNubInstance(config);
@@ -826,12 +814,11 @@ namespace PubNubMessaging.Tests
 
             receivedGrantMessage = false;
 
-            PNConfiguration config = new PNConfiguration
+            PNConfiguration config = new PNConfiguration("mytestuuid")
             {
                 PublishKey = PubnubCommon.PublishKey,
                 SubscribeKey = PubnubCommon.SubscribeKey,
                 SecretKey = PubnubCommon.SecretKey,
-                Uuid = "mytestuuid",
             };
 
             pubnub = createPubNubInstance(config);
@@ -878,12 +865,11 @@ namespace PubNubMessaging.Tests
 
             receivedGrantMessage = false;
 
-            PNConfiguration config = new PNConfiguration
+            PNConfiguration config = new PNConfiguration("mytestuuid")
             {
                 PublishKey = PubnubCommon.PublishKey,
                 SubscribeKey = PubnubCommon.SubscribeKey,
                 SecretKey = PubnubCommon.SecretKey,
-                Uuid = "mytestuuid",
             };
 
             pubnub = createPubNubInstance(config);
@@ -930,12 +916,11 @@ namespace PubNubMessaging.Tests
 
             receivedGrantMessage = false;
 
-            PNConfiguration config = new PNConfiguration
+            PNConfiguration config = new PNConfiguration("mytestuuid")
             {
                 PublishKey = PubnubCommon.PublishKey,
                 SubscribeKey = PubnubCommon.SubscribeKey,
                 SecretKey = PubnubCommon.SecretKey,
-                Uuid = "mytestuuid",
                 Secure = false
             };
 
@@ -996,12 +981,11 @@ namespace PubNubMessaging.Tests
 
             receivedGrantMessage = false;
 
-            PNConfiguration config = new PNConfiguration
+            PNConfiguration config = new PNConfiguration("mytestuuid")
             {
                 PublishKey = PubnubCommon.PublishKey,
                 SubscribeKey = PubnubCommon.SubscribeKey,
                 SecretKey = PubnubCommon.SecretKey,
-                Uuid = "mytestuuid",
             };
 
             pubnub = createPubNubInstance(config);
@@ -1035,12 +1019,11 @@ namespace PubNubMessaging.Tests
 
             receivedRevokeMessage = false;
 
-            PNConfiguration config = new PNConfiguration
+            PNConfiguration config = new PNConfiguration("mytestuuid")
             {
                 PublishKey = PubnubCommon.PublishKey,
                 SubscribeKey = PubnubCommon.SubscribeKey,
                 SecretKey = PubnubCommon.SecretKey,
-                Uuid = "mytestuuid",
                 Secure = false
             };
 

--- a/src/UnitTests/PubnubApi.Tests/WhenMessageAction.cs
+++ b/src/UnitTests/PubnubApi.Tests/WhenMessageAction.cs
@@ -30,13 +30,12 @@ namespace PubNubMessaging.Tests
             bool receivedGrantMessage = false;
             string channel = "hello_my_channel";
 
-            PNConfiguration config = new PNConfiguration
+            PNConfiguration config = new PNConfiguration("mytestuuid")
             {
                 PublishKey = PubnubCommon.PublishKey,
                 SubscribeKey = PubnubCommon.SubscribeKey,
                 SecretKey = PubnubCommon.SecretKey,
                 AuthKey = authKey,
-                Uuid = "mytestuuid",
                 Secure = false
             };
             server.RunOnHttps(false);
@@ -110,11 +109,10 @@ namespace PubNubMessaging.Tests
 
             bool receivedMessage = false;
 
-            PNConfiguration config = new PNConfiguration
+            PNConfiguration config = new PNConfiguration("mytestuuid")
             {
                 PublishKey = PubnubCommon.PublishKey,
                 SubscribeKey = PubnubCommon.SubscribeKey,
-                Uuid = "mytestuuid",
                 Secure = false
             };
             if (PubnubCommon.PAMServerSideRun)
@@ -214,11 +212,10 @@ namespace PubNubMessaging.Tests
 
             bool receivedMessage = false;
 
-            PNConfiguration config = new PNConfiguration
+            PNConfiguration config = new PNConfiguration("mytestuuid")
             {
                 PublishKey = PubnubCommon.PublishKey,
                 SubscribeKey = PubnubCommon.SubscribeKey,
-                Uuid = "mytestuuid",
                 Secure = false
             };
             if (PubnubCommon.PAMServerSideRun)
@@ -321,11 +318,10 @@ namespace PubNubMessaging.Tests
                 return;
             }
 
-            PNConfiguration config = new PNConfiguration
+            PNConfiguration config = new PNConfiguration("mytestuuid")
             {
                 PublishKey = PubnubCommon.PublishKey,
                 SubscribeKey = PubnubCommon.SubscribeKey,
-                Uuid = "mytestuuid",
                 Secure = false
             };
             if (PubnubCommon.PAMServerSideRun)
@@ -414,11 +410,10 @@ namespace PubNubMessaging.Tests
                 return;
             }
 
-            PNConfiguration config = new PNConfiguration
+            PNConfiguration config = new PNConfiguration("mytestuuid")
             {
                 PublishKey = PubnubCommon.PublishKey,
                 SubscribeKey = PubnubCommon.SubscribeKey,
-                Uuid = "mytestuuid",
                 Secure = false
             };
             if (PubnubCommon.PAMServerSideRun)
@@ -498,11 +493,10 @@ namespace PubNubMessaging.Tests
 
             bool receivedMessage = false;
 
-            PNConfiguration config = new PNConfiguration
+            PNConfiguration config = new PNConfiguration("mytestuuid")
             {
                 PublishKey = PubnubCommon.PublishKey,
                 SubscribeKey = PubnubCommon.SubscribeKey,
-                Uuid = "mytestuuid",
                 Secure = false
             };
             if (PubnubCommon.PAMServerSideRun)
@@ -557,11 +551,10 @@ namespace PubNubMessaging.Tests
 
             bool receivedMessage = false;
 
-            PNConfiguration config = new PNConfiguration
+            PNConfiguration config = new PNConfiguration("mytestuuid")
             {
                 PublishKey = PubnubCommon.PublishKey,
                 SubscribeKey = PubnubCommon.SubscribeKey,
-                Uuid = "mytestuuid",
                 Secure = false
             };
             if (PubnubCommon.PAMServerSideRun)
@@ -635,11 +628,10 @@ namespace PubNubMessaging.Tests
                 }
                 );
 
-            PNConfiguration config = new PNConfiguration
+            PNConfiguration config = new PNConfiguration("mytestuuid")
             {
                 PublishKey = PubnubCommon.PublishKey,
                 SubscribeKey = PubnubCommon.SubscribeKey,
-                Uuid = "mytestuuid",
                 Secure = false
             };
             if (PubnubCommon.PAMServerSideRun)
@@ -802,11 +794,10 @@ namespace PubNubMessaging.Tests
                 }
                 );
 
-            PNConfiguration config = new PNConfiguration
+            PNConfiguration config = new PNConfiguration("mytestuuid")
             {
                 PublishKey = PubnubCommon.PublishKey,
                 SubscribeKey = PubnubCommon.SubscribeKey,
-                Uuid = "mytestuuid",
                 Secure = false
             };
             if (PubnubCommon.PAMServerSideRun)

--- a/src/UnitTests/PubnubApi.Tests/WhenMessageCountIsRequested.cs
+++ b/src/UnitTests/PubnubApi.Tests/WhenMessageCountIsRequested.cs
@@ -40,13 +40,12 @@ namespace PubNubMessaging.Tests
 
             receivedGrantMessage = false;
 
-            PNConfiguration config = new PNConfiguration
+            PNConfiguration config = new PNConfiguration("mytestuuid")
             {
                 PublishKey = PubnubCommon.PublishKey,
                 SubscribeKey = PubnubCommon.SubscribeKey,
                 SecretKey = PubnubCommon.SecretKey,
                 AuthKey = authKey,
-                Uuid = "mytestuuid",
             };
 
             pubnub = createPubNubInstance(config);
@@ -104,11 +103,10 @@ namespace PubNubMessaging.Tests
             currentUnitTestCase = "ThenChannel1Timetoken1ShouldReturnSuccess";
             receivedMessage = false;
 
-            PNConfiguration config = new PNConfiguration
+            PNConfiguration config = new PNConfiguration("mytestuuid")
             {
                 PublishKey = PubnubCommon.PublishKey,
                 SubscribeKey = PubnubCommon.SubscribeKey,
-                Uuid = "mytestuuid",
                 Secure = true
             };
             if (PubnubCommon.PAMServerSideRun)
@@ -172,11 +170,10 @@ namespace PubNubMessaging.Tests
             currentUnitTestCase = "ThenWithAsyncChannel1Timetoken1ShouldReturnSuccess";
             receivedMessage = false;
 
-            PNConfiguration config = new PNConfiguration
+            PNConfiguration config = new PNConfiguration("mytestuuid")
             {
                 PublishKey = PubnubCommon.PublishKey,
                 SubscribeKey = PubnubCommon.SubscribeKey,
-                Uuid = "mytestuuid",
                 Secure = true
             };
             if (PubnubCommon.PAMServerSideRun)
@@ -237,11 +234,10 @@ namespace PubNubMessaging.Tests
             currentUnitTestCase = "ThenChannel1Timetoken1ShouldReturnSuccess";
             receivedMessage = false;
 
-            PNConfiguration config = new PNConfiguration
+            PNConfiguration config = new PNConfiguration("mytestuuid")
             {
                 PublishKey = PubnubCommon.PublishKey,
                 SubscribeKey = PubnubCommon.SubscribeKey,
-                Uuid = "mytestuuid",
                 Secure = true
             };
             if (PubnubCommon.PAMServerSideRun)
@@ -305,11 +301,10 @@ namespace PubNubMessaging.Tests
             currentUnitTestCase = "ThenWithAsyncChannel2Timetoken2ShouldReturnSuccess";
             receivedMessage = false;
 
-            PNConfiguration config = new PNConfiguration
+            PNConfiguration config = new PNConfiguration("mytestuuid")
             {
                 PublishKey = PubnubCommon.PublishKey,
                 SubscribeKey = PubnubCommon.SubscribeKey,
-                Uuid = "mytestuuid",
                 Secure = true
             };
             if (PubnubCommon.PAMServerSideRun)

--- a/src/UnitTests/PubnubApi.Tests/WhenMessageDeletedFromChannel.cs
+++ b/src/UnitTests/PubnubApi.Tests/WhenMessageDeletedFromChannel.cs
@@ -40,13 +40,12 @@ namespace PubNubMessaging.Tests
 
             receivedGrantMessage = false;
 
-            PNConfiguration config = new PNConfiguration
+            PNConfiguration config = new PNConfiguration("mytestuuid")
             {
                 PublishKey = PubnubCommon.PublishKey,
                 SubscribeKey = PubnubCommon.SubscribeKey,
                 SecretKey = PubnubCommon.SecretKey,
                 AuthKey = authKey,
-                Uuid = "mytestuuid",
                 Secure = false
             };
             server.RunOnHttps(false);
@@ -101,11 +100,10 @@ namespace PubNubMessaging.Tests
             currentTestCase = "ThenDeleteMessageShouldReturnSuccessMessage";
             receivedMessage = false;
 
-            PNConfiguration config = new PNConfiguration
+            PNConfiguration config = new PNConfiguration("mytestuuid")
             {
                 PublishKey = PubnubCommon.PublishKey,
                 SubscribeKey = PubnubCommon.SubscribeKey,
-                Uuid = "mytestuuid",
                 Secure = false
             };
             if (PubnubCommon.PAMServerSideRun)
@@ -164,11 +162,10 @@ namespace PubNubMessaging.Tests
             currentTestCase = "ThenWithAsyncDeleteMessageShouldReturnSuccessMessage";
             receivedMessage = false;
 
-            PNConfiguration config = new PNConfiguration
+            PNConfiguration config = new PNConfiguration("mytestuuid")
             {
                 PublishKey = PubnubCommon.PublishKey,
                 SubscribeKey = PubnubCommon.SubscribeKey,
-                Uuid = "mytestuuid",
                 Secure = false
             };
             if (PubnubCommon.PAMServerSideRun)

--- a/src/UnitTests/PubnubApi.Tests/WhenMessageDeletedFromChannel.cs
+++ b/src/UnitTests/PubnubApi.Tests/WhenMessageDeletedFromChannel.cs
@@ -74,7 +74,7 @@ namespace PubNubMessaging.Tests
                     .WithResponse(expected)
                     .WithStatusCode(System.Net.HttpStatusCode.OK));
 
-            pubnub.Grant().Channels(new [] { channel }).AuthKeys(new [] { authKey }).Read(true).Write(true).Manage(true).Delete(true).TTL(20).Execute(new UTGrantResult());
+            pubnub.Grant().Channels(new [] { channel }).AuthKeys(new [] { authKey }).Read(true).Write(true).Manage(true).Delete(true).Manage(true).Update(true).TTL(20).Execute(new UTGrantResult());
 
             Thread.Sleep(1000);
 

--- a/src/UnitTests/PubnubApi.Tests/WhenObjectChannelMember.cs
+++ b/src/UnitTests/PubnubApi.Tests/WhenObjectChannelMember.cs
@@ -32,12 +32,11 @@ namespace PubNubMessaging.Tests
             string uuidMetadataId1 = "pandu-ut-uid1";
             string uuidMetadataId2 = "pandu-ut-uid2";
 
-            PNConfiguration config = new PNConfiguration
+            PNConfiguration config = new PNConfiguration("mytestuuid")
             {
                 PublishKey = PubnubCommon.PublishKey,
                 SubscribeKey = PubnubCommon.SubscribeKey,
                 SecretKey = PubnubCommon.SecretKey,
-                Uuid = "mytestuuid",
                 Secure = false
             };
             server.RunOnHttps(false);
@@ -113,11 +112,10 @@ namespace PubNubMessaging.Tests
             string uuidMetadataId1 = "pandu-ut-uid1";
             string uuidMetadataId2 = "pandu-ut-uid2";
 
-            PNConfiguration config = new PNConfiguration
+            PNConfiguration config = new PNConfiguration("mytestuuid")
             {
                 PublishKey = PubnubCommon.PublishKey,
                 SubscribeKey = PubnubCommon.SubscribeKey,
-                Uuid = "mytestuuid",
                 Secure = false
             };
             if (PubnubCommon.PAMServerSideRun)
@@ -363,11 +361,10 @@ namespace PubNubMessaging.Tests
             string uuidMetadataId1 = "pandu-ut-uid1";
             string uuidMetadataId2 = "pandu-ut-uid2";
 
-            PNConfiguration config = new PNConfiguration
+            PNConfiguration config = new PNConfiguration("mytestuuid")
             {
                 PublishKey = PubnubCommon.PublishKey,
                 SubscribeKey = PubnubCommon.SubscribeKey,
-                Uuid = "mytestuuid",
                 Secure = false
             };
             if (PubnubCommon.PAMServerSideRun)
@@ -627,11 +624,10 @@ namespace PubNubMessaging.Tests
             string uuidMetadataId1 = "pandu-ut-uid1";
             string uuidMetadataId2 = "pandu-ut-uid2";
 
-            PNConfiguration config = new PNConfiguration
+            PNConfiguration config = new PNConfiguration("mytestuuid")
             {
                 PublishKey = PubnubCommon.PublishKey,
                 SubscribeKey = PubnubCommon.SubscribeKey,
-                Uuid = "mytestuuid",
                 Secure = false
             };
             if (PubnubCommon.PAMServerSideRun)
@@ -878,11 +874,10 @@ namespace PubNubMessaging.Tests
             string uuidMetadataId1 = "pandu-ut-uid1";
             string uuidMetadataId2 = "pandu-ut-uid2";
 
-            PNConfiguration config = new PNConfiguration
+            PNConfiguration config = new PNConfiguration("mytestuuid")
             {
                 PublishKey = PubnubCommon.PublishKey,
                 SubscribeKey = PubnubCommon.SubscribeKey,
-                Uuid = "mytestuuid",
                 Secure = false
             };
             if (PubnubCommon.PAMServerSideRun)
@@ -1166,11 +1161,10 @@ namespace PubNubMessaging.Tests
                 }
                 );
 
-            PNConfiguration config = new PNConfiguration
+            PNConfiguration config = new PNConfiguration("mytestuuid")
             {
                 PublishKey = PubnubCommon.PublishKey,
                 SubscribeKey = PubnubCommon.SubscribeKey,
-                Uuid = "mytestuuid",
                 Secure = false,
             };
             if (PubnubCommon.PAMServerSideRun)
@@ -1408,11 +1402,10 @@ namespace PubNubMessaging.Tests
                 }
                 );
 
-            PNConfiguration config = new PNConfiguration
+            PNConfiguration config = new PNConfiguration("mytestuuid")
             {
                 PublishKey = PubnubCommon.PublishKey,
                 SubscribeKey = PubnubCommon.SubscribeKey,
-                Uuid = "mytestuuid",
                 Secure = false,
             };
             if (PubnubCommon.PAMServerSideRun)
@@ -1658,11 +1651,10 @@ namespace PubNubMessaging.Tests
                 }
                 );
 
-            PNConfiguration config = new PNConfiguration
+            PNConfiguration config = new PNConfiguration("mytestuuid")
             {
                 PublishKey = PubnubCommon.PublishKey,
                 SubscribeKey = PubnubCommon.SubscribeKey,
-                Uuid = "mytestuuid",
                 Secure = false,
             };
             if (PubnubCommon.PAMServerSideRun)
@@ -1878,11 +1870,10 @@ namespace PubNubMessaging.Tests
                 }
                 );
 
-            PNConfiguration config = new PNConfiguration
+            PNConfiguration config = new PNConfiguration("mytestuuid")
             {
                 PublishKey = PubnubCommon.PublishKey,
                 SubscribeKey = PubnubCommon.SubscribeKey,
-                Uuid = "mytestuuid",
                 Secure = false,
             };
             if (PubnubCommon.PAMServerSideRun)

--- a/src/UnitTests/PubnubApi.Tests/WhenObjectChannelMetadata.cs
+++ b/src/UnitTests/PubnubApi.Tests/WhenObjectChannelMetadata.cs
@@ -31,13 +31,12 @@ namespace PubNubMessaging.Tests
             bool receivedGrantMessage = false;
             string channelMetadataId = "pandu-ut-sid";
 
-            PNConfiguration config = new PNConfiguration
+            PNConfiguration config = new PNConfiguration("mytestuuid")
             {
                 PublishKey = PubnubCommon.PublishKey,
                 SubscribeKey = PubnubCommon.SubscribeKey,
                 SecretKey = PubnubCommon.SecretKey,
                 AuthKey = authKey,
-                Uuid = "mytestuuid",
                 Secure = false
             };
             server.RunOnHttps(false);
@@ -100,11 +99,10 @@ namespace PubNubMessaging.Tests
 
             string channelMetadataId = "pandu-ut-sid";
 
-            PNConfiguration config = new PNConfiguration
+            PNConfiguration config = new PNConfiguration("mytestuuid")
             {
                 PublishKey = PubnubCommon.PublishKey,
                 SubscribeKey = PubnubCommon.SubscribeKey,
-                Uuid = "mytestuuid",
                 Secure = false
             };
             if (PubnubCommon.PAMServerSideRun)
@@ -245,11 +243,10 @@ namespace PubNubMessaging.Tests
 
             string channelMetadataId = "pandu-ut-sid";
 
-            PNConfiguration config = new PNConfiguration
+            PNConfiguration config = new PNConfiguration("mytestuuid")
             {
                 PublishKey = PubnubCommon.PublishKey,
                 SubscribeKey = PubnubCommon.SubscribeKey,
-                Uuid = "mytestuuid",
                 Secure = false
             };
             if (PubnubCommon.PAMServerSideRun)
@@ -409,11 +406,10 @@ namespace PubNubMessaging.Tests
                 }
                 );
 
-            PNConfiguration config = new PNConfiguration
+            PNConfiguration config = new PNConfiguration("mytestuuid")
             {
                 PublishKey = PubnubCommon.PublishKey,
                 SubscribeKey = PubnubCommon.SubscribeKey,
-                Uuid = "mytestuuid",
                 Secure = false,
                 AuthKey = "myauth"
             };
@@ -549,11 +545,10 @@ namespace PubNubMessaging.Tests
                 }
                 );
 
-            PNConfiguration config = new PNConfiguration
+            PNConfiguration config = new PNConfiguration("mytestuuid")
             {
                 PublishKey = PubnubCommon.PublishKey,
                 SubscribeKey = PubnubCommon.SubscribeKey,
-                Uuid = "mytestuuid",
                 Secure = false,
                 AuthKey = "myauth"
             };

--- a/src/UnitTests/PubnubApi.Tests/WhenObjectMembership.cs
+++ b/src/UnitTests/PubnubApi.Tests/WhenObjectMembership.cs
@@ -32,12 +32,11 @@ namespace PubNubMessaging.Tests
             string channelMetadataId1 = "pandu-ut-sid1";
             string channelMetadataId2 = "pandu-ut-sid2";
 
-            PNConfiguration config = new PNConfiguration
+            PNConfiguration config = new PNConfiguration("mytestuuid")
             {
                 PublishKey = PubnubCommon.PublishKey,
                 SubscribeKey = PubnubCommon.SubscribeKey,
                 SecretKey = PubnubCommon.SecretKey,
-                Uuid = "mytestuuid",
                 Secure = false
             };
             server.RunOnHttps(false);
@@ -112,11 +111,10 @@ namespace PubNubMessaging.Tests
             string channelMetadataId1 = "pandu-ut-sid1";
             string channelMetadataId2 = "pandu-ut-sid2";
 
-            PNConfiguration config = new PNConfiguration
+            PNConfiguration config = new PNConfiguration("mytestuuid")
             {
                 PublishKey = PubnubCommon.PublishKey,
                 SubscribeKey = PubnubCommon.SubscribeKey,
-                Uuid = "mytestuuid",
                 Secure = false
             };
             if (PubnubCommon.PAMServerSideRun)
@@ -351,11 +349,10 @@ namespace PubNubMessaging.Tests
             string channelMetadataId1 = "pandu-ut-sid1";
             string channelMetadataId2 = "pandu-ut-sid2";
 
-            PNConfiguration config = new PNConfiguration
+            PNConfiguration config = new PNConfiguration("mytestuuid")
             {
                 PublishKey = PubnubCommon.PublishKey,
                 SubscribeKey = PubnubCommon.SubscribeKey,
-                Uuid = "mytestuuid",
                 Secure = false
             };
             if (PubnubCommon.PAMServerSideRun)
@@ -594,11 +591,10 @@ namespace PubNubMessaging.Tests
             string channelMetadataId1 = "pandu-ut-sid1";
             string channelMetadataId2 = "pandu-ut-sid2";
 
-            PNConfiguration config = new PNConfiguration
+            PNConfiguration config = new PNConfiguration("mytestuuid")
             {
                 PublishKey = PubnubCommon.PublishKey,
                 SubscribeKey = PubnubCommon.SubscribeKey,
-                Uuid = "mytestuuid",
                 Secure = false
             };
             if (PubnubCommon.PAMServerSideRun)
@@ -834,11 +830,10 @@ namespace PubNubMessaging.Tests
             string channelMetadataId1 = "pandu-ut-sid1";
             string channelMetadataId2 = "pandu-ut-sid2";
 
-            PNConfiguration config = new PNConfiguration
+            PNConfiguration config = new PNConfiguration("mytestuuid")
             {
                 PublishKey = PubnubCommon.PublishKey,
                 SubscribeKey = PubnubCommon.SubscribeKey,
-                Uuid = "mytestuuid",
                 Secure = false
             };
             if (PubnubCommon.PAMServerSideRun)
@@ -1102,11 +1097,10 @@ namespace PubNubMessaging.Tests
                 }
                 );
 
-            PNConfiguration config = new PNConfiguration
+            PNConfiguration config = new PNConfiguration("mytestuuid")
             {
                 PublishKey = PubnubCommon.PublishKey,
                 SubscribeKey = PubnubCommon.SubscribeKey,
-                Uuid = "mytestuuid",
                 Secure = false,
             };
             if (PubnubCommon.PAMServerSideRun)
@@ -1345,11 +1339,10 @@ namespace PubNubMessaging.Tests
                 }
                 );
 
-            PNConfiguration config = new PNConfiguration
+            PNConfiguration config = new PNConfiguration("mytestuuid")
             {
                 PublishKey = PubnubCommon.PublishKey,
                 SubscribeKey = PubnubCommon.SubscribeKey,
-                Uuid = "mytestuuid",
                 Secure = false,
             };
             if (PubnubCommon.PAMServerSideRun)
@@ -1592,11 +1585,10 @@ namespace PubNubMessaging.Tests
                 }
                 );
 
-            PNConfiguration config = new PNConfiguration
+            PNConfiguration config = new PNConfiguration("mytestuuid")
             {
                 PublishKey = PubnubCommon.PublishKey,
                 SubscribeKey = PubnubCommon.SubscribeKey,
-                Uuid = "mytestuuid",
                 Secure = false,
             };
             if (PubnubCommon.PAMServerSideRun)
@@ -1822,11 +1814,10 @@ namespace PubNubMessaging.Tests
                 }
                 );
 
-            PNConfiguration config = new PNConfiguration
+            PNConfiguration config = new PNConfiguration("mytestuuid")
             {
                 PublishKey = PubnubCommon.PublishKey,
                 SubscribeKey = PubnubCommon.SubscribeKey,
-                Uuid = "mytestuuid",
                 Secure = false,
             };
             if (PubnubCommon.PAMServerSideRun)

--- a/src/UnitTests/PubnubApi.Tests/WhenObjectUuidMetadata.cs
+++ b/src/UnitTests/PubnubApi.Tests/WhenObjectUuidMetadata.cs
@@ -30,12 +30,11 @@ namespace PubNubMessaging.Tests
             bool receivedGrantMessage = false;
             string uuid_metadata_id = "pandu-ut-uid";
 
-            PNConfiguration config = new PNConfiguration
+            PNConfiguration config = new PNConfiguration("mytestuuid")
             {
                 PublishKey = PubnubCommon.PublishKey,
                 SubscribeKey = PubnubCommon.SubscribeKey,
                 SecretKey = PubnubCommon.SecretKey,
-                Uuid = "mytestuuid",
                 Secure = false
             };
             server.RunOnHttps(false);
@@ -108,11 +107,10 @@ namespace PubNubMessaging.Tests
 
             string uuidMetadataId = "pandu-ut-uid";
 
-            PNConfiguration config = new PNConfiguration
+            PNConfiguration config = new PNConfiguration("mytestuuid")
             {
                 PublishKey = PubnubCommon.PublishKey,
                 SubscribeKey = PubnubCommon.SubscribeKey,
-                Uuid = "mytestuuid",
                 Secure = false,
                 IncludeInstanceIdentifier = false,
                 IncludeRequestIdentifier = false
@@ -256,11 +254,10 @@ namespace PubNubMessaging.Tests
 
             string uuidMetadataId = "pandu-ut-uid";
 
-            PNConfiguration config = new PNConfiguration
+            PNConfiguration config = new PNConfiguration("mytestuuid")
             {
                 PublishKey = PubnubCommon.PublishKey,
                 SubscribeKey = PubnubCommon.SubscribeKey,
-                Uuid = "mytestuuid",
                 Secure = false,
                 IncludeInstanceIdentifier = false,
                 IncludeRequestIdentifier = false
@@ -422,11 +419,10 @@ namespace PubNubMessaging.Tests
                 }
                 );
 
-            PNConfiguration config = new PNConfiguration
+            PNConfiguration config = new PNConfiguration("mytestuuid")
             {
                 PublishKey = PubnubCommon.PublishKey,
                 SubscribeKey = PubnubCommon.SubscribeKey,
-                Uuid = "mytestuuid",
                 Secure = false,
             };
             if (PubnubCommon.PAMServerSideRun)
@@ -562,11 +558,10 @@ namespace PubNubMessaging.Tests
                 }
                 );
 
-            PNConfiguration config = new PNConfiguration
+            PNConfiguration config = new PNConfiguration("mytestuuid")
             {
                 PublishKey = PubnubCommon.PublishKey,
                 SubscribeKey = PubnubCommon.SubscribeKey,
-                Uuid = "mytestuuid",
                 Secure = false,
             };
             if (PubnubCommon.PAMServerSideRun)

--- a/src/UnitTests/PubnubApi.Tests/WhenPushIsRequested.cs
+++ b/src/UnitTests/PubnubApi.Tests/WhenPushIsRequested.cs
@@ -50,13 +50,12 @@ namespace PubNubMessaging.Tests
 
             receivedGrantMessage = false;
 
-            PNConfiguration config = new PNConfiguration
+            PNConfiguration config = new PNConfiguration("mytestuuid")
             {
                 PublishKey = PubnubCommon.PublishKey,
                 SubscribeKey = PubnubCommon.SubscribeKey,
                 SecretKey = PubnubCommon.SecretKey,
                 AuthKey = authKey,
-                Uuid = "mytestuuid",
                 Secure = false
             };
             server.RunOnHttps(false);
@@ -127,11 +126,10 @@ namespace PubNubMessaging.Tests
             publishTimetoken = 0;
             currentTestCase = "ThenPublishMpnsToastShouldReturnSuccess";
 
-            PNConfiguration config = new PNConfiguration
+            PNConfiguration config = new PNConfiguration("mytestuuid")
             {
                 PublishKey = PubnubCommon.PublishKey,
                 SubscribeKey = PubnubCommon.SubscribeKey,
-                Uuid = "mytestuuid",
                 Secure = false
             };
             if (PubnubCommon.PAMServerSideRun)
@@ -192,11 +190,10 @@ namespace PubNubMessaging.Tests
             publishTimetoken = 0;
             currentTestCase = "ThenPublishMpnsFlipTileShouldReturnSuccess";
 
-            PNConfiguration config = new PNConfiguration
+            PNConfiguration config = new PNConfiguration("mytestuuid")
             {
                 PublishKey = PubnubCommon.PublishKey,
                 SubscribeKey = PubnubCommon.SubscribeKey,
-                Uuid = "mytestuuid",
                 Secure = false
             };
             if (PubnubCommon.PAMServerSideRun)
@@ -262,11 +259,10 @@ namespace PubNubMessaging.Tests
             publishTimetoken = 0;
             currentTestCase = "ThenPublishMpnsCycleTileShouldReturnSuccess";
 
-            PNConfiguration config = new PNConfiguration
+            PNConfiguration config = new PNConfiguration("mytestuuid")
             {
                 PublishKey = PubnubCommon.PublishKey,
                 SubscribeKey = PubnubCommon.SubscribeKey,
-                Uuid = "mytestuuid",
                 Secure = false
             };
             if (PubnubCommon.PAMServerSideRun)
@@ -332,11 +328,10 @@ namespace PubNubMessaging.Tests
             publishTimetoken = 0;
             currentTestCase = "ThenPublishMpnsIconicTileShouldReturnSuccess";
 
-            PNConfiguration config = new PNConfiguration
+            PNConfiguration config = new PNConfiguration("mytestuuid")
             {
                 PublishKey = PubnubCommon.PublishKey,
                 SubscribeKey = PubnubCommon.SubscribeKey,
-                Uuid = "mytestuuid",
                 Secure = false
             };
             if (PubnubCommon.PAMServerSideRun)
@@ -408,10 +403,9 @@ namespace PubNubMessaging.Tests
                 return;
             }
 
-            PNConfiguration config = new PNConfiguration
+            PNConfiguration config = new PNConfiguration("mytestuuid")
             {
                 SubscribeKey = PubnubCommon.SubscribeKey,
-                Uuid = "mytestuuid",
                 Secure = false
             };
             if (PubnubCommon.PAMServerSideRun)
@@ -467,10 +461,9 @@ namespace PubNubMessaging.Tests
                 return;
             }
 
-            PNConfiguration config = new PNConfiguration
+            PNConfiguration config = new PNConfiguration("mytestuuid")
             {
                 SubscribeKey = PubnubCommon.SubscribeKey,
-                Uuid = "mytestuuid",
                 Secure = false
             };
             if (PubnubCommon.PAMServerSideRun)
@@ -523,10 +516,9 @@ namespace PubNubMessaging.Tests
                 return;
             }
 
-            PNConfiguration config = new PNConfiguration
+            PNConfiguration config = new PNConfiguration("mytestuuid")
             {
                 SubscribeKey = PubnubCommon.SubscribeKey,
-                Uuid = "mytestuuid",
                 Secure = false
             };
             if (PubnubCommon.PAMServerSideRun)
@@ -588,10 +580,9 @@ namespace PubNubMessaging.Tests
                 return;
             }
 
-            PNConfiguration config = new PNConfiguration
+            PNConfiguration config = new PNConfiguration("mytestuuid")
             {
                 SubscribeKey = PubnubCommon.SubscribeKey,
-                Uuid = "mytestuuid",
                 Secure = false
             };
             if (PubnubCommon.PAMServerSideRun)
@@ -655,10 +646,9 @@ namespace PubNubMessaging.Tests
                 return;
             }
 
-            PNConfiguration config = new PNConfiguration
+            PNConfiguration config = new PNConfiguration("mytestuuid")
             {
                 SubscribeKey = PubnubCommon.SubscribeKey,
-                Uuid = "mytestuuid",
                 Secure = false
             };
             if (PubnubCommon.PAMServerSideRun)
@@ -720,10 +710,9 @@ namespace PubNubMessaging.Tests
                 return;
             }
 
-            PNConfiguration config = new PNConfiguration
+            PNConfiguration config = new PNConfiguration("mytestuuid")
             {
                 SubscribeKey = PubnubCommon.SubscribeKey,
-                Uuid = "mytestuuid",
                 Secure = false
             };
             if (PubnubCommon.PAMServerSideRun)
@@ -787,10 +776,9 @@ namespace PubNubMessaging.Tests
                 return;
             }
 
-            PNConfiguration config = new PNConfiguration
+            PNConfiguration config = new PNConfiguration("mytestuuid")
             {
                 SubscribeKey = PubnubCommon.SubscribeKey,
-                Uuid = "mytestuuid",
                 Secure = false
             };
             if (PubnubCommon.PAMServerSideRun)
@@ -851,10 +839,9 @@ namespace PubNubMessaging.Tests
                 return;
             }
 
-            PNConfiguration config = new PNConfiguration
+            PNConfiguration config = new PNConfiguration("mytestuuid")
             {
                 SubscribeKey = PubnubCommon.SubscribeKey,
-                Uuid = "mytestuuid",
                 Secure = false
             };
             if (PubnubCommon.PAMServerSideRun)
@@ -912,10 +899,9 @@ namespace PubNubMessaging.Tests
                 return;
             }
 
-            PNConfiguration config = new PNConfiguration
+            PNConfiguration config = new PNConfiguration("mytestuuid")
             {
                 SubscribeKey = PubnubCommon.SubscribeKey,
-                Uuid = "mytestuuid",
                 Secure = false
             };
             if (PubnubCommon.PAMServerSideRun)
@@ -976,10 +962,9 @@ namespace PubNubMessaging.Tests
                 return;
             }
 
-            PNConfiguration config = new PNConfiguration
+            PNConfiguration config = new PNConfiguration("mytestuuid")
             {
                 SubscribeKey = PubnubCommon.SubscribeKey,
-                Uuid = "mytestuuid",
                 Secure = false
             };
             if (PubnubCommon.PAMServerSideRun)

--- a/src/UnitTests/PubnubApi.Tests/WhenSubscribedToAChannel.cs
+++ b/src/UnitTests/PubnubApi.Tests/WhenSubscribedToAChannel.cs
@@ -42,13 +42,12 @@ namespace PubNubMessaging.Tests
             
             string[] channelsGrant = { "hello_my_channel", "hello_my_channel1", "hello_my_channel2" };
 
-            PNConfiguration config = new PNConfiguration
+            PNConfiguration config = new PNConfiguration("mytestuuid")
             {
                 PublishKey = PubnubCommon.PublishKey,
                 SubscribeKey = PubnubCommon.SubscribeKey,
                 SecretKey = PubnubCommon.SecretKey,
                 AuthKey = authKey,
-                Uuid = "mytestuuid",
                 Secure = true
             };
             server.RunOnHttps(true);
@@ -161,12 +160,11 @@ namespace PubNubMessaging.Tests
             bool receivedErrorMessage = false;
             CustomClass publishedMessage = new CustomClass();
 
-            PNConfiguration config = new PNConfiguration
+            PNConfiguration config = new PNConfiguration("mytestuuid")
             {
                 PublishKey = PubnubCommon.PublishKey,
                 SubscribeKey = PubnubCommon.SubscribeKey,
                 CipherKey = cipherKey,
-                Uuid = "mytestuuid",
                 Secure = ssl
             };
             if (PubnubCommon.PAMServerSideRun)
@@ -382,11 +380,10 @@ namespace PubNubMessaging.Tests
 
             bool receivedMessage = false;
 
-            PNConfiguration config = new PNConfiguration
+            PNConfiguration config = new PNConfiguration("mytestuuid")
             {
                 PublishKey = PubnubCommon.PublishKey,
                 SubscribeKey = PubnubCommon.SubscribeKey,
-                Uuid = "mytestuuid",
                 Secure = false,
                 LogVerbosity = PNLogVerbosity.BODY,
                 PubnubLog = new TestLog(),
@@ -466,11 +463,10 @@ namespace PubNubMessaging.Tests
 
             bool receivedMessage = false;
 
-            PNConfiguration config = new PNConfiguration
+            PNConfiguration config = new PNConfiguration("mytestuuid")
             {
                 PublishKey = PubnubCommon.PublishKey,
                 SubscribeKey = PubnubCommon.SubscribeKey,
-                Uuid = "mytestuuid",
                 Secure = false
             };
             if (PubnubCommon.PAMServerSideRun)
@@ -578,11 +574,10 @@ namespace PubNubMessaging.Tests
 
             bool receivedMessage = false;
 
-            PNConfiguration config = new PNConfiguration
+            PNConfiguration config = new PNConfiguration("mytestuuid")
             {
                 PublishKey = PubnubCommon.PublishKey,
                 SubscribeKey = PubnubCommon.SubscribeKey,
-                Uuid = "mytestuuid",
                 Secure = true,
                 LogVerbosity = PNLogVerbosity.BODY,
                 PubnubLog = new TestLog(),
@@ -695,11 +690,10 @@ namespace PubNubMessaging.Tests
             bool receivedErrorMessage = false;
             int numberOfReceivedMessages = 0;
 
-            PNConfiguration config = new PNConfiguration
+            PNConfiguration config = new PNConfiguration("mytestuuid")
             {
                 PublishKey = PubnubCommon.PublishKey,
                 SubscribeKey = PubnubCommon.SubscribeKey,
-                Uuid = "mytestuuid",
                 Secure = false
             };
             if (PubnubCommon.PAMServerSideRun)

--- a/src/UnitTests/PubnubApi.Tests/WhenSubscribedToAChannel2.cs
+++ b/src/UnitTests/PubnubApi.Tests/WhenSubscribedToAChannel2.cs
@@ -54,13 +54,12 @@ namespace PubNubMessaging.Tests
 
             receivedGrantMessage = false;
 
-            PNConfiguration config = new PNConfiguration
+            PNConfiguration config = new PNConfiguration("mytestuuid")
             {
                 PublishKey = PubnubCommon.PublishKey,
                 SubscribeKey = PubnubCommon.SubscribeKey,
                 SecretKey = PubnubCommon.SecretKey,
                 AuthKey = authKey,
-                Uuid = "mytestuuid",
                 Secure = false
             };
             server.RunOnHttps(false);
@@ -123,12 +122,11 @@ namespace PubNubMessaging.Tests
                 Assert.Ignore("Ignored for Server side run");
             }
 
-            PNConfiguration config = new PNConfiguration
+            PNConfiguration config = new PNConfiguration("mytestuuid")
             {
                 PublishKey = PubnubCommon.PublishKey,
                 SubscribeKey = PubnubCommon.SubscribeKey,
                 CipherKey = cipherKey,
-                Uuid = "mytestuuid",
                 Secure = ssl,
                 LogVerbosity = PNLogVerbosity.BODY,
                 PubnubLog = new TestLog(),
@@ -321,12 +319,11 @@ namespace PubNubMessaging.Tests
                 Assert.Ignore("Ignored for Server side run");
             }
 
-            PNConfiguration config = new PNConfiguration
+            PNConfiguration config = new PNConfiguration("mytestuuid")
             {
                 PublishKey = PubnubCommon.PublishKey,
                 SubscribeKey = PubnubCommon.SubscribeKey,
                 CipherKey = cipherKey,
-                Uuid = "mytestuuid",
                 Secure = ssl,
                 LogVerbosity = PNLogVerbosity.BODY,
                 PubnubLog = new TestLog(),

--- a/src/UnitTests/PubnubApi.Tests/WhenSubscribedToAChannel3.cs
+++ b/src/UnitTests/PubnubApi.Tests/WhenSubscribedToAChannel3.cs
@@ -44,13 +44,12 @@ namespace PubNubMessaging.Tests
 
             receivedGrantMessage = false;
 
-            PNConfiguration config = new PNConfiguration
+            PNConfiguration config = new PNConfiguration("mytestuuid")
             {
                 PublishKey = PubnubCommon.PublishKey,
                 SubscribeKey = PubnubCommon.SubscribeKey,
                 SecretKey = PubnubCommon.SecretKey,
                 AuthKey = authKey,
-                Uuid = "mytestuuid",
                 Secure = false
             };
             server.RunOnHttps(false);
@@ -113,12 +112,11 @@ namespace PubNubMessaging.Tests
                 Assert.Ignore("Ignored for Server side run");
             }
 
-            PNConfiguration config = new PNConfiguration
+            PNConfiguration config = new PNConfiguration("mytestuuid")
             {
                 PublishKey = PubnubCommon.PublishKey,
                 SubscribeKey = PubnubCommon.SubscribeKey,
                 CipherKey = cipherKey,
-                Uuid = "mytestuuid",
                 Secure = ssl
             };
             if (PubnubCommon.PAMServerSideRun)
@@ -229,12 +227,11 @@ namespace PubNubMessaging.Tests
                 Assert.Ignore("Ignored for Server side run");
             }
 
-            PNConfiguration config = new PNConfiguration
+            PNConfiguration config = new PNConfiguration("mytestuuid")
             {
                 PublishKey = PubnubCommon.PublishKey,
                 SubscribeKey = PubnubCommon.SubscribeKey,
                 CipherKey = cipherKey,
-                Uuid = "mytestuuid",
                 Secure = ssl
             };
             if (PubnubCommon.PAMServerSideRun)
@@ -419,12 +416,11 @@ namespace PubNubMessaging.Tests
                 Assert.Ignore("Ignored for Server side run");
             }
 
-            PNConfiguration config = new PNConfiguration
+            PNConfiguration config = new PNConfiguration("mytestuuid")
             {
                 PublishKey = PubnubCommon.PublishKey,
                 SubscribeKey = PubnubCommon.SubscribeKey,
                 CipherKey = cipherKey,
-                Uuid = "mytestuuid",
                 Secure = ssl
             };
             if (PubnubCommon.PAMServerSideRun)

--- a/src/UnitTests/PubnubApi.Tests/WhenSubscribedToAChannelGroup.cs
+++ b/src/UnitTests/PubnubApi.Tests/WhenSubscribedToAChannelGroup.cs
@@ -46,12 +46,11 @@ namespace PubNubMessaging.Tests
 
             bool receivedGrantMessage = false;
 
-            PNConfiguration config = new PNConfiguration
+            PNConfiguration config = new PNConfiguration("mytestuuid")
             {
                 PublishKey = PubnubCommon.PublishKey,
                 SubscribeKey = PubnubCommon.SubscribeKey,
                 SecretKey = PubnubCommon.SecretKey,
-                Uuid = "mytestuuid",
                 Secure = false
             };
             server.RunOnHttps(false);
@@ -171,11 +170,10 @@ namespace PubNubMessaging.Tests
 
             bool receivedMessage = false;
 
-            PNConfiguration config = new PNConfiguration
+            PNConfiguration config = new PNConfiguration("mytestuuid")
             {
                 PublishKey = PubnubCommon.PublishKey,
                 SubscribeKey = PubnubCommon.SubscribeKey,
-                Uuid = "mytestuuid",
                 Secure = false,
                 LogVerbosity = PNLogVerbosity.BODY,
                 PubnubLog = new TestLog(),
@@ -340,11 +338,10 @@ namespace PubNubMessaging.Tests
 
             bool receivedMessage = false;
 
-            PNConfiguration config = new PNConfiguration
+            PNConfiguration config = new PNConfiguration("mytestuuid")
             {
                 PublishKey = PubnubCommon.PublishKey,
                 SubscribeKey = PubnubCommon.SubscribeKey,
-                Uuid = "mytestuuid",
                 Secure = false
             };
             if (PubnubCommon.PAMServerSideRun)
@@ -466,11 +463,10 @@ namespace PubNubMessaging.Tests
 
             bool receivedMessage = false;
 
-            PNConfiguration config = new PNConfiguration
+            PNConfiguration config = new PNConfiguration("mytestuuid")
             {
                 PublishKey = PubnubCommon.PublishKey,
                 SubscribeKey = PubnubCommon.SubscribeKey,
-                Uuid = "mytestuuid",
                 Secure = false
             };
             if (PubnubCommon.PAMServerSideRun)

--- a/src/UnitTests/PubnubApi.Tests/WhenSubscribedToWildcardChannel.cs
+++ b/src/UnitTests/PubnubApi.Tests/WhenSubscribedToWildcardChannel.cs
@@ -42,13 +42,12 @@ namespace PubNubMessaging.Tests
 
             bool receivedGrantMessage = false;
 
-            PNConfiguration config = new PNConfiguration
+            PNConfiguration config = new PNConfiguration("mytestuuid")
             {
                 PublishKey = PubnubCommon.PublishKey,
                 SubscribeKey = PubnubCommon.SubscribeKey,
                 SecretKey = PubnubCommon.SecretKey,
                 AuthKey = authKey,
-                Uuid = "mytestuuid",
                 Secure = false,
                 LogVerbosity = PNLogVerbosity.BODY,
                 PubnubLog = new TestLog()
@@ -442,12 +441,11 @@ namespace PubNubMessaging.Tests
             bool internalReceivedMessage = false;
             bool receivedErrorMessage = false;
 
-            PNConfiguration config = new PNConfiguration
+            PNConfiguration config = new PNConfiguration("mytestuuid")
             {
                 PublishKey = PubnubCommon.PublishKey,
                 SubscribeKey = PubnubCommon.SubscribeKey,
                 CipherKey = cipherKey,
-                Uuid = "mytestuuid",
                 Secure = ssl,
                 LogVerbosity = PNLogVerbosity.BODY,
                 PubnubLog = new TestLog()
@@ -659,12 +657,11 @@ namespace PubNubMessaging.Tests
             bool internalReceivedMessage = false;
             bool receivedErrorMessage = false;
 
-            PNConfiguration config = new PNConfiguration
+            PNConfiguration config = new PNConfiguration("mytestuuid")
             {
                 PublishKey = PubnubCommon.PublishKey,
                 SubscribeKey = PubnubCommon.SubscribeKey,
                 CipherKey = cipherKey,
-                Uuid = "mytestuuid",
                 Secure = ssl
             };
             if (PubnubCommon.PAMServerSideRun)
@@ -849,11 +846,10 @@ namespace PubNubMessaging.Tests
 
             bool receivedMessage = false;
 
-            PNConfiguration config = new PNConfiguration
+            PNConfiguration config = new PNConfiguration("mytestuuid")
             {
                 PublishKey = PubnubCommon.PublishKey,
                 SubscribeKey = PubnubCommon.SubscribeKey,
-                Uuid = "mytestuuid",
                 AuthKey = authKey,
                 Secure = false
             };
@@ -1086,11 +1082,10 @@ namespace PubNubMessaging.Tests
             bool receivedMessage = false;
             bool receivedErrorMessage = true;
 
-            PNConfiguration config = new PNConfiguration
+            PNConfiguration config = new PNConfiguration("mytestuuid")
             {
                 PublishKey = PubnubCommon.PublishKey,
                 SubscribeKey = PubnubCommon.SubscribeKey,
-                Uuid = "mytestuuid",
                 Secure = false,
                 LogVerbosity = PNLogVerbosity.BODY,
                 PubnubLog = new TestLog(),

--- a/src/UnitTests/PubnubApi.Tests/WhenUnsubscribedToAChannel.cs
+++ b/src/UnitTests/PubnubApi.Tests/WhenUnsubscribedToAChannel.cs
@@ -40,13 +40,12 @@ namespace PubNubMessaging.Tests
 
             receivedGrantMessage = false;
 
-            PNConfiguration config = new PNConfiguration
+            PNConfiguration config = new PNConfiguration("mytestuuid")
             {
                 PublishKey = PubnubCommon.PublishKey,
                 SubscribeKey = PubnubCommon.SubscribeKey,
                 SecretKey = PubnubCommon.SecretKey,
                 AuthKey = authKey,
-                Uuid = "mytestuuid",
                 Secure = false
             };
             server.RunOnHttps(false);
@@ -98,11 +97,10 @@ namespace PubNubMessaging.Tests
             receivedMessage = false;
             currentTestCase = "ThenShouldReturnUnsubscribedMessage";
 
-            PNConfiguration config = new PNConfiguration
+            PNConfiguration config = new PNConfiguration("mytestuuid")
             {
                 PublishKey = PubnubCommon.PublishKey,
                 SubscribeKey = PubnubCommon.SubscribeKey,
-                Uuid = "mytestuuid",
                 Secure = false
             };
             if (PubnubCommon.PAMServerSideRun)

--- a/src/UnitTests/PubnubApi.Tests/WhenUnsubscribedToAChannelGroup.cs
+++ b/src/UnitTests/PubnubApi.Tests/WhenUnsubscribedToAChannelGroup.cs
@@ -29,13 +29,12 @@ namespace PubNubMessaging.Tests
 
             bool receivedGrantMessage = false;
 
-            PNConfiguration config = new PNConfiguration
+            PNConfiguration config = new PNConfiguration("mytestuuid")
             {
                 PublishKey = PubnubCommon.PublishKey,
                 SubscribeKey = PubnubCommon.SubscribeKey,
                 SecretKey = PubnubCommon.SecretKey,
                 AuthKey = authKey,
-                Uuid = "mytestuuid",
                 Secure = false
             };
             server.RunOnHttps(false);
@@ -120,11 +119,10 @@ namespace PubNubMessaging.Tests
 
             bool receivedMessage = false;
 
-            PNConfiguration config = new PNConfiguration
+            PNConfiguration config = new PNConfiguration("mytestuuid")
             {
                 PublishKey = PubnubCommon.PublishKey,
                 SubscribeKey = PubnubCommon.SubscribeKey,
-                Uuid = "mytestuuid",
                 Secure = false
             };
             if (PubnubCommon.PAMServerSideRun)


### PR DESCRIPTION
refactor: BREAKING CHANGE. UUID is mandatory to use SDK.

UUID is mandatory to use SDK.

BREAKING CHANGES: UUID is mandatory to use SDK.