### PR TITLE
Refactor Telemetry Task Result to GetAwaiter().GetResult()

### DIFF
--- a/.pubnub.yml
+++ b/.pubnub.yml
@@ -1,8 +1,15 @@
 name: c-sharp
-version: "6.2.0"
+version: "6.3.0"
 schema: 1
 scm: github.com/pubnub/c-sharp
 changelog:
+  - date: 2022-03-22
+    version: v6.3.0
+    changes:
+      - type: bug
+        text: "Refactor Telemetry Task Result to GetAwaiter().GetResult() ."
+      - type: bug
+        text: "Removed SILVERLIGHT, WINDOWS_PHONE preprocessor directive code."
   - date: 2022-01-27
     version: v6.2.0
     changes:
@@ -636,7 +643,7 @@ features:
     - QUERY-PARAM
 supported-platforms:
   -
-    version: Pubnub 'C#' 6.2.0
+    version: Pubnub 'C#' 6.3.0
     platforms:
       - Windows 10 and up
       - Windows Server 2008 and up
@@ -646,7 +653,7 @@ supported-platforms:
       - .Net Framework 4.5
       - .Net Framework 4.6.1+
   -
-    version: PubnubPCL 'C#' 6.2.0
+    version: PubnubPCL 'C#' 6.3.0
     platforms:
       - Xamarin.Android
       - Xamarin.iOS
@@ -665,7 +672,7 @@ supported-platforms:
       - .Net Standard 2.1
       - .Net Core
   -
-    version: PubnubUWP 'C#' 6.2.0
+    version: PubnubUWP 'C#' 6.3.0
     platforms:
       - Windows Phone 10
       - Universal Windows Apps
@@ -689,7 +696,7 @@ sdks:
             distribution-type: source
             distribution-repository: GitHub
             package-name: Pubnub
-            location: https://github.com/pubnub/c-sharp/releases/tag/v6.2.0.0
+            location: https://github.com/pubnub/c-sharp/releases/tag/v6.3.0.0
             requires:
               -
                 name: ".Net"
@@ -986,7 +993,7 @@ sdks:
             distribution-type: source
             distribution-repository: GitHub
             package-name: PubNubPCL
-            location: https://github.com/pubnub/c-sharp/releases/tag/v6.2.0.0
+            location: https://github.com/pubnub/c-sharp/releases/tag/v6.3.0.0
             requires:
               -
                 name: ".Net Core"
@@ -1359,7 +1366,7 @@ sdks:
             distribution-type: source
             distribution-repository: GitHub
             package-name: PubnubUWP
-            location: https://github.com/pubnub/c-sharp/releases/tag/v6.2.0.0
+            location: https://github.com/pubnub/c-sharp/releases/tag/v6.3.0.0
             requires:
               -
                 name: "Universal Windows Platform Development"

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,8 @@
+v6.3.0 - March 22 2022
+-----------------------------
+- Fixed: refactor Telemetry Task Result to GetAwaiter().GetResult() .
+- Fixed: removed SILVERLIGHT, WINDOWS_PHONE preprocessor directive code.
+
 v6.2.0 - January 27 2022
 -----------------------------
 - Modified: bumped PeterO.Cbor library version to 4.5.2.

--- a/src/Api/PubnubApi/Builder/UrlRequestBuilder.cs
+++ b/src/Api/PubnubApi/Builder/UrlRequestBuilder.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Text;
 using PubnubApi.Interface;
 using System.Globalization;
+using System.Threading.Tasks;
 #if !NETSTANDARD10 && !NETSTANDARD11 && !NETSTANDARD12 && !WP81
 using System.Reflection;
 #endif
@@ -2064,14 +2065,18 @@ namespace PubnubApi
 
                 if (pubnubConfig.EnableTelemetry && telemetryMgr != null)
                 {
-                    Dictionary<string, string> opsLatency = telemetryMgr.GetOperationsLatency().Result;
-                    if (opsLatency != null && opsLatency.Count > 0)
+                    var telemetryTask = Task.Factory.StartNew(async() => 
                     {
-                        foreach (string key in opsLatency.Keys)
+                        Dictionary<string, string> opsLatency = await telemetryMgr.GetOperationsLatency();
+                        if (opsLatency != null && opsLatency.Count > 0)
                         {
-                            ret.Add(key, opsLatency[key]);
+                            foreach (string key in opsLatency.Keys)
+                            {
+                                ret.Add(key, opsLatency[key]);
+                            }
                         }
-                    }
+                    }).Unwrap();
+                    telemetryTask.Wait();
                 }
 
                 if (!string.IsNullOrEmpty(pubnubConfig.SecretKey))

