### PR TITLE
Pubnub Instance Destroy fix

### DIFF
--- a/.pubnub.yml
+++ b/.pubnub.yml
@@ -1,8 +1,13 @@
 name: c-sharp
-version: "6.7.0"
+version: "6.8.0"
 schema: 1
 scm: github.com/pubnub/c-sharp
 changelog:
+  - date: 2022-08-10
+    version: v6.8.0
+    changes:
+      - type: bug
+        text: "Fixed Destroy() method when multiple Pubnub instances were in use."
   - date: 2022-07-27
     version: v6.7.0
     changes:
@@ -665,7 +670,7 @@ features:
     - QUERY-PARAM
 supported-platforms:
   -
-    version: Pubnub 'C#' 6.7.0
+    version: Pubnub 'C#' 6.8.0
     platforms:
       - Windows 10 and up
       - Windows Server 2008 and up
@@ -675,7 +680,7 @@ supported-platforms:
       - .Net Framework 4.5
       - .Net Framework 4.6.1+
   -
-    version: PubnubPCL 'C#' 6.7.0
+    version: PubnubPCL 'C#' 6.8.0
     platforms:
       - Xamarin.Android
       - Xamarin.iOS
@@ -695,7 +700,7 @@ supported-platforms:
       - .Net Core
       - .Net 6.0
   -
-    version: PubnubUWP 'C#' 6.7.0
+    version: PubnubUWP 'C#' 6.8.0
     platforms:
       - Windows Phone 10
       - Universal Windows Apps
@@ -719,7 +724,7 @@ sdks:
             distribution-type: source
             distribution-repository: GitHub
             package-name: Pubnub
-            location: https://github.com/pubnub/c-sharp/releases/tag/v6.7.0.0
+            location: https://github.com/pubnub/c-sharp/releases/tag/v6.8.0.0
             requires:
               -
                 name: ".Net"
@@ -1002,7 +1007,7 @@ sdks:
             distribution-type: source
             distribution-repository: GitHub
             package-name: PubNubPCL
-            location: https://github.com/pubnub/c-sharp/releases/tag/v6.7.0.0
+            location: https://github.com/pubnub/c-sharp/releases/tag/v6.8.0.0
             requires:
               -
                 name: ".Net Core"
@@ -1361,7 +1366,7 @@ sdks:
             distribution-type: source
             distribution-repository: GitHub
             package-name: PubnubUWP
-            location: https://github.com/pubnub/c-sharp/releases/tag/v6.7.0.0
+            location: https://github.com/pubnub/c-sharp/releases/tag/v6.8.0.0
             requires:
               -
                 name: "Universal Windows Platform Development"

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+v6.8.0 - August 10 2022
+-----------------------------
+- Fixed: fixed Destroy() method when multiple Pubnub instances were in use.
+
 v6.7.0 - July 27 2022
 -----------------------------
 - Modified: added support for Users/Spaces to GrantToken.

--- a/src/Api/PubnubApi/Properties/AssemblyInfo.cs
+++ b/src/Api/PubnubApi/Properties/AssemblyInfo.cs
@@ -11,8 +11,8 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyProduct("Pubnub C# SDK")]
 [assembly: AssemblyCopyright("Copyright ©  2021")]
 [assembly: AssemblyTrademark("")]
-[assembly: AssemblyVersion("6.7.0.0")]
-[assembly: AssemblyFileVersion("6.7.0.0")]
+[assembly: AssemblyVersion("6.8.0.0")]
+[assembly: AssemblyFileVersion("6.8.0.0")]
 // Setting ComVisible to false makes the types in this assembly not visible
 // to COM components.  If you need to access a type in this assembly from
 // COM, set the ComVisible attribute to true on that type.

--- a/src/Api/PubnubApi/PubnubApi.csproj
+++ b/src/Api/PubnubApi/PubnubApi.csproj
@@ -13,7 +13,7 @@
 
   <PropertyGroup>
     <PackageId>Pubnub</PackageId>
