### PR TITLE
Refactor Telemetry Task Result to GetAwaiter().GetResult()

### DIFF
--- a/src/UnitTests/PubnubApi.Tests/TestHarness.cs
+++ b/src/UnitTests/PubnubApi.Tests/TestHarness.cs
@@ -15,7 +15,7 @@ namespace PubNubMessaging.Tests
                 #pragma warning restore CS0162 // Unreachable code detected
 
                 IPubnubUnitTest unitTest = new PubnubUnitTest();
-                unitTest.Timetoken = 1567581283;
+                unitTest.Timetoken = 1567581283; //Hardcoded timetoken
                 unitTest.RequestId = "myRequestId";
                 unitTest.InternetAvailable = true;
                 unitTest.SdkVersion = "Csharp";


### PR DESCRIPTION

fix: Refactor Telemetry Task Result to GetAwaiter().GetResult()

Refactor Telemetry Task Result to GetAwaiter().GetResult() 

fix: Removed SILVERLIGHT, WINDOWS_PHONE preprocessor directive code

Removed SILVERLIGHT, WINDOWS_PHONE preprocessor directive code