--- a/src/Api/PubnubApi/Builder/UrlRequestBuilder.cs
+++ b/src/Api/PubnubApi/Builder/UrlRequestBuilder.cs
@@ -5,6 +5,7 @@ using System.Text;
 using PubnubApi.Interface;
 using System.Globalization;
 using System.Threading.Tasks;
+using System.Threading;
 #if !NETSTANDARD10 && !NETSTANDARD11 && !NETSTANDARD12 && !WP81
 using System.Reflection;
 #endif
@@ -2065,18 +2066,14 @@ namespace PubnubApi
 
                 if (pubnubConfig.EnableTelemetry && telemetryMgr != null)
                 {
-                    var telemetryTask = Task.Factory.StartNew(async() => 
+                    Dictionary<string, string> opsLatency = telemetryMgr.GetOperationsLatency().ConfigureAwait(false).GetAwaiter().GetResult();
+                    if (opsLatency != null && opsLatency.Count > 0)
                     {
-                        Dictionary<string, string> opsLatency = await telemetryMgr.GetOperationsLatency();
-                        if (opsLatency != null && opsLatency.Count > 0)
+                        foreach (string key in opsLatency.Keys)
                         {
-                            foreach (string key in opsLatency.Keys)
-                            {
-                                ret.Add(key, opsLatency[key]);
-                            }
+                            ret.Add(key, opsLatency[key]);
                         }
-                    }).Unwrap();
-                    telemetryTask.Wait();
+                    }
                 }
 
                 if (!string.IsNullOrEmpty(pubnubConfig.SecretKey))

--- a/src/Api/PubnubApi/Properties/AssemblyInfo.cs
+++ b/src/Api/PubnubApi/Properties/AssemblyInfo.cs
@@ -11,8 +11,8 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyProduct("Pubnub C# SDK")]
 [assembly: AssemblyCopyright("Copyright ©  2021")]
 [assembly: AssemblyTrademark("")]
-[assembly: AssemblyVersion("6.2.0.0")]
-[assembly: AssemblyFileVersion("6.2.0.0")]
+[assembly: AssemblyVersion("6.3.0.0")]
+[assembly: AssemblyFileVersion("6.3.0.0")]
 // Setting ComVisible to false makes the types in this assembly not visible
 // to COM components.  If you need to access a type in this assembly from
 // COM, set the ComVisible attribute to true on that type.

--- a/src/Api/PubnubApi/PubnubApi.csproj
+++ b/src/Api/PubnubApi/PubnubApi.csproj
@@ -13,7 +13,7 @@
 
   <PropertyGroup>
     <PackageId>Pubnub</PackageId>
-    <PackageVersion>6.2.0.0</PackageVersion>
+    <PackageVersion>6.3.0.0</PackageVersion>
     <Title>PubNub C# .NET - Web Data Push API</Title>
     <Authors>Pandu Masabathula</Authors>
     <Owners>PubNub</Owners>
@@ -21,7 +21,8 @@
     <PackageIconUrl>http://pubnub.s3.amazonaws.com/2011/powered-by-pubnub/pubnub-icon-600x600.png</PackageIconUrl>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
     <RepositoryUrl>https://github.com/pubnub/c-sharp/</RepositoryUrl>
-    <PackageReleaseNotes>Bumped PeterO.Cbor library version to 4.5.2.</PackageReleaseNotes>
+    <PackageReleaseNotes>Refactor Telemetry Task Result to GetAwaiter().GetResult() .
+Removed SILVERLIGHT, WINDOWS_PHONE preprocessor directive code.</PackageReleaseNotes>
     <PackageTags>Web Data Push Real-time Notifications ESB Message Broadcasting Distributed Computing</PackageTags>
     <!--<Summary>PubNub is a Massively Scalable Web Push Service for Web and Mobile Games.  This is a cloud-based service for broadcasting messages to thousands of web and mobile clients simultaneously</Summary>-->
     <Description>PubNub is a Massively Scalable Web Push Service for Web and Mobile Games.  This is a cloud-based service for broadcasting messages to thousands of web and mobile clients simultaneously</Description>