-    <PackageVersion>6.7.0.0</PackageVersion>
+    <PackageVersion>6.8.0.0</PackageVersion>
     <Title>PubNub C# .NET - Web Data Push API</Title>
     <Authors>Pandu Masabathula</Authors>
     <Owners>PubNub</Owners>
@@ -21,7 +21,7 @@
     <PackageIconUrl>http://pubnub.s3.amazonaws.com/2011/powered-by-pubnub/pubnub-icon-600x600.png</PackageIconUrl>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
     <RepositoryUrl>https://github.com/pubnub/c-sharp/</RepositoryUrl>
-    <PackageReleaseNotes>Added support for Users/Spaces to GrantToken.</PackageReleaseNotes>
+    <PackageReleaseNotes>Fixed Destroy() method when multiple Pubnub instances were in use.</PackageReleaseNotes>
     <PackageTags>Web Data Push Real-time Notifications ESB Message Broadcasting Distributed Computing</PackageTags>
     <!--<Summary>PubNub is a Massively Scalable Web Push Service for Web and Mobile Games.  This is a cloud-based service for broadcasting messages to thousands of web and mobile clients simultaneously</Summary>-->
     <Description>PubNub is a Massively Scalable Web Push Service for Web and Mobile Games.  This is a cloud-based service for broadcasting messages to thousands of web and mobile clients simultaneously</Description>

--- a/src/Api/PubnubApi/PubnubCoreBase.cs
+++ b/src/Api/PubnubApi/PubnubCoreBase.cs
@@ -2273,7 +2273,10 @@ namespace PubnubApi
 
         internal void EndPendingRequests()
         {
-            SubscribeCallbackListenerList.Clear();
+            if (SubscribeCallbackListenerList.ContainsKey(PubnubInstance.InstanceId))
+            {
+                SubscribeCallbackListenerList[PubnubInstance.InstanceId].Clear();
+            }
 
             RemoveChannelDictionary();
             TerminatePendingWebRequest();
@@ -2314,7 +2317,11 @@ namespace PubnubApi
                 ChannelGroupUserState[PubnubInstance.InstanceId].Clear();
             }
 
-            RemoveHttpClients();
+            if (MultiChannelSubscribe.Count > 0 && MultiChannelSubscribe.Select(t => t.Value.Count > 0).Count() == 0
+                 && MultiChannelGroupSubscribe.Count > 0 && MultiChannelGroupSubscribe.Select(t => t.Value.Count > 0).Count() == 0)
+            {
+                RemoveHttpClients();
+            }
 
             PubnubInstance = null;
         }

--- a/src/Api/PubnubApi/PubnubCoreBase.cs
+++ b/src/Api/PubnubApi/PubnubCoreBase.cs
@@ -2317,9 +2317,48 @@ namespace PubnubApi
                 ChannelGroupUserState[PubnubInstance.InstanceId].Clear();
             }
 
+            if (MultiChannelSubscribe.Count > 0 && MultiChannelSubscribe.Where(t => t.Value.Keys.Count > 0).Count() == 0
+                 && MultiChannelGroupSubscribe.Count > 0 && MultiChannelGroupSubscribe.Where(t => t.Value.Keys.Count > 0).Count() == 0)
+            {
+                RemoveHttpClients();
+            }
             PubnubInstance = null;
         }
 