--- a/src/Api/PubnubApi/PubnubCoreBase.cs
+++ b/src/Api/PubnubApi/PubnubCoreBase.cs
@@ -229,11 +229,6 @@ namespace PubnubApi
                 PubnubLocalHeartbeatCheckIntervalInSeconds = pubnubConfiguation.PresenceInterval;
             }
             enableResumeOnReconnect = pubnubConfiguation.ReconnectionPolicy != PNReconnectionPolicy.NONE;
-
-#if (SILVERLIGHT || WINDOWS_PHONE)
-            HttpWebRequest.RegisterPrefix("https://", WebRequestCreator.ClientHttp);
-            HttpWebRequest.RegisterPrefix("http://", WebRequestCreator.ClientHttp);
-#endif
         }
 
 

--- a/src/Api/PubnubApiPCL/PubnubApiPCL.csproj
+++ b/src/Api/PubnubApiPCL/PubnubApiPCL.csproj
@@ -14,7 +14,7 @@
 
   <PropertyGroup>
     <PackageId>PubnubPCL</PackageId>
-    <PackageVersion>6.2.0.0</PackageVersion>
+    <PackageVersion>6.3.0.0</PackageVersion>
     <Title>PubNub C# .NET - Web Data Push API</Title>
     <Authors>Pandu Masabathula</Authors>
     <Owners>PubNub</Owners>
@@ -22,7 +22,8 @@
     <PackageIconUrl>http://pubnub.s3.amazonaws.com/2011/powered-by-pubnub/pubnub-icon-600x600.png</PackageIconUrl>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
     <RepositoryUrl>https://github.com/pubnub/c-sharp/</RepositoryUrl>
-    <PackageReleaseNotes>Bumped PeterO.Cbor library version to 4.5.2.</PackageReleaseNotes>
+    <PackageReleaseNotes>Refactor Telemetry Task Result to GetAwaiter().GetResult() .
+Removed SILVERLIGHT, WINDOWS_PHONE preprocessor directive code.</PackageReleaseNotes>
     <PackageTags>Web Data Push Real-time Notifications ESB Message Broadcasting Distributed Computing</PackageTags>
     <!--<Summary>PubNub is a Massively Scalable Web Push Service for Web and Mobile Games.  This is a cloud-based service for broadcasting messages to thousands of web and mobile clients simultaneously</Summary>-->
     <Description>PubNub is a Massively Scalable Web Push Service for Web and Mobile Games.  This is a cloud-based service for broadcasting messages to thousands of web and mobile clients simultaneously</Description>

--- a/src/Api/PubnubApiUWP/PubnubApiUWP.csproj
+++ b/src/Api/PubnubApiUWP/PubnubApiUWP.csproj
@@ -15,7 +15,7 @@
 
   <PropertyGroup>
     <PackageId>PubnubUWP</PackageId>
-    <PackageVersion>6.2.0.0</PackageVersion>
+    <PackageVersion>6.3.0.0</PackageVersion>
     <Title>PubNub C# .NET - Web Data Push API</Title>
     <Authors>Pandu Masabathula</Authors>
     <Owners>PubNub</Owners>
@@ -23,7 +23,8 @@
     <PackageIconUrl>http://pubnub.s3.amazonaws.com/2011/powered-by-pubnub/pubnub-icon-600x600.png</PackageIconUrl>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
     <RepositoryUrl>https://github.com/pubnub/c-sharp/</RepositoryUrl>
-    <PackageReleaseNotes>Bumped PeterO.Cbor library version to 4.5.2.</PackageReleaseNotes>
+    <PackageReleaseNotes>Refactor Telemetry Task Result to GetAwaiter().GetResult() .
+Removed SILVERLIGHT, WINDOWS_PHONE preprocessor directive code.</PackageReleaseNotes>
     <PackageTags>Web Data Push Real-time Notifications ESB Message Broadcasting Distributed Computing</PackageTags>
     <!--<Summary>PubNub is a Massively Scalable Web Push Service for Web and Mobile Games.  This is a cloud-based service for broadcasting messages to thousands of web and mobile clients simultaneously</Summary>-->
     <Description>PubNub is a Massively Scalable Web Push Service for Web and Mobile Games.  This is a cloud-based service for broadcasting messages to thousands of web and mobile clients simultaneously</Description>


### PR DESCRIPTION

fix: Refactor Telemetry Task Result to GetAwaiter().GetResult()

Refactor Telemetry Task Result to GetAwaiter().GetResult() 

fix: Removed SILVERLIGHT, WINDOWS_PHONE preprocessor directive code

Removed SILVERLIGHT, WINDOWS_PHONE preprocessor directive code