+        internal static void RemoveHttpClients()
+        {
+            //Conditionalmethod logic
+#if !NET35 && !NET40 && !NET45 && !NET461 && !NET48 && !NETSTANDARD10
+            if (httpClientNetworkStatus != null)
+            {
+                try{
+                    httpClientNetworkStatus.CancelPendingRequests();
+                    httpClientNetworkStatus.Dispose();
+                    httpClientNetworkStatus = null;
+                }
+                catch { /* ignore */ }
+            }
+            if (httpClientSubscribe != null)
+            {
+                try{
+                    httpClientSubscribe.CancelPendingRequests();
+                    httpClientSubscribe.Dispose();
+                    httpClientSubscribe = null;
+                }
+                catch { /* ignore */ }
+            }
+            if (httpClientNonsubscribe != null)
+            {
+                try{
+                    httpClientNonsubscribe.CancelPendingRequests();
+                    httpClientNonsubscribe.Dispose();
+                    httpClientNonsubscribe = null;
+                }
+                catch { /* ignore */ }
+            }
+#endif
+        }
+        
         internal void TerminateCurrentSubscriberRequest()
         {
             string[] channels = GetCurrentSubscriberChannels();

--- a/src/Api/PubnubApi/PubnubCoreBase.cs
+++ b/src/Api/PubnubApi/PubnubCoreBase.cs
@@ -2317,47 +2317,7 @@ namespace PubnubApi
                 ChannelGroupUserState[PubnubInstance.InstanceId].Clear();
             }
 
-            if (MultiChannelSubscribe.Count > 0 && MultiChannelSubscribe.Select(t => t.Value.Count > 0).Count() == 0
-                 && MultiChannelGroupSubscribe.Count > 0 && MultiChannelGroupSubscribe.Select(t => t.Value.Count > 0).Count() == 0)
-            {
-                RemoveHttpClients();
-            }
-
             PubnubInstance = null;
-        }
-
-        internal static void RemoveHttpClients()
-        {
-            //Conditionalmethod logic
-#if !NET35 && !NET40 && !NET45 && !NET461 && !NET48 && !NETSTANDARD10
-            if (httpClientNetworkStatus != null)
-            {
-                try{
-                    httpClientNetworkStatus.CancelPendingRequests();
-                    httpClientNetworkStatus.Dispose();
-                    httpClientNetworkStatus = null;
-                }
-                catch { /* ignore */ }
-            }
-            if (httpClientSubscribe != null)
-            {
-                try{
-                    httpClientSubscribe.CancelPendingRequests();
-                    httpClientSubscribe.Dispose();
-                    httpClientSubscribe = null;
-                }
-                catch { /* ignore */ }
-            }
-            if (httpClientNonsubscribe != null)
-            {
-                try{
-                    httpClientNonsubscribe.CancelPendingRequests();
-                    httpClientNonsubscribe.Dispose();
-                    httpClientNonsubscribe = null;
-                }
-                catch { /* ignore */ }
-            }
-#endif
         }
 
         internal void TerminateCurrentSubscriberRequest()

--- a/src/Api/PubnubApiPCL/PubnubApiPCL.csproj
+++ b/src/Api/PubnubApiPCL/PubnubApiPCL.csproj
@@ -14,7 +14,7 @@
 
   <PropertyGroup>
     <PackageId>PubnubPCL</PackageId>
-    <PackageVersion>6.7.0.0</PackageVersion>
+    <PackageVersion>6.8.0.0</PackageVersion>
     <Title>PubNub C# .NET - Web Data Push API</Title>
     <Authors>Pandu Masabathula</Authors>
     <Owners>PubNub</Owners>
@@ -22,7 +22,7 @@
     <PackageIconUrl>http://pubnub.s3.amazonaws.com/2011/powered-by-pubnub/pubnub-icon-600x600.png</PackageIconUrl>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
     <RepositoryUrl>https://github.com/pubnub/c-sharp/</RepositoryUrl>
-    <PackageReleaseNotes>Added support for Users/Spaces to GrantToken.</PackageReleaseNotes>
+    <PackageReleaseNotes>Fixed Destroy() method when multiple Pubnub instances were in use.</PackageReleaseNotes>
     <PackageTags>Web Data Push Real-time Notifications ESB Message Broadcasting Distributed Computing</PackageTags>
     <!--<Summary>PubNub is a Massively Scalable Web Push Service for Web and Mobile Games.  This is a cloud-based service for broadcasting messages to thousands of web and mobile clients simultaneously</Summary>-->
     <Description>PubNub is a Massively Scalable Web Push Service for Web and Mobile Games.  This is a cloud-based service for broadcasting messages to thousands of web and mobile clients simultaneously</Description>

--- a/src/Api/PubnubApiUWP/PubnubApiUWP.csproj
+++ b/src/Api/PubnubApiUWP/PubnubApiUWP.csproj
@@ -15,7 +15,7 @@
 
   <PropertyGroup>
     <PackageId>PubnubUWP</PackageId>
-    <PackageVersion>6.7.0.0</PackageVersion>
+    <PackageVersion>6.8.0.0</PackageVersion>
     <Title>PubNub C# .NET - Web Data Push API</Title>
     <Authors>Pandu Masabathula</Authors>
     <Owners>PubNub</Owners>
@@ -23,7 +23,7 @@
     <PackageIconUrl>http://pubnub.s3.amazonaws.com/2011/powered-by-pubnub/pubnub-icon-600x600.png</PackageIconUrl>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
     <RepositoryUrl>https://github.com/pubnub/c-sharp/</RepositoryUrl>
-    <PackageReleaseNotes>Added support for Users/Spaces to GrantToken.</PackageReleaseNotes>
+    <PackageReleaseNotes>Fixed Destroy() method when multiple Pubnub instances were in use.</PackageReleaseNotes>
     <PackageTags>Web Data Push Real-time Notifications ESB Message Broadcasting Distributed Computing</PackageTags>
     <!--<Summary>PubNub is a Massively Scalable Web Push Service for Web and Mobile Games.  This is a cloud-based service for broadcasting messages to thousands of web and mobile clients simultaneously</Summary>-->
     <Description>PubNub is a Massively Scalable Web Push Service for Web and Mobile Games.  This is a cloud-based service for broadcasting messages to thousands of web and mobile clients simultaneously</Description>

--- a/src/Examples/PubnubApi.ConsoleExample/PubnubApi.ConsoleExample.csproj
+++ b/src/Examples/PubnubApi.ConsoleExample/PubnubApi.ConsoleExample.csproj
@@ -48,8 +48,8 @@
     <Reference Include="Numbers, Version=1.8.2.0, Culture=neutral, PublicKeyToken=9cd62db60ea5554c, processorArchitecture=MSIL">
       <HintPath>..\..\packages\PeterO.Numbers.1.8.2\lib\net40\Numbers.dll</HintPath>
     </Reference>
-    <Reference Include="Pubnub, Version=6.6.0.0, Culture=neutral, PublicKeyToken=dc66f52ce6619f44, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Pubnub.6.6.0\lib\net48\Pubnub.dll</HintPath>
+    <Reference Include="Pubnub, Version=6.7.0.0, Culture=neutral, PublicKeyToken=dc66f52ce6619f44, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Pubnub.6.7.0\lib\net48\Pubnub.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.ComponentModel.Composition" />

--- a/src/Examples/PubnubApi.ConsoleExample/packages.config
+++ b/src/Examples/PubnubApi.ConsoleExample/packages.config
@@ -4,7 +4,7 @@
   <package id="PeterO.Cbor" version="4.5.2" targetFramework="net461" />
   <package id="PeterO.Numbers" version="1.8.2" targetFramework="net461" />
   <package id="PeterO.URIUtility" version="1.0.0" targetFramework="net461" />
-  <package id="Pubnub" version="6.6.0" targetFramework="net48" />
+  <package id="Pubnub" version="6.7.0" targetFramework="net48" />
   <package id="System.Collections" version="4.0.11" targetFramework="net461" />
   <package id="System.Diagnostics.Debug" version="4.0.11" targetFramework="net461" />
   <package id="System.Globalization" version="4.0.11" targetFramework="net461" />


### PR DESCRIPTION

fix: Fixed Destroy() method when multiple Pubnub instances were in use

Fixed Destroy() method when multiple Pubnub instances were in use.

