### PR TITLE
null status fix for PublishFileMessage

### DIFF
--- a/.pubnub.yml
+++ b/.pubnub.yml
@@ -1,8 +1,17 @@
 name: c-sharp
-version: "6.12.0"
+version: "6.13.0"
 schema: 1
 scm: github.com/pubnub/c-sharp
 changelog:
+  - date: 2022-12-05
+    version: v6.13.0
+    changes:
+      - type: bug
+        text: "Added null check for PublishFileMessage PNStatus in SendFileOperation."
+      - type: bug
+        text: "Removed invalid Content-Type in ObjectsV2 request headers targeting .Net Frameworks."
+      - type: improvement
+        text: "Added CultureInfo.InvariantCulture to string formatting."
   - date: 2022-11-14
     version: v6.12.0
     changes:
@@ -692,7 +701,7 @@ features:
     - QUERY-PARAM
 supported-platforms:
   -
-    version: Pubnub 'C#' 6.12.0
+    version: Pubnub 'C#' 6.13.0
     platforms:
       - Windows 10 and up
       - Windows Server 2008 and up
@@ -702,7 +711,7 @@ supported-platforms:
       - .Net Framework 4.5
       - .Net Framework 4.6.1+
   -
-    version: PubnubPCL 'C#' 6.12.0
+    version: PubnubPCL 'C#' 6.13.0
     platforms:
       - Xamarin.Android
       - Xamarin.iOS
@@ -722,7 +731,7 @@ supported-platforms:
       - .Net Core
       - .Net 6.0
   -
-    version: PubnubUWP 'C#' 6.12.0
+    version: PubnubUWP 'C#' 6.13.0
     platforms:
       - Windows Phone 10
       - Universal Windows Apps
@@ -746,7 +755,7 @@ sdks:
             distribution-type: source
             distribution-repository: GitHub
             package-name: Pubnub
-            location: https://github.com/pubnub/c-sharp/releases/tag/v6.12.0.0
+            location: https://github.com/pubnub/c-sharp/releases/tag/v6.13.0.0
             requires:
               -
                 name: ".Net"
@@ -1029,7 +1038,7 @@ sdks:
             distribution-type: source
             distribution-repository: GitHub
             package-name: PubNubPCL
-            location: https://github.com/pubnub/c-sharp/releases/tag/v6.12.0.0
+            location: https://github.com/pubnub/c-sharp/releases/tag/v6.13.0.0
             requires:
               -
                 name: ".Net Core"
@@ -1388,7 +1397,7 @@ sdks:
             distribution-type: source
             distribution-repository: GitHub
             package-name: PubnubUWP
-            location: https://github.com/pubnub/c-sharp/releases/tag/v6.12.0.0
+            location: https://github.com/pubnub/c-sharp/releases/tag/v6.13.0.0
             requires:
               -
                 name: "Universal Windows Platform Development"

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,10 @@
+v6.13.0 - December 05 2022
+-----------------------------
+- Fixed: added null check for PublishFileMessage PNStatus in SendFileOperation.
+- Fixed: removed invalid Content-Type in ObjectsV2 request headers targeting .Net Frameworks.
+
+- Modified: added CultureInfo.InvariantCulture to string formatting.
+
 v6.12.0 - November 14 2022
 -----------------------------
 - Fixed: encode comma char for push related multi channels.

--- a/src/Api/PubnubApi/Builder/StatusBuilder.cs
+++ b/src/Api/PubnubApi/Builder/StatusBuilder.cs
@@ -57,7 +57,7 @@ namespace PubnubApi
                 {
                     Dictionary<string, object> deserializeStatus = jsonLibrary.DeserializeToDictionaryOfObject(targetException.Message);
                     if (deserializeStatus != null && deserializeStatus.Count >= 1 
-                        && deserializeStatus.ContainsKey("error") && string.Equals(deserializeStatus["error"].ToString(), "true", StringComparison.CurrentCultureIgnoreCase)
+                        && deserializeStatus.ContainsKey("error") && string.Equals(deserializeStatus["error"].ToString(), "true", StringComparison.OrdinalIgnoreCase)
                         && deserializeStatus.ContainsKey("status") && Int32.TryParse(deserializeStatus["status"].ToString(), out serverErrorStatusCode))
                     {
                         serverErrorMessage = true;

--- a/src/Api/PubnubApi/Builder/UriUtil.cs
+++ b/src/Api/PubnubApi/Builder/UriUtil.cs
@@ -33,41 +33,41 @@ namespace PubnubApi
                     int positionOfChar = index;
                     if ((ch == ',' && ignoreComma) || (ch == ':' && ignoreColon))
                     {
-                        o.Append(ch.ToString());
+                        o.Append(ch);
                     }
                     else if (Char.IsSurrogatePair(s, positionOfChar))
                     {
-                        string codepoint = ConvertToUtf32(s, positionOfChar).ToString("X4");
+                        string codepoint = ConvertToUtf32(s, positionOfChar).ToString("X4", CultureInfo.InvariantCulture);
 
-                        int codePointValue = int.Parse(codepoint, NumberStyles.HexNumber);
+                        int codePointValue = int.Parse(codepoint, NumberStyles.HexNumber, CultureInfo.InvariantCulture);
                         if (codePointValue <= 0x7F)
                         {
                             System.Diagnostics.Debug.WriteLine("0x7F");
-                            string utf8HexValue = string.Format("%{0}", codePointValue);
+                            string utf8HexValue = string.Format(CultureInfo.InvariantCulture, "%{0}", codePointValue);
                             o.Append(utf8HexValue);
                         }
                         else if (codePointValue <= 0x7FF)
                         {
-                            string one = (0xC0 | ((codePointValue >> 6) & 0x1F)).ToString("X");
-                            string two = (0x80 | (codePointValue & 0x3F)).ToString("X");
-                            string utf8HexValue = string.Format("%{0}%{1}", one, two);
+                            string one = (0xC0 | ((codePointValue >> 6) & 0x1F)).ToString("X", CultureInfo.InvariantCulture);
+                            string two = (0x80 | (codePointValue & 0x3F)).ToString("X", CultureInfo.InvariantCulture);
+                            string utf8HexValue = string.Format(CultureInfo.InvariantCulture, "%{0}%{1}", one, two);
                             o.Append(utf8HexValue);
                         }
                         else if (codePointValue <= 0xFFFF)
                         {
-                            string one = (0xE0 | ((codePointValue >> 12) & 0x0F)).ToString("X");
-                            string two = (0x80 | ((codePointValue >> 6) & 0x3F)).ToString("X");
-                            string three = (0x80 | (codePointValue & 0x3F)).ToString("X");
-                            string utf8HexValue = string.Format("%{0}%{1}%{2}", one, two, three);
+                            string one = (0xE0 | ((codePointValue >> 12) & 0x0F)).ToString("X", CultureInfo.InvariantCulture);
+                            string two = (0x80 | ((codePointValue >> 6) & 0x3F)).ToString("X", CultureInfo.InvariantCulture);
+                            string three = (0x80 | (codePointValue & 0x3F)).ToString("X", CultureInfo.InvariantCulture);
+                            string utf8HexValue = string.Format(CultureInfo.InvariantCulture, "%{0}%{1}%{2}", one, two, three);
                             o.Append(utf8HexValue);
                         }
                         else if (codePointValue <= 0x10FFFF)
                         {
-                            string one = (0xF0 | ((codePointValue >> 18) & 0x07)).ToString("X");
-                            string two = (0x80 | ((codePointValue >> 12) & 0x3F)).ToString("X");
-                            string three = (0x80 | ((codePointValue >> 6) & 0x3F)).ToString("X");
-                            string four = (0x80 | (codePointValue & 0x3F)).ToString("X");
-                            string utf8HexValue = string.Format("%{0}%{1}%{2}%{3}", one, two, three, four);
+                            string one = (0xF0 | ((codePointValue >> 18) & 0x07)).ToString("X", CultureInfo.InvariantCulture);
+                            string two = (0x80 | ((codePointValue >> 12) & 0x3F)).ToString("X", CultureInfo.InvariantCulture);
+                            string three = (0x80 | ((codePointValue >> 6) & 0x3F)).ToString("X", CultureInfo.InvariantCulture);
+                            string four = (0x80 | (codePointValue & 0x3F)).ToString("X", CultureInfo.InvariantCulture);
+                            string utf8HexValue = string.Format(CultureInfo.InvariantCulture, "%{0}%{1}%{2}%{3}", one, two, three, four);
                             o.Append(utf8HexValue);
                         }
 
@@ -79,7 +79,7 @@ namespace PubnubApi
 #if NET35 || NET40
                         if (escapeChar == ch.ToString() && IsUnsafeToEncode(ch, ignoreComma, ignoreColon))
                         {
-                            escapeChar = string.Format("%{0}{1}", ToHex(ch / 16), ToHex(ch % 16));
+                            escapeChar = string.Format(CultureInfo.InvariantCulture, "%{0}{1}", ToHex(ch / 16), ToHex(ch % 16));
                         }
 #endif
                         o.Append(escapeChar);
@@ -147,16 +147,16 @@ namespace PubnubApi
         internal const int LowSurrogateStart = 0x00dc00;
         internal const int UnicodePlane01Start = 0x10000;
 
-        private static int ConvertToUtf32(String s, int index)
+        private static int ConvertToUtf32(string s, int index)
         {
             if (s == null)
             {
-                throw new ArgumentNullException("s");
+                throw new ArgumentNullException(nameof(s), "invalid.");
             }
 
             if (index < 0 || index >= s.Length)
             {
-                throw new ArgumentOutOfRangeException("index");
+                throw new ArgumentOutOfRangeException(nameof(index), "invalid.");
             }
 
             // Check if the character at index is a high surrogate.
@@ -177,19 +177,19 @@ namespace PubnubApi
                         }
                         else
                         {
-                            throw new ArgumentException("index");
+                            throw new ArgumentException("index value invalid.");
                         }
                     }
                     else
                     {
                         // Found a high surrogate at the end of the string.
-                        throw new ArgumentException("index");
+                        throw new ArgumentException("index value invalid.");
                     }
                 }
                 else
                 {
                     // Find a low surrogate at the character pointed by index.
-                    throw new ArgumentException("index");
+                    throw new ArgumentException("index value invalid.");
                 }
             }
 

--- a/src/Api/PubnubApi/Builder/UrlRequestBuilder.cs
+++ b/src/Api/PubnubApi/Builder/UrlRequestBuilder.cs
@@ -85,17 +85,17 @@ namespace PubnubApi
 
             if (!requestQueryStringParams.ContainsKey("tt"))
             {
-                requestQueryStringParams.Add("tt", timetoken.ToString());
+                requestQueryStringParams.Add("tt", timetoken.ToString(CultureInfo.InvariantCulture));
             }
 
             if (!requestQueryStringParams.ContainsKey("tr") && region > 0)
             {
-                requestQueryStringParams.Add("tr", region.ToString());
+                requestQueryStringParams.Add("tr", region.ToString(CultureInfo.InvariantCulture));
             }
 
             if (pubnubConfig.ContainsKey(pubnubInstanceId) && pubnubConfig[pubnubInstanceId].PresenceTimeout != 0)
             {
-                requestQueryStringParams.Add("heartbeat", pubnubConfig[pubnubInstanceId].PresenceTimeout.ToString());
+                requestQueryStringParams.Add("heartbeat", pubnubConfig[pubnubInstanceId].PresenceTimeout.ToString(CultureInfo.InvariantCulture));
             }
 
             if (channelGroups != null && channelGroups.Length > 0 && channelGroups[0] != "")
@@ -141,7 +141,7 @@ namespace PubnubApi
 
             if (pubnubConfig.ContainsKey(pubnubInstanceId) && pubnubConfig[pubnubInstanceId].PresenceTimeout != 0)
             {
-                requestQueryStringParams.Add("heartbeat", pubnubConfig[pubnubInstanceId].PresenceTimeout.ToString());
+                requestQueryStringParams.Add("heartbeat", pubnubConfig[pubnubInstanceId].PresenceTimeout.ToString(CultureInfo.InvariantCulture));
             }
 
             string channelsJsonState = jsonUserState;
@@ -204,7 +204,7 @@ namespace PubnubApi
 
             if (storeInHistory && ttl >= 0)
             {
-                requestQueryStringParams.Add("tt1", ttl.ToString());
+                requestQueryStringParams.Add("tt1", ttl.ToString(CultureInfo.InvariantCulture));
             }
 
             if (!storeInHistory)
@@ -296,8 +296,8 @@ namespace PubnubApi
                 requestQueryStringParams.Add("channel-group", UriUtil.EncodeUriComponent(commaDelimitedchannelGroup, currentType, false, false, false));
             }
 
-            requestQueryStringParams.Add("disable_uuids", disableUUID.ToString());
-            requestQueryStringParams.Add("state", userState.ToString());
+            requestQueryStringParams.Add("disable_uuids", disableUUID.ToString(CultureInfo.InvariantCulture));
+            requestQueryStringParams.Add("state", userState.ToString(CultureInfo.InvariantCulture));
 
             if (externalQueryParam != null && externalQueryParam.Count > 0)
             {
@@ -329,7 +329,7 @@ namespace PubnubApi
 
             Dictionary<string, string> requestQueryStringParams = new Dictionary<string, string>();
 
-            requestQueryStringParams.Add("count", (count <= -1) ? "100" : count.ToString());
+            requestQueryStringParams.Add("count", (count <= -1) ? "100" : count.ToString(CultureInfo.InvariantCulture));
 
             if (reverse)
             {
@@ -386,7 +386,7 @@ namespace PubnubApi
 
             Dictionary<string, string> requestQueryStringParams = new Dictionary<string, string>();
 
-            requestQueryStringParams.Add("max", (count <= -1) ? (includeMessageActions || (channels != null && channels.Length > 1) ? "25" : "100") : count.ToString());
+            requestQueryStringParams.Add("max", (count <= -1) ? (includeMessageActions || (channels != null && channels.Length > 1) ? "25" : "100") : count.ToString(CultureInfo.InvariantCulture));
 
             if (reverse)
             {
@@ -452,7 +452,7 @@ namespace PubnubApi
 
             if (timetokens != null && timetokens.Length > 0)
             {
-                string tt = string.Join(",", timetokens.Select(x => x.ToString()).ToArray());
+                string tt = string.Join(",", timetokens.Select(x => x.ToString(CultureInfo.InvariantCulture)).ToArray());
                 if (timetokens.Length == 1)
                 {
                     requestQueryStringParams.Add("timetoken", tt);
@@ -582,16 +582,16 @@ namespace PubnubApi
 
             if (ttl > -1)
             {
-                requestQueryStringParams.Add("ttl", ttl.ToString());
+                requestQueryStringParams.Add("ttl", ttl.ToString(CultureInfo.InvariantCulture));
             }
 
-            requestQueryStringParams.Add("r", Convert.ToInt32(read).ToString());
-            requestQueryStringParams.Add("w", Convert.ToInt32(write).ToString());
-            requestQueryStringParams.Add("d", Convert.ToInt32(delete).ToString());
-            requestQueryStringParams.Add("m", Convert.ToInt32(manage).ToString());
-            requestQueryStringParams.Add("g", Convert.ToInt32(get).ToString());
-            requestQueryStringParams.Add("u", Convert.ToInt32(update).ToString());
-            requestQueryStringParams.Add("j", Convert.ToInt32(join).ToString());
+            requestQueryStringParams.Add("r", Convert.ToInt32(read).ToString(CultureInfo.InvariantCulture));
+            requestQueryStringParams.Add("w", Convert.ToInt32(write).ToString(CultureInfo.InvariantCulture));
+            requestQueryStringParams.Add("d", Convert.ToInt32(delete).ToString(CultureInfo.InvariantCulture));
+            requestQueryStringParams.Add("m", Convert.ToInt32(manage).ToString(CultureInfo.InvariantCulture));
+            requestQueryStringParams.Add("g", Convert.ToInt32(get).ToString(CultureInfo.InvariantCulture));
+            requestQueryStringParams.Add("u", Convert.ToInt32(update).ToString(CultureInfo.InvariantCulture));
+            requestQueryStringParams.Add("j", Convert.ToInt32(join).ToString(CultureInfo.InvariantCulture));
 
             if (externalQueryParam != null && externalQueryParam.Count > 0)
             {
@@ -1027,12 +1027,12 @@ namespace PubnubApi
             Dictionary<string, string> requestQueryStringParams = new Dictionary<string, string>();
             if (pushType == PNPushType.APNS2)
             {
-                requestQueryStringParams.Add("environment", environment.ToString().ToLower());
+                requestQueryStringParams.Add("environment", environment.ToString().ToLowerInvariant());
                 requestQueryStringParams.Add("topic", UriUtil.EncodeUriComponent(deviceTopic, currentType, false, false, false));
             }
             else
             {
-                requestQueryStringParams.Add("type", pushType.ToString().ToLower());
+                requestQueryStringParams.Add("type", pushType.ToString().ToLowerInvariant());
             }
             requestQueryStringParams.Add("add", UriUtil.EncodeUriComponent(channel, currentType, false, false, false));
 
@@ -1081,12 +1081,12 @@ namespace PubnubApi
             Dictionary<string, string> requestQueryStringParams = new Dictionary<string, string>();
             if (pushType == PNPushType.APNS2)
             {
-                requestQueryStringParams.Add("environment", environment.ToString().ToLower());
+                requestQueryStringParams.Add("environment", environment.ToString().ToLowerInvariant());
                 requestQueryStringParams.Add("topic", UriUtil.EncodeUriComponent(deviceTopic, currentType, false, false, false));
             }
             else
             {
-                requestQueryStringParams.Add("type", pushType.ToString().ToLower());
+                requestQueryStringParams.Add("type", pushType.ToString().ToLowerInvariant());
             }
 
             if (externalQueryParam != null && externalQueryParam.Count > 0)
@@ -1132,12 +1132,12 @@ namespace PubnubApi
             Dictionary<string, string> requestQueryStringParams = new Dictionary<string, string>();
             if (pushType == PNPushType.APNS2)
             {
-                requestQueryStringParams.Add("environment", environment.ToString().ToLower());
+                requestQueryStringParams.Add("environment", environment.ToString().ToLowerInvariant());
                 requestQueryStringParams.Add("topic", UriUtil.EncodeUriComponent(deviceTopic, currentType, false, false, false));
             }
             else
             {
-                requestQueryStringParams.Add("type", pushType.ToString().ToLower());
+                requestQueryStringParams.Add("type", pushType.ToString().ToLowerInvariant());
             }
             requestQueryStringParams.Add("remove", UriUtil.EncodeUriComponent(channel, currentType, false, false, false));
 
@@ -1185,12 +1185,12 @@ namespace PubnubApi
 
             if (pushType == PNPushType.APNS2)
             {
-                requestQueryStringParams.Add("environment", environment.ToString().ToLower());
+                requestQueryStringParams.Add("environment", environment.ToString().ToLowerInvariant());
                 requestQueryStringParams.Add("topic", UriUtil.EncodeUriComponent(deviceTopic, currentType, false, false, false));
             }
             else
             {
-                requestQueryStringParams.Add("type", pushType.ToString().ToLower());
+                requestQueryStringParams.Add("type", pushType.ToString().ToLowerInvariant());
             }
 
             if (externalQueryParam != null && externalQueryParam.Count > 0)
@@ -1239,7 +1239,7 @@ namespace PubnubApi
 
             if (pubnubConfig.ContainsKey(pubnubInstanceId) && pubnubConfig[pubnubInstanceId].PresenceTimeout != 0)
             {
-                requestQueryStringParams.Add("heartbeat", pubnubConfig[pubnubInstanceId].PresenceTimeout.ToString());
+                requestQueryStringParams.Add("heartbeat", pubnubConfig[pubnubInstanceId].PresenceTimeout.ToString(CultureInfo.InvariantCulture));
             }
 
             string queryString = BuildQueryString(currentType, requestQueryStringParams);
@@ -1768,7 +1768,7 @@ namespace PubnubApi
             url.Add("channel");
             url.Add(channel);
             url.Add("message");
-            url.Add(messageTimetoken.ToString());
+            url.Add(messageTimetoken.ToString(CultureInfo.InvariantCulture));
 
             Dictionary<string, string> requestQueryStringParams = new Dictionary<string, string>();
 
@@ -1799,9 +1799,9 @@ namespace PubnubApi
             url.Add("channel");
             url.Add(channel);
             url.Add("message");
-            url.Add(messageTimetoken.ToString());
+            url.Add(messageTimetoken.ToString(CultureInfo.InvariantCulture));
             url.Add("action");
-            url.Add(actionTimetoken.ToString());
+            url.Add(actionTimetoken.ToString(CultureInfo.InvariantCulture));
 
             Dictionary<string, string> requestQueryStringParams = new Dictionary<string, string>();
             if (messageActionUuid != null)
@@ -1930,7 +1930,7 @@ namespace PubnubApi
 
             if (storeInHistory && ttl >= 0)
             {
-                requestQueryStringParams.Add("tt1", ttl.ToString());
+                requestQueryStringParams.Add("tt1", ttl.ToString(CultureInfo.InvariantCulture));
             }
 
             if (!storeInHistory)
@@ -1999,7 +1999,7 @@ namespace PubnubApi
             url.Add("files");
 
             Dictionary<string, string> requestQueryStringParams = new Dictionary<string, string>();
-            requestQueryStringParams.Add("limit", (limit <= -1) ? "100" : limit.ToString());
+            requestQueryStringParams.Add("limit", (limit <= -1) ? "100" : limit.ToString(CultureInfo.InvariantCulture));
             if (!string.IsNullOrEmpty(nextToken))
             {
                 requestQueryStringParams.Add("next", nextToken);
@@ -2080,7 +2080,7 @@ namespace PubnubApi
 
                 if (pubnubConfig.ContainsKey(pubnubInstanceId) && !string.IsNullOrEmpty(pubnubConfig[pubnubInstanceId].SecretKey))
                 {
-                    ret.Add("timestamp", timeStamp.ToString());
+                    ret.Add("timestamp", timeStamp.ToString(CultureInfo.InvariantCulture));
                 }
 
                 if (type != PNOperationType.PNTimeOperation
@@ -2107,8 +2107,8 @@ namespace PubnubApi
             StringBuilder string_to_sign = new StringBuilder();
             if (pubnubConfig.ContainsKey(pubnubInstanceId))
             {
-                string_to_sign.Append(pubnubConfig[pubnubInstanceId].SubscribeKey).Append("\n").Append(pubnubConfig[pubnubInstanceId].PublishKey).Append("\n");
-                string_to_sign.Append(partialUrl).Append("\n");
+                string_to_sign.Append(pubnubConfig[pubnubInstanceId].SubscribeKey).Append('\n').Append(pubnubConfig[pubnubInstanceId].PublishKey).Append('\n');
+                string_to_sign.Append(partialUrl).Append('\n');
                 string_to_sign.Append(queryStringToSign);
 
                 PubnubCrypto pubnubCrypto = new PubnubCrypto((opType != PNOperationType.PNSignalOperation) ? pubnubConfig[pubnubInstanceId].CipherKey : "", pubnubConfig[pubnubInstanceId], this.pubnubLog, null);
@@ -2133,15 +2133,15 @@ namespace PubnubApi
             StringBuilder string_to_sign = new StringBuilder();
             if (pubnubConfig.ContainsKey(pubnubInstanceId))
             {
-                string_to_sign.AppendFormat("{0}\n", method.ToUpperInvariant());
-                string_to_sign.AppendFormat("{0}\n", pubnubConfig[pubnubInstanceId].PublishKey);
-                string_to_sign.AppendFormat("{0}\n", partialUrl);
-                string_to_sign.AppendFormat("{0}\n", queryStringToSign);
+                string_to_sign.AppendFormat(CultureInfo.InvariantCulture, "{0}\n", method.ToUpperInvariant());
+                string_to_sign.AppendFormat(CultureInfo.InvariantCulture, "{0}\n", pubnubConfig[pubnubInstanceId].PublishKey);
+                string_to_sign.AppendFormat(CultureInfo.InvariantCulture, "{0}\n", partialUrl);
+                string_to_sign.AppendFormat(CultureInfo.InvariantCulture, "{0}\n", queryStringToSign);
                 string_to_sign.Append(requestBody);
 
                 PubnubCrypto pubnubCrypto = new PubnubCrypto((opType != PNOperationType.PNSignalOperation) ? pubnubConfig[pubnubInstanceId].CipherKey : "", pubnubConfig[pubnubInstanceId], this.pubnubLog, null);
                 signature = pubnubCrypto.PubnubAccessManagerSign(pubnubConfig[pubnubInstanceId].SecretKey, string_to_sign.ToString());
-                signature = string.Format("v2.{0}", signature.TrimEnd(new[] { '=' }));
+                signature = string.Format(CultureInfo.InvariantCulture, "v2.{0}", signature.TrimEnd(new[] { '=' }));
                 if (this.pubnubLog != null && this.pubnubConfig != null)
                 {
                     LoggingMethod.WriteToLog(pubnubLog, "string_to_sign = " + string_to_sign, pubnubConfig[pubnubInstanceId].LogVerbosity);
@@ -2173,7 +2173,7 @@ namespace PubnubApi
                 Dictionary<string, string> commonQueryStringParams = GenerateCommonQueryParams(type, qsUuid);
                 Dictionary<string, string> queryStringParams = new Dictionary<string, string>(commonQueryStringParams.Concat(internalQueryStringParamDic).GroupBy(item => item.Key).ToDictionary(item => item.Key, item => item.First().Value));
 
-                queryString = string.Join("&", queryStringParams.OrderBy(kvp => kvp.Key, StringComparer.Ordinal).Select(kvp => string.Format("{0}={1}", kvp.Key, kvp.Value)).ToArray());
+                queryString = string.Join("&", queryStringParams.OrderBy(kvp => kvp.Key, StringComparer.Ordinal).Select(kvp => string.Format(CultureInfo.InvariantCulture, "{0}={1}", kvp.Key, kvp.Value)).ToArray());
 
             }
             catch (Exception ex)
@@ -2201,7 +2201,7 @@ namespace PubnubApi
 
             for (int componentIndex = 0; componentIndex < urlComponents.Count; componentIndex++)
             {
-                url.Append("/");
+                url.Append('/');
 
                 if ((type == PNOperationType.PNPublishOperation || type == PNOperationType.PNPublishFileMessageOperation) && componentIndex == urlComponents.Count - 1)
                 {
@@ -2217,7 +2217,7 @@ namespace PubnubApi
                 }
             }
 
-            url.Append("?");
+            url.Append('?');
             url.Append(queryString);
             System.Diagnostics.Debug.WriteLine("sb = " + url);
             Uri requestUri = new Uri(url.ToString());
@@ -2242,7 +2242,7 @@ namespace PubnubApi
                 {
                     signature = GeneratePAMv2Signature(queryString, partialUrl.ToString(), type);
                 }
-                string queryStringWithSignature = string.Format("{0}&signature={1}", queryString, signature);
+                string queryStringWithSignature = string.Format(CultureInfo.InvariantCulture, "{0}&signature={1}", queryString, signature);
                 UriBuilder uriBuilder = new UriBuilder(requestUri);
                 uriBuilder.Query = queryStringWithSignature;
 

--- a/src/Api/PubnubApi/ClientNetworkStatus.cs
+++ b/src/Api/PubnubApi/ClientNetworkStatus.cs
@@ -140,12 +140,12 @@ namespace PubnubApi
                 catch (AggregateException ae) {
                     foreach (var ie in ae.InnerExceptions)
                     {
-                        LoggingMethod.WriteToLog(pubnubLog, string.Format("DateTime {0} AggregateException CheckInternetStatus Error: {1} {2} ", DateTime.Now.ToString(CultureInfo.InvariantCulture), ie.GetType().Name, ie.Message), pubnubConfig.LogVerbosity);
+                        LoggingMethod.WriteToLog(pubnubLog, string.Format(CultureInfo.InvariantCulture, "DateTime {0} AggregateException CheckInternetStatus Error: {1} {2} ", DateTime.Now.ToString(CultureInfo.InvariantCulture), ie.GetType().Name, ie.Message), pubnubConfig.LogVerbosity);
                     }
                 }
                 catch(Exception ex)
                 {
-                    LoggingMethod.WriteToLog(pubnubLog, string.Format("DateTime {0} Exception CheckInternetStatus Error: {1}", DateTime.Now.ToString(CultureInfo.InvariantCulture), ex.Message), pubnubConfig.LogVerbosity);
+                    LoggingMethod.WriteToLog(pubnubLog, string.Format(CultureInfo.InvariantCulture, "DateTime {0} Exception CheckInternetStatus Error: {1}", DateTime.Now.ToString(CultureInfo.InvariantCulture), ex.Message), pubnubConfig.LogVerbosity);
                 }
 
                 return networkStatus;
@@ -171,7 +171,7 @@ namespace PubnubApi
             {
                 if (isInternetCheckRunning)
                 {
-                    LoggingMethod.WriteToLog(pubnubLog, string.Format("DateTime {0} InternetCheckRunning Already running", DateTime.Now.ToString(CultureInfo.InvariantCulture)), pubnubConfig.LogVerbosity);
+                    LoggingMethod.WriteToLog(pubnubLog, string.Format(CultureInfo.InvariantCulture, "DateTime {0} InternetCheckRunning Already running", DateTime.Now.ToString(CultureInfo.InvariantCulture)), pubnubConfig.LogVerbosity);
                     return networkStatus;
                 }
             }
@@ -193,7 +193,7 @@ namespace PubnubApi
             {
                 isInternetCheckRunning = true;
             }
-            LoggingMethod.WriteToLog(pubnubLog, string.Format("DateTime {0} CheckSocketConnect Entered", DateTime.Now.ToString(CultureInfo.InvariantCulture)), pubnubConfig.LogVerbosity);
+            LoggingMethod.WriteToLog(pubnubLog, string.Format(CultureInfo.InvariantCulture, "DateTime {0} CheckSocketConnect Entered", DateTime.Now.ToString(CultureInfo.InvariantCulture)), pubnubConfig.LogVerbosity);
 
             Action<bool> internalCallback = null;
             PNCallback<T> pubnubCallback = null;
@@ -240,7 +240,7 @@ namespace PubnubApi
             catch (Exception ex)
             {
                 networkStatus = false;
-                LoggingMethod.WriteToLog(pubnubLog, string.Format("DateTime {0} CheckSocketConnect (HttpClient Or Task.Factory) Failed {1}", DateTime.Now.ToString(CultureInfo.InvariantCulture), ex.Message), pubnubConfig.LogVerbosity);
+                LoggingMethod.WriteToLog(pubnubLog, string.Format(CultureInfo.InvariantCulture, "DateTime {0} CheckSocketConnect (HttpClient Or Task.Factory) Failed {1}", DateTime.Now.ToString(CultureInfo.InvariantCulture), ex.Message), pubnubConfig.LogVerbosity);
                 if (!networkStatus)
                 {
                     t.TrySetResult(false);
@@ -267,7 +267,7 @@ namespace PubnubApi
                 callback.OnResponse(default(T), status);
             }
 
-			LoggingMethod.WriteToLog(pubnubLog, string.Format("DateTime {0} ParseCheckSocketConnectException Error. {1}", DateTime.Now.ToString(CultureInfo.InvariantCulture), ex.Message), pubnubConfig.LogVerbosity);
+			LoggingMethod.WriteToLog(pubnubLog, string.Format(CultureInfo.InvariantCulture, "DateTime {0} ParseCheckSocketConnectException Error. {1}", DateTime.Now.ToString(CultureInfo.InvariantCulture), ex.Message), pubnubConfig.LogVerbosity);
 			internalcallback(false);
 		}
 
@@ -281,11 +281,11 @@ namespace PubnubApi
                 successFlag = response.IsSuccessStatusCode;
                 if (successFlag)
                 {
-                    LoggingMethod.WriteToLog(pubnubLog, string.Format("DateTime {0} GetTimeWithHttpClient Resp OK", DateTime.Now.ToString(CultureInfo.InvariantCulture)), pubnubConfig.LogVerbosity);
+                    LoggingMethod.WriteToLog(pubnubLog, string.Format(CultureInfo.InvariantCulture, "DateTime {0} GetTimeWithHttpClient Resp OK", DateTime.Now.ToString(CultureInfo.InvariantCulture)), pubnubConfig.LogVerbosity);
                 }
                 else
                 {
-                    LoggingMethod.WriteToLog(pubnubLog, string.Format("DateTime {0} GetTimeWithHttpClient FAILED", DateTime.Now.ToString(CultureInfo.InvariantCulture)), pubnubConfig.LogVerbosity);
+                    LoggingMethod.WriteToLog(pubnubLog, string.Format(CultureInfo.InvariantCulture, "DateTime {0} GetTimeWithHttpClient FAILED", DateTime.Now.ToString(CultureInfo.InvariantCulture)), pubnubConfig.LogVerbosity);
                 }
             }
             finally
@@ -307,12 +307,12 @@ namespace PubnubApi
                 {
                     if (response != null)
                     {
-                        LoggingMethod.WriteToLog(pubnubLog, string.Format("DateTime {0} GetTimeWithTaskFactoryAsync Resp {1}", DateTime.Now.ToString(CultureInfo.InvariantCulture), response.StatusCode.ToString()), pubnubConfig.LogVerbosity);
+                        LoggingMethod.WriteToLog(pubnubLog, string.Format(CultureInfo.InvariantCulture, "DateTime {0} GetTimeWithTaskFactoryAsync Resp {1}", DateTime.Now.ToString(CultureInfo.InvariantCulture), response.StatusCode.ToString()), pubnubConfig.LogVerbosity);
                         successFlag = response.StatusCode == HttpStatusCode.OK;
                     }
                     else
                     {
-                        LoggingMethod.WriteToLog(pubnubLog, string.Format("DateTime {0} GetTimeWithTaskFactoryAsync FAILED.", DateTime.Now.ToString(CultureInfo.InvariantCulture)), pubnubConfig.LogVerbosity);
+                        LoggingMethod.WriteToLog(pubnubLog, string.Format(CultureInfo.InvariantCulture, "DateTime {0} GetTimeWithTaskFactoryAsync FAILED.", DateTime.Now.ToString(CultureInfo.InvariantCulture)), pubnubConfig.LogVerbosity);
                     }
                 }
             }
@@ -357,7 +357,7 @@ namespace PubnubApi
                         }
                         ), pubnubRequestState);
 
-                new Timer(OnPubnubWebRequestTimeout<T>, pubnubRequestState, pubnubConfig.NonSubscribeRequestTimeout * 1000, Timeout.Infinite);
+                var _ = new Timer(OnPubnubWebRequestTimeout<T>, pubnubRequestState, pubnubConfig.NonSubscribeRequestTimeout * 1000, Timeout.Infinite);
             }
             finally
             {
@@ -383,7 +383,7 @@ namespace PubnubApi
                 }
                 catch {  /* ignore */ }
 
-                LoggingMethod.WriteToLog(pubnubLog, string.Format("DateTime: {0}, GetTimeWithClassicHttp timedout", DateTime.Now.ToString(CultureInfo.InvariantCulture)), pubnubConfig.LogVerbosity);
+                LoggingMethod.WriteToLog(pubnubLog, string.Format(CultureInfo.InvariantCulture, "DateTime: {0}, GetTimeWithClassicHttp timedout", DateTime.Now.ToString(CultureInfo.InvariantCulture)), pubnubConfig.LogVerbosity);
             }
         }
     }

--- a/src/Api/PubnubApi/ConcurrentDictionary.cs
+++ b/src/Api/PubnubApi/ConcurrentDictionary.cs
@@ -44,7 +44,7 @@ namespace PubnubApi
             bool updated = false;
             if (object.Equals(key, default(TKey)))
             {
-                throw new ArgumentNullException("key");
+                throw new ArgumentNullException(nameof(key), "invalid.");
             }
 
             lock (syncRoot)

--- a/src/Api/PubnubApi/EndPoint/Access/GrantTokenOperation.cs
+++ b/src/Api/PubnubApi/EndPoint/Access/GrantTokenOperation.cs
@@ -283,7 +283,7 @@ namespace PubnubApi.EndPoint
 
             if (!atleastOnePermission)
             {
-                LoggingMethod.WriteToLog(pubnubLog, string.Format("DateTime {0} At least one permission is needed for at least one or more of uuids/users, channels/spaces or groups",DateTime.Now.ToString(CultureInfo.InvariantCulture)), PNLogVerbosity.BODY);
+                LoggingMethod.WriteToLog(pubnubLog, string.Format(CultureInfo.InvariantCulture, "DateTime {0} At least one permission is needed for at least one or more of uuids/users, channels/spaces or groups",DateTime.Now.ToString(CultureInfo.InvariantCulture)), PNLogVerbosity.BODY);
             }
 
             Dictionary<string, object> resourcesCollection = new Dictionary<string, object>();
@@ -418,7 +418,7 @@ namespace PubnubApi.EndPoint
 
             if (!atleastOnePermission)
             {
-                LoggingMethod.WriteToLog(pubnubLog, string.Format("DateTime {0} At least one permission is needed for at least one or more of uuids, channels or groups", DateTime.Now.ToString(CultureInfo.InvariantCulture)), PNLogVerbosity.BODY);
+                LoggingMethod.WriteToLog(pubnubLog, string.Format(CultureInfo.InvariantCulture, "DateTime {0} At least one permission is needed for at least one or more of uuids, channels or groups", DateTime.Now.ToString(CultureInfo.InvariantCulture)), PNLogVerbosity.BODY);
             }
 
             Dictionary<string, object> resourcesCollection = new Dictionary<string, object>();

--- a/src/Api/PubnubApi/EndPoint/Files/DownloadFileOperation.cs
+++ b/src/Api/PubnubApi/EndPoint/Files/DownloadFileOperation.cs
@@ -161,7 +161,7 @@ namespace PubnubApi.EndPoint
                         {
                             PubnubCrypto aes = new PubnubCrypto(currentCipherKey, config, pubnubLog, null);
                             outputBytes = aes.Decrypt(item1Bytes, true);
-                            LoggingMethod.WriteToLog(pubnubLog, string.Format("DateTime {0}, Stream length (after Decrypt)= {1}", DateTime.Now.ToString(CultureInfo.InvariantCulture), item1Bytes.Length), config.LogVerbosity);
+                            LoggingMethod.WriteToLog(pubnubLog, string.Format(CultureInfo.InvariantCulture, "DateTime {0}, Stream length (after Decrypt)= {1}", DateTime.Now.ToString(CultureInfo.InvariantCulture), item1Bytes.Length), config.LogVerbosity);
                         }
                         catch (Exception ex)
                         {
@@ -230,7 +230,7 @@ namespace PubnubApi.EndPoint
                     {
                         PubnubCrypto aes = new PubnubCrypto(currentCipherKey, config, pubnubLog, null);
                         outputBytes = aes.Decrypt(item1Bytes, true);
-                        LoggingMethod.WriteToLog(pubnubLog, string.Format("DateTime {0}, Stream length (after Decrypt)= {1}", DateTime.Now.ToString(CultureInfo.InvariantCulture), item1Bytes.Length), config.LogVerbosity);
+                        LoggingMethod.WriteToLog(pubnubLog, string.Format(CultureInfo.InvariantCulture, "DateTime {0}, Stream length (after Decrypt)= {1}", DateTime.Now.ToString(CultureInfo.InvariantCulture), item1Bytes.Length), config.LogVerbosity);
                     }
                     catch (Exception ex)
                     {

--- a/src/Api/PubnubApi/EndPoint/Files/PublishFileMessage.cs
+++ b/src/Api/PubnubApi/EndPoint/Files/PublishFileMessage.cs
@@ -193,7 +193,7 @@ namespace PubnubApi.EndPoint
                 if (result != null && result.Count >= 3)
                 {
                     int publishStatus;
-                    Int32.TryParse(result[0].ToString(), out publishStatus);
+                    var _ = Int32.TryParse(result[0].ToString(), out publishStatus);
                     if (publishStatus == 1)
                     {
                         ProcessResponseCallbacks(result, requestState);
@@ -258,7 +258,7 @@ namespace PubnubApi.EndPoint
                 if (result != null && result.Count >= 3)
                 {
                     int publishStatus;
-                    Int32.TryParse(result[0].ToString(), out publishStatus);
+                    var _ = Int32.TryParse(result[0].ToString(), out publishStatus);
                     if (publishStatus == 1)
                     {
                         List<object> resultList = ProcessJsonResponse(requestState, json);

--- a/src/Api/PubnubApi/EndPoint/Files/SendFileOperation.cs
+++ b/src/Api/PubnubApi/EndPoint/Files/SendFileOperation.cs
@@ -157,7 +157,7 @@ namespace PubnubApi.EndPoint
                 }
                 return;
             }
-            LoggingMethod.WriteToLog(pubnubLog, string.Format("DateTime {0} GenerateFileUploadUrl OK.", DateTime.Now.ToString(CultureInfo.InvariantCulture)), config.LogVerbosity);
+            LoggingMethod.WriteToLog(pubnubLog, string.Format(CultureInfo.InvariantCulture, "DateTime {0} GenerateFileUploadUrl OK.", DateTime.Now.ToString(CultureInfo.InvariantCulture)), config.LogVerbosity);
 
             RequestState<PNFileUploadResult> requestState = new RequestState<PNFileUploadResult>();
             requestState.ResponseType = PNOperationType.PNFileUploadOperation;
@@ -170,7 +170,7 @@ namespace PubnubApi.EndPoint
             byte[] sendFileByteArray = GetByteArrayFromFilePath(sendFileFullPath);
 
             
-            string dataBoundary = String.Format("----------{0:N}", Guid.NewGuid());
+            string dataBoundary = String.Format(CultureInfo.InvariantCulture, "----------{0:N}", Guid.NewGuid());
             string contentType = "multipart/form-data; boundary=" + dataBoundary;
             string currentCipherKey = !string.IsNullOrEmpty(this.currentFileCipherKey) ? this.currentFileCipherKey : config.CipherKey;
             byte[] postData = GetMultipartFormData(sendFileByteArray,generateFileUploadUrlResult.FileName, generateFileUploadUrlResult.FileUploadRequest.FormFields, dataBoundary, currentCipherKey, config, pubnubLog);
@@ -179,9 +179,9 @@ namespace PubnubApi.EndPoint
             UrlProcessRequest(new Uri(generateFileUploadUrlResult.FileUploadRequest.Url), requestState, false, postData, contentType).ContinueWith(r =>
             {
                 json = r.Result.Item1;
-                if (!string.IsNullOrEmpty(json) && string.Compare(json,"{}", StringComparison.CurrentCultureIgnoreCase) == 0)
+                if (!string.IsNullOrEmpty(json) && string.Equals(json,"{}", StringComparison.OrdinalIgnoreCase))
                 {
-                    LoggingMethod.WriteToLog(pubnubLog, string.Format("DateTime {0} GenerateFileUploadUrl -> file upload OK.", DateTime.Now.ToString(CultureInfo.InvariantCulture)), config.LogVerbosity);
+                    LoggingMethod.WriteToLog(pubnubLog, string.Format(CultureInfo.InvariantCulture, "DateTime {0} GenerateFileUploadUrl -> file upload OK.", DateTime.Now.ToString(CultureInfo.InvariantCulture)), config.LogVerbosity);
                     //do internal publish after successful file upload
 
                     Dictionary<string, object> publishPayload = new Dictionary<string, object>();
@@ -208,7 +208,7 @@ namespace PubnubApi.EndPoint
                             result.Timetoken = publishFileMessage.Timetoken;
                             result.FileId = generateFileUploadUrlResult.FileId;
                             result.FileName = generateFileUploadUrlResult.FileName;
-                            LoggingMethod.WriteToLog(pubnubLog, string.Format("DateTime {0} GenerateFileUploadUrl -> file upload -> PublishFileMessage -> OK.", DateTime.Now.ToString(CultureInfo.InvariantCulture)), config.LogVerbosity);
+                            LoggingMethod.WriteToLog(pubnubLog, string.Format(CultureInfo.InvariantCulture, "DateTime {0} GenerateFileUploadUrl -> file upload -> PublishFileMessage -> OK.", DateTime.Now.ToString(CultureInfo.InvariantCulture)), config.LogVerbosity);
                             r.Result.Item2.Error = false;
                             callback.OnResponse(result, r.Result.Item2);
                         }
@@ -219,7 +219,7 @@ namespace PubnubApi.EndPoint
                             {
                                 callback.OnResponse(null, publishFileMessageStatus);
                             }
-                            LoggingMethod.WriteToLog(pubnubLog, string.Format("DateTime {0} PublishFileMessage Failed. currentFileRetryCount={1}", DateTime.Now.ToString(CultureInfo.InvariantCulture), currentFileRetryCount), config.LogVerbosity);
+                            LoggingMethod.WriteToLog(pubnubLog, string.Format(CultureInfo.InvariantCulture, "DateTime {0} PublishFileMessage Failed. currentFileRetryCount={1}", DateTime.Now.ToString(CultureInfo.InvariantCulture), currentFileRetryCount), config.LogVerbosity);
 #if !NET35 && !NET40
                             Task.Delay(1000).Wait();
 #else
@@ -260,7 +260,7 @@ namespace PubnubApi.EndPoint
                 ret.Status = errStatus;
                 return ret;
             }
-            LoggingMethod.WriteToLog(pubnubLog, string.Format("DateTime {0} GenerateFileUploadUrl OK.", DateTime.Now.ToString(CultureInfo.InvariantCulture)), config.LogVerbosity);
+            LoggingMethod.WriteToLog(pubnubLog, string.Format(CultureInfo.InvariantCulture, "DateTime {0} GenerateFileUploadUrl OK.", DateTime.Now.ToString(CultureInfo.InvariantCulture)), config.LogVerbosity);
 
             RequestState<PNFileUploadResult> requestState = new RequestState<PNFileUploadResult>();
             requestState.ResponseType = PNOperationType.PNFileUploadOperation;
@@ -271,7 +271,7 @@ namespace PubnubApi.EndPoint
 
             byte[] sendFileByteArray = GetByteArrayFromFilePath(sendFileFullPath);
 
-            string dataBoundary = String.Format("----------{0:N}", Guid.NewGuid());
+            string dataBoundary = String.Format(CultureInfo.InvariantCulture, "----------{0:N}", Guid.NewGuid());
             string contentType = "multipart/form-data; boundary=" + dataBoundary;
             string currentCipherKey = !string.IsNullOrEmpty(this.currentFileCipherKey) ? this.currentFileCipherKey : config.CipherKey;
             byte[] postData = GetMultipartFormData(sendFileByteArray, generateFileUploadUrlResult.FileName, generateFileUploadUrlResult.FileUploadRequest.FormFields, dataBoundary, currentCipherKey, config, pubnubLog);
@@ -281,7 +281,7 @@ namespace PubnubApi.EndPoint
             string json = JsonAndStatusTuple.Item1;
             if (!string.IsNullOrEmpty(json))
             {
-                LoggingMethod.WriteToLog(pubnubLog, string.Format("DateTime {0} GenerateFileUploadUrl -> file upload OK.", DateTime.Now.ToString(CultureInfo.InvariantCulture)), config.LogVerbosity);                //do internal publish after successful file upload
+                LoggingMethod.WriteToLog(pubnubLog, string.Format(CultureInfo.InvariantCulture, "DateTime {0} GenerateFileUploadUrl -> file upload OK.", DateTime.Now.ToString(CultureInfo.InvariantCulture)), config.LogVerbosity);                //do internal publish after successful file upload
 
                 Dictionary<string, object> publishPayload = new Dictionary<string, object>();
                 if (this.publishMessage != null && !string.IsNullOrEmpty(this.publishMessage.ToString()))
@@ -311,13 +311,13 @@ namespace PubnubApi.EndPoint
                         result.FileName = generateFileUploadUrlResult.FileName;
                         ret.Result = result;
                         ret.Status.Error = false;
-                        LoggingMethod.WriteToLog(pubnubLog, string.Format("DateTime {0} GenerateFileUploadUrl -> file upload -> PublishFileMessage -> OK.", DateTime.Now.ToString(CultureInfo.InvariantCulture)), config.LogVerbosity);                //do internal publish after successful file upload
+                        LoggingMethod.WriteToLog(pubnubLog, string.Format(CultureInfo.InvariantCulture, "DateTime {0} GenerateFileUploadUrl -> file upload -> PublishFileMessage -> OK.", DateTime.Now.ToString(CultureInfo.InvariantCulture)), config.LogVerbosity);                //do internal publish after successful file upload
                     }
                     else
                     {
                         publishFailed = true;
                         ret.Status = publishFileMessageStatus;
-                        LoggingMethod.WriteToLog(pubnubLog, string.Format("DateTime {0} PublishFileMessage Failed. currentFileRetryCount={1}", DateTime.Now.ToString(CultureInfo.InvariantCulture), currentFileRetryCount), config.LogVerbosity);
+                        LoggingMethod.WriteToLog(pubnubLog, string.Format(CultureInfo.InvariantCulture, "DateTime {0} PublishFileMessage Failed. currentFileRetryCount={1}", DateTime.Now.ToString(CultureInfo.InvariantCulture), currentFileRetryCount), config.LogVerbosity);
 #if !NET35 && !NET40
                         Task.Delay(1000).Wait();
 #else
@@ -454,7 +454,7 @@ namespace PubnubApi.EndPoint
                     {
                         fileContentType = kvp.Value.ToString();
                     }
-                    string postParamData = string.Format("--{0}\r\nContent-Disposition: form-data; name=\"{1}\"\r\n\r\n{2}",
+                    string postParamData = string.Format(CultureInfo.InvariantCulture, "--{0}\r\nContent-Disposition: form-data; name=\"{1}\"\r\n\r\n{2}",
                             dataBoundary,
                             kvp.Key,
                             kvp.Value);
@@ -465,7 +465,7 @@ namespace PubnubApi.EndPoint
                     byte[] emptyData = Encoding.UTF8.GetBytes(emptyLine);
                     dataStream.Write(emptyData, 0, emptyData.Length);
                 }
-                string header = string.Format("--{0}\r\nContent-Disposition: form-data; name=\"{1}\"; filename=\"{2}\"\r\nContent-Type: {3}\r\n\r\n",
+                string header = string.Format(CultureInfo.InvariantCulture, "--{0}\r\nContent-Disposition: form-data; name=\"{1}\"; filename=\"{2}\"\r\nContent-Type: {3}\r\n\r\n",
                             dataBoundary,
                             "file",
                             fileName,
@@ -498,7 +498,7 @@ namespace PubnubApi.EndPoint
                 dataStream.Position = 0;
                 ret = new byte[dataStream.Length];
                 int bytesRead = dataStream.Read(ret, 0, ret.Length);
-                System.Diagnostics.Debug.WriteLine(string.Format("MultipartFormData byte count = {0}", bytesRead));
+                System.Diagnostics.Debug.WriteLine(string.Format(CultureInfo.InvariantCulture, "MultipartFormData byte count = {0}", bytesRead));
 #if NET35 || NET40 || NET45 || NET461 || NET48
                 dataStream.Close();
 #endif

--- a/src/Api/PubnubApi/EndPoint/Files/SendFileOperation.cs
+++ b/src/Api/PubnubApi/EndPoint/Files/SendFileOperation.cs
@@ -201,7 +201,7 @@ namespace PubnubApi.EndPoint
                         PNResult<PNPublishFileMessageResult> publishFileMessageResponse = PublishFileMessage(publishPayload, queryParam).Result;
                         PNPublishFileMessageResult publishFileMessage = publishFileMessageResponse.Result;
                         PNStatus publishFileMessageStatus = publishFileMessageResponse.Status;
-                        if (!publishFileMessageStatus.Error && publishFileMessage != null)
+                        if (publishFileMessageStatus != null && !publishFileMessageStatus.Error && publishFileMessage != null)
                         {
                             publishFailed = false;
                             PNFileUploadResult result = new PNFileUploadResult();
@@ -302,7 +302,7 @@ namespace PubnubApi.EndPoint
                     PNResult<PNPublishFileMessageResult> publishFileMessageResponse = await PublishFileMessage(publishPayload, queryParam).ConfigureAwait(false);
                     PNPublishFileMessageResult publishFileMessage = publishFileMessageResponse.Result;
                     PNStatus publishFileMessageStatus = publishFileMessageResponse.Status;
-                    if (!publishFileMessageStatus.Error && publishFileMessage != null)
+                    if (publishFileMessageStatus != null && !publishFileMessageStatus.Error && publishFileMessage != null)
                     {
                         publishFailed = false;
                         PNFileUploadResult result = new PNFileUploadResult();
@@ -407,6 +407,18 @@ namespace PubnubApi.EndPoint
                         PNException ex = new PNException("File has been upload but the notification couldn't be sent to the subscribed users");
                         PNStatus status = statusBuilder.CreateStatusResponse(requestState.ResponseType, PNStatusCategory.PNUnknownCategory, requestState, (int)HttpStatusCode.BadRequest, ex);
                         status.AdditonalData = new Dictionary<string, string> { {"FileId", currentFileId }, {"FileName", sendFileName } };
+                        ret.Status = status;
+                    }
+                }
+                else
+                {
+                    ret.Status = r.Result.Item2;
+                    if (ret.Status == null)
+                    {
+                        PNException ex = new PNException("PublishFileMessage failed.");
+                        StatusBuilder statusBuilder = new StatusBuilder(config, jsonLibrary);
+                        PNStatus status = statusBuilder.CreateStatusResponse(requestState.ResponseType, PNStatusCategory.PNUnknownCategory, requestState, (int)HttpStatusCode.BadRequest, ex);
+                        status.AdditonalData = new Dictionary<string, string> { { "FileId", currentFileId }, { "FileName", sendFileName } };
                         ret.Status = status;
                     }
                 }

--- a/src/Api/PubnubApi/EndPoint/Presence/SetStateOperation.cs
+++ b/src/Api/PubnubApi/EndPoint/Presence/SetStateOperation.cs
@@ -6,6 +6,7 @@ using PubnubApi.Interface;
 using System.Threading.Tasks;
 using System.Threading;
 using System.Net;
+using System.Globalization;
 
 namespace PubnubApi.EndPoint
 {
@@ -501,11 +502,11 @@ namespace PubnubApi.EndPoint
 
                     if (jsonUserState == "")
                     {
-                        jsonUserState = string.Format("\"{0}\":{{{1}}}", currentChannel, jsonChannelUserState);
+                        jsonUserState = string.Format(CultureInfo.InvariantCulture, "\"{0}\":{{{1}}}", currentChannel, jsonChannelUserState);
                     }
                     else
                     {
-                        jsonUserState = string.Format("{0},\"{1}\":{{{2}}}", jsonUserState, currentChannel, jsonChannelUserState);
+                        jsonUserState = string.Format(CultureInfo.InvariantCulture, "{0},\"{1}\":{{{2}}}", jsonUserState, currentChannel, jsonChannelUserState);
                     }
                 }
                 for (int channelGroupIndex = 0; channelGroupIndex < channelGroupList.Count; channelGroupIndex++)
@@ -514,14 +515,14 @@ namespace PubnubApi.EndPoint
 
                     if (jsonUserState == "")
                     {
-                        jsonUserState = string.Format("\"{0}\":{{{1}}}", currentChannelGroup, jsonChannelGroupUserState);
+                        jsonUserState = string.Format(CultureInfo.InvariantCulture, "\"{0}\":{{{1}}}", currentChannelGroup, jsonChannelGroupUserState);
                     }
                     else
                     {
-                        jsonUserState = string.Format("{0},\"{1}\":{{{2}}}", jsonUserState, currentChannelGroup, jsonChannelGroupUserState);
+                        jsonUserState = string.Format(CultureInfo.InvariantCulture, "{0},\"{1}\":{{{2}}}", jsonUserState, currentChannelGroup, jsonChannelGroupUserState);
                     }
                 }
-                jsonUserState = string.Format("{{{0}}}", jsonUserState);
+                jsonUserState = string.Format(CultureInfo.InvariantCulture, "{{{0}}}", jsonUserState);
             }
 
             return jsonUserState;
@@ -545,12 +546,12 @@ namespace PubnubApi.EndPoint
             }
             else if (channelJsonUserState.Trim().Length > 0 && channelGroupJsonUserState.Trim().Length > 0)
             {
-                jsonStateBuilder.AppendFormat("{0}:{1},{2}:{3}", channel, channelJsonUserState, channelGroup, channelGroupJsonUserState);
+                jsonStateBuilder.AppendFormat(CultureInfo.InvariantCulture, "{0}:{1},{2}:{3}", channel, channelJsonUserState, channelGroup, channelGroupJsonUserState);
             }
 
             if (jsonStateBuilder.Length > 0)
             {
-                retJsonUserState = string.Format("{{{0}}}", jsonStateBuilder);
+                retJsonUserState = string.Format(CultureInfo.InvariantCulture, "{{{0}}}", jsonStateBuilder);
             }
 
             return retJsonUserState;

--- a/src/Api/PubnubApi/EndPoint/PubSub/FireOperation.cs
+++ b/src/Api/PubnubApi/EndPoint/PubSub/FireOperation.cs
@@ -215,7 +215,7 @@ namespace PubnubApi.EndPoint
                 if (result != null && result.Count >= 3)
                 {
                     int publishStatus;
-                    Int32.TryParse(result[0].ToString(), out publishStatus);
+                    var _ = Int32.TryParse(result[0].ToString(), out publishStatus);
                     if (publishStatus == 1)
                     {
                         ProcessResponseCallbacks(result, requestState);
@@ -293,7 +293,7 @@ namespace PubnubApi.EndPoint
                 if (result != null && result.Count >= 3)
                 {
                     int publishStatus;
-                    Int32.TryParse(result[0].ToString(), out publishStatus);
+                    var _ = Int32.TryParse(result[0].ToString(), out publishStatus);
                     if (publishStatus == 1)
                     {
                         List<object> resultList = ProcessJsonResponse(requestState, json);

--- a/src/Api/PubnubApi/EndPoint/PubSub/ListenerManager.cs
+++ b/src/Api/PubnubApi/EndPoint/PubSub/ListenerManager.cs
@@ -51,7 +51,7 @@ namespace PubnubApi.EndPoint
                     }
                     catch (Exception ex)
                     {
-                        LoggingMethod.WriteToLog(pubnubLog, string.Format("DateTime {0}, ListenerManager AddListener => Exception = {1}", DateTime.Now.ToString(CultureInfo.InvariantCulture), ex), pubnubConfig.LogVerbosity);
+                        LoggingMethod.WriteToLog(pubnubLog, string.Format(CultureInfo.InvariantCulture, "DateTime {0}, ListenerManager AddListener => Exception = {1}", DateTime.Now.ToString(CultureInfo.InvariantCulture), ex), pubnubConfig.LogVerbosity);
                     }
                 }
             }
@@ -80,7 +80,7 @@ namespace PubnubApi.EndPoint
                     }
                     catch (Exception ex)
                     {
-                        LoggingMethod.WriteToLog(pubnubLog, string.Format("DateTime {0}, ListenerManager RemoveListener => Exception = {1}", DateTime.Now.ToString(CultureInfo.InvariantCulture), ex), pubnubConfig.LogVerbosity);
+                        LoggingMethod.WriteToLog(pubnubLog, string.Format(CultureInfo.InvariantCulture, "DateTime {0}, ListenerManager RemoveListener => Exception = {1}", DateTime.Now.ToString(CultureInfo.InvariantCulture), ex), pubnubConfig.LogVerbosity);
                     }
                 }
             }

--- a/src/Api/PubnubApi/EndPoint/PubSub/PublishOperation.cs
+++ b/src/Api/PubnubApi/EndPoint/PubSub/PublishOperation.cs
@@ -246,7 +246,7 @@ namespace PubnubApi.EndPoint
                     if (result != null && result.Count >= 3)
                     {
                         int publishStatus;
-                        Int32.TryParse(result[0].ToString(), out publishStatus);
+                        var _ = Int32.TryParse(result[0].ToString(), out publishStatus);
                         if (publishStatus == 1)
                         {
                             ProcessResponseCallbacks(result, requestState);
@@ -340,7 +340,7 @@ namespace PubnubApi.EndPoint
                     if (result != null && result.Count >= 3)
                     {
                         int publishStatus;
-                        Int32.TryParse(result[0].ToString(), out publishStatus);
+                        var _ = Int32.TryParse(result[0].ToString(), out publishStatus);
                         if (publishStatus == 1)
                         {
                             List<object> resultList = ProcessJsonResponse(requestState, json);

--- a/src/Api/PubnubApi/EndPoint/PubSub/SignalOperation.cs
+++ b/src/Api/PubnubApi/EndPoint/PubSub/SignalOperation.cs
@@ -184,7 +184,7 @@ namespace PubnubApi.EndPoint
                     if (result != null && result.Count >= 3)
                     {
                         int signalStatus;
-                        Int32.TryParse(result[0].ToString(), out signalStatus);
+                        var _ = Int32.TryParse(result[0].ToString(), out signalStatus);
                         if (signalStatus == 1)
                         {
                             ProcessResponseCallbacks(result, requestState);
@@ -251,7 +251,7 @@ namespace PubnubApi.EndPoint
                 if (result != null && result.Count >= 3)
                 {
                     int publishStatus;
-                    Int32.TryParse(result[0].ToString(), out publishStatus);
+                    var _ = Int32.TryParse(result[0].ToString(), out publishStatus);
                     if (publishStatus == 1)
                     {
                         List<object> resultList = ProcessJsonResponse(requestState, json);

--- a/src/Api/PubnubApi/EndPoint/PubSub/SubscribeManager.cs
+++ b/src/Api/PubnubApi/EndPoint/PubSub/SubscribeManager.cs
@@ -47,7 +47,7 @@ namespace PubnubApi.EndPoint
                 {
                     if (ChannelRequest[PubnubInstance.InstanceId].ContainsKey(multiChannelName))
                     {
-                        LoggingMethod.WriteToLog(pubnubLog, string.Format("DateTime {0}, Aborting previous subscribe/presence requests having channel(s)={1}; channelgroup(s)={2}", DateTime.Now.ToString(CultureInfo.InvariantCulture), multiChannelName, multiChannelGroupName), config.ContainsKey(PubnubInstance.InstanceId) ? config[PubnubInstance.InstanceId].LogVerbosity : PNLogVerbosity.NONE);
+                        LoggingMethod.WriteToLog(pubnubLog, string.Format(CultureInfo.InvariantCulture, "DateTime {0}, Aborting previous subscribe/presence requests having channel(s)={1}; channelgroup(s)={2}", DateTime.Now.ToString(CultureInfo.InvariantCulture), multiChannelName, multiChannelGroupName), config.ContainsKey(PubnubInstance.InstanceId) ? config[PubnubInstance.InstanceId].LogVerbosity : PNLogVerbosity.NONE);
 
                         HttpWebRequest webRequest;
                         ChannelRequest[PubnubInstance.InstanceId].TryGetValue(multiChannelName, out webRequest);
@@ -57,11 +57,11 @@ namespace PubnubApi.EndPoint
                         bool removedChannel = ChannelRequest[PubnubInstance.InstanceId].TryRemove(multiChannelName, out removedRequest);
                         if (removedChannel)
                         {
-                            LoggingMethod.WriteToLog(pubnubLog, string.Format("DateTime {0}, Success to remove channel(s)={1}; channelgroup(s)={2} from _channelRequest (MultiChannelUnSubscribeInit).", DateTime.Now.ToString(CultureInfo.InvariantCulture), multiChannelName, multiChannelGroupName), config.ContainsKey(PubnubInstance.InstanceId) ? config[PubnubInstance.InstanceId].LogVerbosity : PNLogVerbosity.NONE);
+                            LoggingMethod.WriteToLog(pubnubLog, string.Format(CultureInfo.InvariantCulture, "DateTime {0}, Success to remove channel(s)={1}; channelgroup(s)={2} from _channelRequest (MultiChannelUnSubscribeInit).", DateTime.Now.ToString(CultureInfo.InvariantCulture), multiChannelName, multiChannelGroupName), config.ContainsKey(PubnubInstance.InstanceId) ? config[PubnubInstance.InstanceId].LogVerbosity : PNLogVerbosity.NONE);
                         }
                         else
                         {
-                            LoggingMethod.WriteToLog(pubnubLog, string.Format("DateTime {0}, Unable to remove channel(s)={1}; channelgroup(s)={2} from _channelRequest (MultiChannelUnSubscribeInit).", DateTime.Now.ToString(CultureInfo.InvariantCulture), multiChannelName, multiChannelGroupName), config.ContainsKey(PubnubInstance.InstanceId) ? config[PubnubInstance.InstanceId].LogVerbosity : PNLogVerbosity.NONE);
+                            LoggingMethod.WriteToLog(pubnubLog, string.Format(CultureInfo.InvariantCulture, "DateTime {0}, Unable to remove channel(s)={1}; channelgroup(s)={2} from _channelRequest (MultiChannelUnSubscribeInit).", DateTime.Now.ToString(CultureInfo.InvariantCulture), multiChannelName, multiChannelGroupName), config.ContainsKey(PubnubInstance.InstanceId) ? config[PubnubInstance.InstanceId].LogVerbosity : PNLogVerbosity.NONE);
                         }
                         if (webRequest != null)
                         {
@@ -70,7 +70,7 @@ namespace PubnubApi.EndPoint
                     }
                     else
                     {
-                        LoggingMethod.WriteToLog(pubnubLog, string.Format("DateTime {0}, Unable to capture channel(s)={1}; channelgroup(s)={2} from _channelRequest to abort request.", DateTime.Now.ToString(CultureInfo.InvariantCulture), multiChannelName, multiChannelGroupName), config.ContainsKey(PubnubInstance.InstanceId) ? config[PubnubInstance.InstanceId].LogVerbosity : PNLogVerbosity.NONE);
+                        LoggingMethod.WriteToLog(pubnubLog, string.Format(CultureInfo.InvariantCulture, "DateTime {0}, Unable to capture channel(s)={1}; channelgroup(s)={2} from _channelRequest to abort request.", DateTime.Now.ToString(CultureInfo.InvariantCulture), multiChannelName, multiChannelGroupName), config.ContainsKey(PubnubInstance.InstanceId) ? config[PubnubInstance.InstanceId].LogVerbosity : PNLogVerbosity.NONE);
                     }
                 }, CancellationToken.None, TaskCreationOptions.PreferFairness, TaskScheduler.Default).ConfigureAwait(false);
 
@@ -109,7 +109,7 @@ namespace PubnubApi.EndPoint
 
                 if (PubnubInstance == null)
                 {
-                    LoggingMethod.WriteToLog(pubnubLog, string.Format("DateTime {0}, PubnubInstance is null. exiting MultiChannelUnSubscribeInit", DateTime.Now.ToString(CultureInfo.InvariantCulture)), config.ContainsKey(PubnubInstance.InstanceId) ? config[PubnubInstance.InstanceId].LogVerbosity : PNLogVerbosity.NONE);
+                    LoggingMethod.WriteToLog(pubnubLog, string.Format(CultureInfo.InvariantCulture, "DateTime {0}, PubnubInstance is null. exiting MultiChannelUnSubscribeInit", DateTime.Now.ToString(CultureInfo.InvariantCulture)), config.ContainsKey(PubnubInstance.InstanceId) ? config[PubnubInstance.InstanceId].LogVerbosity : PNLogVerbosity.NONE);
                     return;
                 }
 
@@ -149,7 +149,7 @@ namespace PubnubApi.EndPoint
                             else
                             {
                                 validChannels.Add(channelName);
-                                string presenceChannelName = string.Format("{0}-pnpres", channelName);
+                                string presenceChannelName = string.Format(CultureInfo.InvariantCulture, "{0}-pnpres", channelName);
                                 if (MultiChannelSubscribe.ContainsKey(PubnubInstance.InstanceId) && MultiChannelSubscribe[PubnubInstance.InstanceId] != null && MultiChannelSubscribe[PubnubInstance.InstanceId].ContainsKey(presenceChannelName))
                                 {
                                     validChannels.Add(presenceChannelName);
@@ -183,7 +183,7 @@ namespace PubnubApi.EndPoint
                             else
                             {
                                 validChannelGroups.Add(channelGroupName);
-                                string presenceChannelGroupName = string.Format("{0}-pnpres", channelGroupName);
+                                string presenceChannelGroupName = string.Format(CultureInfo.InvariantCulture, "{0}-pnpres", channelGroupName);
                                 if (MultiChannelGroupSubscribe.ContainsKey(PubnubInstance.InstanceId) && MultiChannelGroupSubscribe[PubnubInstance.InstanceId] != null && MultiChannelGroupSubscribe[PubnubInstance.InstanceId].ContainsKey(presenceChannelGroupName))
                                 {
                                     validChannelGroups.Add(presenceChannelGroupName);
@@ -208,7 +208,7 @@ namespace PubnubApi.EndPoint
                         {
                             if (ChannelRequest[PubnubInstance.InstanceId].ContainsKey(multiChannelName))
                             {
-                                LoggingMethod.WriteToLog(pubnubLog, string.Format("DateTime {0}, Aborting previous subscribe/presence requests having channel(s)={1}; channelgroup(s)={2}", DateTime.Now.ToString(CultureInfo.InvariantCulture), multiChannelName, multiChannelGroupName), config.ContainsKey(PubnubInstance.InstanceId) ? config[PubnubInstance.InstanceId].LogVerbosity : PNLogVerbosity.NONE);
+                                LoggingMethod.WriteToLog(pubnubLog, string.Format(CultureInfo.InvariantCulture, "DateTime {0}, Aborting previous subscribe/presence requests having channel(s)={1}; channelgroup(s)={2}", DateTime.Now.ToString(CultureInfo.InvariantCulture), multiChannelName, multiChannelGroupName), config.ContainsKey(PubnubInstance.InstanceId) ? config[PubnubInstance.InstanceId].LogVerbosity : PNLogVerbosity.NONE);
 
                                 HttpWebRequest webRequest;
                                 ChannelRequest[PubnubInstance.InstanceId].TryGetValue(multiChannelName, out webRequest);
@@ -218,11 +218,11 @@ namespace PubnubApi.EndPoint
                                 bool removedChannel = ChannelRequest[PubnubInstance.InstanceId].TryRemove(multiChannelName, out removedRequest);
                                 if (removedChannel)
                                 {
-                                    LoggingMethod.WriteToLog(pubnubLog, string.Format("DateTime {0}, Success to remove channel(s)={1}; channelgroup(s)={2} from _channelRequest (MultiChannelUnSubscribeInit).", DateTime.Now.ToString(CultureInfo.InvariantCulture), multiChannelName, multiChannelGroupName), config.ContainsKey(PubnubInstance.InstanceId) ? config[PubnubInstance.InstanceId].LogVerbosity : PNLogVerbosity.NONE);
+                                    LoggingMethod.WriteToLog(pubnubLog, string.Format(CultureInfo.InvariantCulture, "DateTime {0}, Success to remove channel(s)={1}; channelgroup(s)={2} from _channelRequest (MultiChannelUnSubscribeInit).", DateTime.Now.ToString(CultureInfo.InvariantCulture), multiChannelName, multiChannelGroupName), config.ContainsKey(PubnubInstance.InstanceId) ? config[PubnubInstance.InstanceId].LogVerbosity : PNLogVerbosity.NONE);
                                 }
                                 else
                                 {
-                                    LoggingMethod.WriteToLog(pubnubLog, string.Format("DateTime {0}, Unable to remove channel(s)={1}; channelgroup(s)={2} from _channelRequest (MultiChannelUnSubscribeInit).", DateTime.Now.ToString(CultureInfo.InvariantCulture), multiChannelName, multiChannelGroupName), config.ContainsKey(PubnubInstance.InstanceId) ? config[PubnubInstance.InstanceId].LogVerbosity : PNLogVerbosity.NONE);
+                                    LoggingMethod.WriteToLog(pubnubLog, string.Format(CultureInfo.InvariantCulture, "DateTime {0}, Unable to remove channel(s)={1}; channelgroup(s)={2} from _channelRequest (MultiChannelUnSubscribeInit).", DateTime.Now.ToString(CultureInfo.InvariantCulture), multiChannelName, multiChannelGroupName), config.ContainsKey(PubnubInstance.InstanceId) ? config[PubnubInstance.InstanceId].LogVerbosity : PNLogVerbosity.NONE);
                                 }
                                 if (webRequest != null)
                                 {
@@ -231,7 +231,7 @@ namespace PubnubApi.EndPoint
                             }
                             else
                             {
-                                LoggingMethod.WriteToLog(pubnubLog, string.Format("DateTime {0}, Unable to capture channel(s)={1}; channelgroup(s)={2} from _channelRequest to abort request.", DateTime.Now.ToString(CultureInfo.InvariantCulture), multiChannelName, multiChannelGroupName), config.ContainsKey(PubnubInstance.InstanceId) ? config[PubnubInstance.InstanceId].LogVerbosity : PNLogVerbosity.NONE);
+                                LoggingMethod.WriteToLog(pubnubLog, string.Format(CultureInfo.InvariantCulture, "DateTime {0}, Unable to capture channel(s)={1}; channelgroup(s)={2} from _channelRequest to abort request.", DateTime.Now.ToString(CultureInfo.InvariantCulture), multiChannelName, multiChannelGroupName), config.ContainsKey(PubnubInstance.InstanceId) ? config[PubnubInstance.InstanceId].LogVerbosity : PNLogVerbosity.NONE);
                             }
                         }, CancellationToken.None, TaskCreationOptions.PreferFairness, TaskScheduler.Default).ConfigureAwait(false);
 
@@ -400,13 +400,13 @@ namespace PubnubApi.EndPoint
                             PresenceHeartbeatTimer.Dispose();
                             PresenceHeartbeatTimer = null;
                         }
-                        LoggingMethod.WriteToLog(pubnubLog, string.Format("DateTime {0}, All channels are Unsubscribed. Further subscription was stopped", DateTime.Now.ToString(CultureInfo.InvariantCulture)), config.ContainsKey(PubnubInstance.InstanceId) ? config[PubnubInstance.InstanceId].LogVerbosity : PNLogVerbosity.NONE);
+                        LoggingMethod.WriteToLog(pubnubLog, string.Format(CultureInfo.InvariantCulture, "DateTime {0}, All channels are Unsubscribed. Further subscription was stopped", DateTime.Now.ToString(CultureInfo.InvariantCulture)), config.ContainsKey(PubnubInstance.InstanceId) ? config[PubnubInstance.InstanceId].LogVerbosity : PNLogVerbosity.NONE);
                     }
                 }
             }
             catch(Exception ex)
             {
-                LoggingMethod.WriteToLog(pubnubLog, string.Format("DateTime {0} SubscribeManager=> MultiChannelUnSubscribeInit \n channel(s)={1} \n cg(s)={2} \n Exception Details={3}", DateTime.Now.ToString(CultureInfo.InvariantCulture), string.Join(",", validChannels.OrderBy(x => x).ToArray()), string.Join(",", validChannelGroups.OrderBy(x => x).ToArray()), ex), config.ContainsKey(PubnubInstance.InstanceId) ? config[PubnubInstance.InstanceId].LogVerbosity : PNLogVerbosity.NONE);
+                LoggingMethod.WriteToLog(pubnubLog, string.Format(CultureInfo.InvariantCulture, "DateTime {0} SubscribeManager=> MultiChannelUnSubscribeInit \n channel(s)={1} \n cg(s)={2} \n Exception Details={3}", DateTime.Now.ToString(CultureInfo.InvariantCulture), string.Join(",", validChannels.OrderBy(x => x).ToArray()), string.Join(",", validChannelGroups.OrderBy(x => x).ToArray()), ex), config.ContainsKey(PubnubInstance.InstanceId) ? config[PubnubInstance.InstanceId].LogVerbosity : PNLogVerbosity.NONE);
             }
         }
 
@@ -482,7 +482,7 @@ namespace PubnubApi.EndPoint
                                 string multiChannelName = keysList[keyIndex];
                                 if (ChannelRequest[PubnubInstance.InstanceId].ContainsKey(multiChannelName))
                                 {
-                                    LoggingMethod.WriteToLog(pubnubLog, string.Format("DateTime {0}, Aborting previous subscribe/presence requests having channel(s)={1}; channelgroup(s)={2}", DateTime.Now.ToString(CultureInfo.InvariantCulture), multiChannelName, multiChannelGroupName), config.ContainsKey(PubnubInstance.InstanceId) ? config[PubnubInstance.InstanceId].LogVerbosity : PNLogVerbosity.NONE);
+                                    LoggingMethod.WriteToLog(pubnubLog, string.Format(CultureInfo.InvariantCulture, "DateTime {0}, Aborting previous subscribe/presence requests having channel(s)={1}; channelgroup(s)={2}", DateTime.Now.ToString(CultureInfo.InvariantCulture), multiChannelName, multiChannelGroupName), config.ContainsKey(PubnubInstance.InstanceId) ? config[PubnubInstance.InstanceId].LogVerbosity : PNLogVerbosity.NONE);
                                     HttpWebRequest webRequest;
                                     ChannelRequest[PubnubInstance.InstanceId].TryGetValue(multiChannelName, out webRequest);
                                     ChannelRequest[PubnubInstance.InstanceId].TryUpdate(multiChannelName, null, webRequest);
@@ -491,11 +491,11 @@ namespace PubnubApi.EndPoint
                                     bool removedChannel = ChannelRequest[PubnubInstance.InstanceId].TryRemove(multiChannelName, out removedRequest);
                                     if (removedChannel)
                                     {
-                                        LoggingMethod.WriteToLog(pubnubLog, string.Format("DateTime {0}, Success to remove channel(s)={1}; channelgroup(s)={2} from _channelRequest (MultiChannelSubscribeInit).", DateTime.Now.ToString(CultureInfo.InvariantCulture), multiChannelName, multiChannelGroupName), config.ContainsKey(PubnubInstance.InstanceId) ? config[PubnubInstance.InstanceId].LogVerbosity : PNLogVerbosity.NONE);
+                                        LoggingMethod.WriteToLog(pubnubLog, string.Format(CultureInfo.InvariantCulture, "DateTime {0}, Success to remove channel(s)={1}; channelgroup(s)={2} from _channelRequest (MultiChannelSubscribeInit).", DateTime.Now.ToString(CultureInfo.InvariantCulture), multiChannelName, multiChannelGroupName), config.ContainsKey(PubnubInstance.InstanceId) ? config[PubnubInstance.InstanceId].LogVerbosity : PNLogVerbosity.NONE);
                                     }
                                     else
                                     {
-                                        LoggingMethod.WriteToLog(pubnubLog, string.Format("DateTime {0}, Unable to remove channel(s)={1}; channelgroup(s)={2} from _channelRequest (MultiChannelSubscribeInit).", DateTime.Now.ToString(CultureInfo.InvariantCulture), multiChannelName, multiChannelGroupName), config.ContainsKey(PubnubInstance.InstanceId) ? config[PubnubInstance.InstanceId].LogVerbosity : PNLogVerbosity.NONE);
+                                        LoggingMethod.WriteToLog(pubnubLog, string.Format(CultureInfo.InvariantCulture, "DateTime {0}, Unable to remove channel(s)={1}; channelgroup(s)={2} from _channelRequest (MultiChannelSubscribeInit).", DateTime.Now.ToString(CultureInfo.InvariantCulture), multiChannelName, multiChannelGroupName), config.ContainsKey(PubnubInstance.InstanceId) ? config[PubnubInstance.InstanceId].LogVerbosity : PNLogVerbosity.NONE);
                                     }
                                     if (webRequest != null)
                                     {
@@ -504,13 +504,13 @@ namespace PubnubApi.EndPoint
                                 }
                                 else
                                 {
-                                    LoggingMethod.WriteToLog(pubnubLog, string.Format("DateTime {0}, Unable to capture channel(s)={1}; channelgroup(s)={2} from _channelRequest to abort request.", DateTime.Now.ToString(CultureInfo.InvariantCulture), multiChannelName, multiChannelGroupName), config.ContainsKey(PubnubInstance.InstanceId) ? config[PubnubInstance.InstanceId].LogVerbosity : PNLogVerbosity.NONE);
+                                    LoggingMethod.WriteToLog(pubnubLog, string.Format(CultureInfo.InvariantCulture, "DateTime {0}, Unable to capture channel(s)={1}; channelgroup(s)={2} from _channelRequest to abort request.", DateTime.Now.ToString(CultureInfo.InvariantCulture), multiChannelName, multiChannelGroupName), config.ContainsKey(PubnubInstance.InstanceId) ? config[PubnubInstance.InstanceId].LogVerbosity : PNLogVerbosity.NONE);
                                 }
                             }
                         }
                         else
                         {
-                            LoggingMethod.WriteToLog(pubnubLog, string.Format("DateTime {0}, Unable to find instance id = {1} from _channelRequest.", DateTime.Now.ToString(CultureInfo.InvariantCulture), PubnubInstance.InstanceId), config.ContainsKey(PubnubInstance.InstanceId) ? config[PubnubInstance.InstanceId].LogVerbosity : PNLogVerbosity.NONE);
+                            LoggingMethod.WriteToLog(pubnubLog, string.Format(CultureInfo.InvariantCulture, "DateTime {0}, Unable to find instance id = {1} from _channelRequest.", DateTime.Now.ToString(CultureInfo.InvariantCulture), PubnubInstance.InstanceId), config.ContainsKey(PubnubInstance.InstanceId) ? config[PubnubInstance.InstanceId].LogVerbosity : PNLogVerbosity.NONE);
                         }
                     }
 
@@ -568,7 +568,7 @@ namespace PubnubApi.EndPoint
             }
             catch(Exception ex)
             {
-                LoggingMethod.WriteToLog(pubnubLog, string.Format("DateTime {0} SubscribeManager=> MultiChannelSubscribeInit \n channel(s)={1} \n cg(s)={2} \n Exception Details={3}", DateTime.Now.ToString(CultureInfo.InvariantCulture), string.Join(",", validChannels.OrderBy(x => x).ToArray()), string.Join(",", validChannelGroups.OrderBy(x => x).ToArray()), ex), config.ContainsKey(PubnubInstance.InstanceId) ? config[PubnubInstance.InstanceId].LogVerbosity : PNLogVerbosity.NONE);
+                LoggingMethod.WriteToLog(pubnubLog, string.Format(CultureInfo.InvariantCulture, "DateTime {0} SubscribeManager=> MultiChannelSubscribeInit \n channel(s)={1} \n cg(s)={2} \n Exception Details={3}", DateTime.Now.ToString(CultureInfo.InvariantCulture), string.Join(",", validChannels.OrderBy(x => x).ToArray()), string.Join(",", validChannelGroups.OrderBy(x => x).ToArray()), ex), config.ContainsKey(PubnubInstance.InstanceId) ? config[PubnubInstance.InstanceId].LogVerbosity : PNLogVerbosity.NONE);
             }
         }
 
@@ -576,19 +576,19 @@ namespace PubnubApi.EndPoint
         {
             if (!config.ContainsKey(PubnubInstance.InstanceId))
             {
-                LoggingMethod.WriteToLog(pubnubLog, string.Format("DateTime {0}, InstanceId Not Available. Exiting MultiChannelSubscribeRequest", DateTime.Now.ToString(CultureInfo.InvariantCulture)), PNLogVerbosity.BODY);
+                LoggingMethod.WriteToLog(pubnubLog, string.Format(CultureInfo.InvariantCulture, "DateTime {0}, InstanceId Not Available. Exiting MultiChannelSubscribeRequest", DateTime.Now.ToString(CultureInfo.InvariantCulture)), PNLogVerbosity.BODY);
                 return;
             }
             if (SubscribeDisconnected[PubnubInstance.InstanceId])
             {
-                LoggingMethod.WriteToLog(pubnubLog, string.Format("DateTime {0}, SubscribeDisconnected. Exiting MultiChannelSubscribeRequest", DateTime.Now.ToString(CultureInfo.InvariantCulture)), config[PubnubInstance.InstanceId].LogVerbosity);
+                LoggingMethod.WriteToLog(pubnubLog, string.Format(CultureInfo.InvariantCulture, "DateTime {0}, SubscribeDisconnected. Exiting MultiChannelSubscribeRequest", DateTime.Now.ToString(CultureInfo.InvariantCulture)), config[PubnubInstance.InstanceId].LogVerbosity);
                 return;
             }
 
             //Exit if the channel is unsubscribed
             if (MultiChannelSubscribe != null && MultiChannelSubscribe[PubnubInstance.InstanceId].Count <= 0 && MultiChannelGroupSubscribe != null && MultiChannelGroupSubscribe[PubnubInstance.InstanceId].Count <= 0)
             {
-                LoggingMethod.WriteToLog(pubnubLog, string.Format("DateTime {0}, Zero channels/channelGroups. Further subscription was stopped", DateTime.Now.ToString(CultureInfo.InvariantCulture)), config.ContainsKey(PubnubInstance.InstanceId) ? config[PubnubInstance.InstanceId].LogVerbosity : PNLogVerbosity.NONE);
+                LoggingMethod.WriteToLog(pubnubLog, string.Format(CultureInfo.InvariantCulture, "DateTime {0}, Zero channels/channelGroups. Further subscription was stopped", DateTime.Now.ToString(CultureInfo.InvariantCulture)), config.ContainsKey(PubnubInstance.InstanceId) ? config[PubnubInstance.InstanceId].LogVerbosity : PNLogVerbosity.NONE);
                 return;
             }
 
@@ -617,9 +617,9 @@ namespace PubnubApi.EndPoint
                 }
             }
 
-            if (!ChannelRequest.ContainsKey(PubnubInstance.InstanceId) || (!multiChannel.Equals(",", StringComparison.CurrentCultureIgnoreCase) && !ChannelRequest[PubnubInstance.InstanceId].ContainsKey(multiChannel)))
+            if (!ChannelRequest.ContainsKey(PubnubInstance.InstanceId) || (!multiChannel.Equals(",", StringComparison.OrdinalIgnoreCase) && !ChannelRequest[PubnubInstance.InstanceId].ContainsKey(multiChannel)))
             {
-                LoggingMethod.WriteToLog(pubnubLog, string.Format("DateTime {0}, PubnubInstance.InstanceId NOT matching", DateTime.Now.ToString(CultureInfo.InvariantCulture)), config.ContainsKey(PubnubInstance.InstanceId) ? config[PubnubInstance.InstanceId].LogVerbosity : PNLogVerbosity.NONE);
+                LoggingMethod.WriteToLog(pubnubLog, string.Format(CultureInfo.InvariantCulture, "DateTime {0}, PubnubInstance.InstanceId NOT matching", DateTime.Now.ToString(CultureInfo.InvariantCulture)), config.ContainsKey(PubnubInstance.InstanceId) ? config[PubnubInstance.InstanceId].LogVerbosity : PNLogVerbosity.NONE);
                 return;
             }
 
@@ -657,20 +657,20 @@ namespace PubnubApi.EndPoint
                         lastTimetoken = LastSubscribeTimetoken[PubnubInstance.InstanceId];
                     }
                 }
-                LoggingMethod.WriteToLog(pubnubLog, string.Format("DateTime {0}, Building request for channel(s)={1}, channelgroup(s)={2} with timetoken={3}", DateTime.Now.ToString(CultureInfo.InvariantCulture), multiChannel, multiChannelGroup, lastTimetoken), config.ContainsKey(PubnubInstance.InstanceId) ? config[PubnubInstance.InstanceId].LogVerbosity : PNLogVerbosity.NONE);
+                LoggingMethod.WriteToLog(pubnubLog, string.Format(CultureInfo.InvariantCulture, "DateTime {0}, Building request for channel(s)={1}, channelgroup(s)={2} with timetoken={3}", DateTime.Now.ToString(CultureInfo.InvariantCulture), multiChannel, multiChannelGroup, lastTimetoken), config.ContainsKey(PubnubInstance.InstanceId) ? config[PubnubInstance.InstanceId].LogVerbosity : PNLogVerbosity.NONE);
                 // Build URL
                 string channelsJsonState = BuildJsonUserState(channels, channelGroups, false);
                 config[PubnubInstance.InstanceId].UserId = CurrentUserId[PubnubInstance.InstanceId]; // to make sure we capture if UUID is changed
                 IUrlRequestBuilder urlBuilder = new UrlRequestBuilder(config[PubnubInstance.InstanceId], jsonLibrary, unit, pubnubLog, pubnubTelemetryMgr, (PubnubInstance != null && !string.IsNullOrEmpty(PubnubInstance.InstanceId) && PubnubTokenMgrCollection.ContainsKey(PubnubInstance.InstanceId)) ? PubnubTokenMgrCollection[PubnubInstance.InstanceId] : null, (PubnubInstance != null) ? PubnubInstance.InstanceId : "");
                 
-                Uri request = urlBuilder.BuildMultiChannelSubscribeRequest("GET", "", channels, channelGroups, (Convert.ToInt64(timetoken.ToString()) == 0) ? Convert.ToInt64(timetoken.ToString()) : lastTimetoken, region, channelsJsonState, initialSubscribeUrlParams, externalQueryParam);
+                Uri request = urlBuilder.BuildMultiChannelSubscribeRequest("GET", "", channels, channelGroups, (Convert.ToInt64(timetoken.ToString(), CultureInfo.InvariantCulture) == 0) ? Convert.ToInt64(timetoken.ToString(), CultureInfo.InvariantCulture) : lastTimetoken, region, channelsJsonState, initialSubscribeUrlParams, externalQueryParam);
 
                 pubnubRequestState = new RequestState<T>();
                 pubnubRequestState.Channels = channels;
                 pubnubRequestState.ChannelGroups = channelGroups;
                 pubnubRequestState.ResponseType = type;
                 pubnubRequestState.Reconnect = reconnect;
-                pubnubRequestState.Timetoken = Convert.ToInt64(timetoken.ToString());
+                pubnubRequestState.Timetoken = Convert.ToInt64(timetoken.ToString(), CultureInfo.InvariantCulture);
                 pubnubRequestState.Region = region;
 
                 // Wait for message
@@ -687,17 +687,17 @@ namespace PubnubApi.EndPoint
                     string subscribedChannelGroups = (MultiChannelGroupSubscribe.ContainsKey(PubnubInstance.InstanceId) && MultiChannelGroupSubscribe[PubnubInstance.InstanceId].Count > 0) ? MultiChannelGroupSubscribe[PubnubInstance.InstanceId].Keys.OrderBy(x => x).Aggregate((x, y) => x + "," + y) : "";
                     string currentChannelGroups = (channelGroups != null && channelGroups.Length > 0) ? channelGroups.OrderBy(x => x).Aggregate((x, y) => x + "," + y) : "";
 
-                    if (subscribedChannels.Equals(currentChannels, StringComparison.CurrentCultureIgnoreCase) && subscribedChannelGroups.Equals(currentChannelGroups, StringComparison.CurrentCultureIgnoreCase))
+                    if (subscribedChannels.Equals(currentChannels, StringComparison.OrdinalIgnoreCase) && subscribedChannelGroups.Equals(currentChannelGroups, StringComparison.OrdinalIgnoreCase))
                     {
                         List<object> result = ProcessJsonResponse<T>(pubnubRequestState, json);
-                        LoggingMethod.WriteToLog(pubnubLog, string.Format("DateTime: {0}, result count of ProcessJsonResponse = {1}", DateTime.Now.ToString(CultureInfo.InvariantCulture), (result != null) ? result.Count : -1), config[PubnubInstance.InstanceId].LogVerbosity);
+                        LoggingMethod.WriteToLog(pubnubLog, string.Format(CultureInfo.InvariantCulture, "DateTime: {0}, result count of ProcessJsonResponse = {1}", DateTime.Now.ToString(CultureInfo.InvariantCulture), (result != null) ? result.Count : -1), config[PubnubInstance.InstanceId].LogVerbosity);
 
                         ProcessResponseCallbacks<T>(result, pubnubRequestState);
 
                         if ((pubnubRequestState.ResponseType == PNOperationType.PNSubscribeOperation || pubnubRequestState.ResponseType == PNOperationType.Presence) && (result != null) && (result.Count > 0))
                         {
                             long jsonTimetoken = GetTimetokenFromMultiplexResult(result);
-                            LoggingMethod.WriteToLog(pubnubLog, string.Format("DateTime: {0}, jsonTimetoken = {1}", DateTime.Now.ToString(CultureInfo.InvariantCulture), jsonTimetoken), config[PubnubInstance.InstanceId].LogVerbosity);
+                            LoggingMethod.WriteToLog(pubnubLog, string.Format(CultureInfo.InvariantCulture, "DateTime: {0}, jsonTimetoken = {1}", DateTime.Now.ToString(CultureInfo.InvariantCulture), jsonTimetoken), config[PubnubInstance.InstanceId].LogVerbosity);
 
                             if (jsonTimetoken > 0)
                             {
@@ -725,11 +725,11 @@ namespace PubnubApi.EndPoint
                     }
                     else
                     {
-                        LoggingMethod.WriteToLog(pubnubLog, string.Format("DateTime: {0}, condition failed for subscribedChannels == currentChannels && subscribedChannelGroups == currentChannelGroups", DateTime.Now.ToString(CultureInfo.InvariantCulture)), config[PubnubInstance.InstanceId].LogVerbosity);
-                        LoggingMethod.WriteToLog(pubnubLog, string.Format("DateTime: {0}, subscribedChannels = {1}", DateTime.Now.ToString(CultureInfo.InvariantCulture), subscribedChannels), config[PubnubInstance.InstanceId].LogVerbosity);
-                        LoggingMethod.WriteToLog(pubnubLog, string.Format("DateTime: {0}, currentChannels = {1}", DateTime.Now.ToString(CultureInfo.InvariantCulture), currentChannels), config[PubnubInstance.InstanceId].LogVerbosity);
-                        LoggingMethod.WriteToLog(pubnubLog, string.Format("DateTime: {0}, subscribedChannelGroups = {1}", DateTime.Now.ToString(CultureInfo.InvariantCulture), subscribedChannelGroups), config[PubnubInstance.InstanceId].LogVerbosity);
-                        LoggingMethod.WriteToLog(pubnubLog, string.Format("DateTime: {0}, currentChannelGroups = {1}", DateTime.Now.ToString(CultureInfo.InvariantCulture), currentChannelGroups), config[PubnubInstance.InstanceId].LogVerbosity);
+                        LoggingMethod.WriteToLog(pubnubLog, string.Format(CultureInfo.InvariantCulture, "DateTime: {0}, condition failed for subscribedChannels == currentChannels && subscribedChannelGroups == currentChannelGroups", DateTime.Now.ToString(CultureInfo.InvariantCulture)), config[PubnubInstance.InstanceId].LogVerbosity);
+                        LoggingMethod.WriteToLog(pubnubLog, string.Format(CultureInfo.InvariantCulture, "DateTime: {0}, subscribedChannels = {1}", DateTime.Now.ToString(CultureInfo.InvariantCulture), subscribedChannels), config[PubnubInstance.InstanceId].LogVerbosity);
+                        LoggingMethod.WriteToLog(pubnubLog, string.Format(CultureInfo.InvariantCulture, "DateTime: {0}, currentChannels = {1}", DateTime.Now.ToString(CultureInfo.InvariantCulture), currentChannels), config[PubnubInstance.InstanceId].LogVerbosity);
+                        LoggingMethod.WriteToLog(pubnubLog, string.Format(CultureInfo.InvariantCulture, "DateTime: {0}, subscribedChannelGroups = {1}", DateTime.Now.ToString(CultureInfo.InvariantCulture), subscribedChannelGroups), config[PubnubInstance.InstanceId].LogVerbosity);
+                        LoggingMethod.WriteToLog(pubnubLog, string.Format(CultureInfo.InvariantCulture, "DateTime: {0}, currentChannelGroups = {1}", DateTime.Now.ToString(CultureInfo.InvariantCulture), currentChannelGroups), config[PubnubInstance.InstanceId].LogVerbosity);
                     }
 
                 }
@@ -748,7 +748,7 @@ namespace PubnubApi.EndPoint
             }
             catch (Exception ex)
             {
-                LoggingMethod.WriteToLog(pubnubLog, string.Format("DateTime {0} method:_subscribe \n channel={1} \n timetoken={2} \n Exception Details={3}", DateTime.Now.ToString(CultureInfo.InvariantCulture), string.Join(",", channels.OrderBy(x => x).ToArray()), timetoken, ex), config[PubnubInstance.InstanceId].LogVerbosity);
+                LoggingMethod.WriteToLog(pubnubLog, string.Format(CultureInfo.InvariantCulture, "DateTime {0} method:_subscribe \n channel={1} \n timetoken={2} \n Exception Details={3}", DateTime.Now.ToString(CultureInfo.InvariantCulture), string.Join(",", channels.OrderBy(x => x).ToArray()), timetoken, ex), config[PubnubInstance.InstanceId].LogVerbosity);
 
                 PNStatusCategory errorCategory = PNStatusCategoryHelper.GetPNStatusCategory(ex);
                 PNStatus status = new StatusBuilder(config[PubnubInstance.InstanceId], jsonLibrary).CreateStatusResponse<T>(type, errorCategory, pubnubRequestState, (int)HttpStatusCode.NotFound, new PNException(ex));
@@ -770,7 +770,7 @@ namespace PubnubApi.EndPoint
 
         private void MultiplexExceptionHandlerTimerCallback<T>(object state)
         {
-            LoggingMethod.WriteToLog(pubnubLog, string.Format("DateTime {0} MultiplexExceptionHandlerTimerCallback", DateTime.Now.ToString(CultureInfo.InvariantCulture)), config.ContainsKey(PubnubInstance.InstanceId) ? config[PubnubInstance.InstanceId].LogVerbosity : PNLogVerbosity.NONE);
+            LoggingMethod.WriteToLog(pubnubLog, string.Format(CultureInfo.InvariantCulture, "DateTime {0} MultiplexExceptionHandlerTimerCallback", DateTime.Now.ToString(CultureInfo.InvariantCulture)), config.ContainsKey(PubnubInstance.InstanceId) ? config[PubnubInstance.InstanceId].LogVerbosity : PNLogVerbosity.NONE);
             RequestState<T> currentState = state as RequestState<T>;
             if (currentState != null)
             {
@@ -845,13 +845,13 @@ namespace PubnubApi.EndPoint
                 int region = GetRegionFromMultiplexResult(message);
                 Task.Factory.StartNew(() =>
                 {
-                    LoggingMethod.WriteToLog(pubnubLog, string.Format("DateTime {0} MultiplexInternalCallback timetoken = {1}; region = {2}", DateTime.Now.ToString(CultureInfo.InvariantCulture), timetoken, region), config.ContainsKey(PubnubInstance.InstanceId) ? config[PubnubInstance.InstanceId].LogVerbosity : PNLogVerbosity.NONE);
+                    LoggingMethod.WriteToLog(pubnubLog, string.Format(CultureInfo.InvariantCulture, "DateTime {0} MultiplexInternalCallback timetoken = {1}; region = {2}", DateTime.Now.ToString(CultureInfo.InvariantCulture), timetoken, region), config.ContainsKey(PubnubInstance.InstanceId) ? config[PubnubInstance.InstanceId].LogVerbosity : PNLogVerbosity.NONE);
                     MultiChannelSubscribeRequest<T>(type, channels, channelGroups, timetoken, region, false, null, this.customQueryParam);
                 }, CancellationToken.None, TaskCreationOptions.PreferFairness, TaskScheduler.Default).ConfigureAwait(false);
             }
             else
             {
-                LoggingMethod.WriteToLog(pubnubLog, string.Format("DateTime {0}, Lost Channel Name for resubscribe", DateTime.Now.ToString(CultureInfo.InvariantCulture)), config.ContainsKey(PubnubInstance.InstanceId) ? config[PubnubInstance.InstanceId].LogVerbosity : PNLogVerbosity.NONE);
+                LoggingMethod.WriteToLog(pubnubLog, string.Format(CultureInfo.InvariantCulture, "DateTime {0}, Lost Channel Name for resubscribe", DateTime.Now.ToString(CultureInfo.InvariantCulture)), config.ContainsKey(PubnubInstance.InstanceId) ? config[PubnubInstance.InstanceId].LogVerbosity : PNLogVerbosity.NONE);
             }
         }
 
@@ -867,22 +867,22 @@ namespace PubnubApi.EndPoint
                 netState.Region = region;
                 if (!config.ContainsKey(PubnubInstance.InstanceId))
                 {
-                    LoggingMethod.WriteToLog(pubnubLog, string.Format("DateTime {0}, InstanceId Not Available. So no reconnect", DateTime.Now.ToString(CultureInfo.InvariantCulture)), PNLogVerbosity.BODY);
+                    LoggingMethod.WriteToLog(pubnubLog, string.Format(CultureInfo.InvariantCulture, "DateTime {0}, InstanceId Not Available. So no reconnect", DateTime.Now.ToString(CultureInfo.InvariantCulture)), PNLogVerbosity.BODY);
                 }
 
                 if (SubscribeDisconnected[PubnubInstance.InstanceId])
                 {
-                    LoggingMethod.WriteToLog(pubnubLog, string.Format("DateTime {0}, Subscribe is still Disconnected. So no reconnect", DateTime.Now.ToString(CultureInfo.InvariantCulture)), config[PubnubInstance.InstanceId].LogVerbosity);
+                    LoggingMethod.WriteToLog(pubnubLog, string.Format(CultureInfo.InvariantCulture, "DateTime {0}, Subscribe is still Disconnected. So no reconnect", DateTime.Now.ToString(CultureInfo.InvariantCulture)), config[PubnubInstance.InstanceId].LogVerbosity);
                 }
                 else if (config[PubnubInstance.InstanceId].ReconnectionPolicy != PNReconnectionPolicy.NONE)
                 {
-                    LoggingMethod.WriteToLog(pubnubLog, string.Format("DateTime {0}, Subscribe - No internet connection for channel={1} and channelgroup={2}; networkAvailable={3}", DateTime.Now.ToString(CultureInfo.InvariantCulture), string.Join(",", channels.OrderBy(x => x).ToArray()), channelGroups != null ? string.Join(",", channelGroups) : "", networkAvailable), config[PubnubInstance.InstanceId].LogVerbosity);
+                    LoggingMethod.WriteToLog(pubnubLog, string.Format(CultureInfo.InvariantCulture, "DateTime {0}, Subscribe - No internet connection for channel={1} and channelgroup={2}; networkAvailable={3}", DateTime.Now.ToString(CultureInfo.InvariantCulture), string.Join(",", channels.OrderBy(x => x).ToArray()), channelGroups != null ? string.Join(",", channelGroups) : "", networkAvailable), config[PubnubInstance.InstanceId].LogVerbosity);
                     TerminateReconnectTimer();
                     ReconnectNetwork<T>(netState);
                 }
                 else
                 {
-                    LoggingMethod.WriteToLog(pubnubLog, string.Format("DateTime {0}, reconnection policy is DISABLED, please handle reconnection manually.", DateTime.Now.ToString(CultureInfo.InvariantCulture)), config[PubnubInstance.InstanceId].LogVerbosity);
+                    LoggingMethod.WriteToLog(pubnubLog, string.Format(CultureInfo.InvariantCulture, "DateTime {0}, reconnection policy is DISABLED, please handle reconnection manually.", DateTime.Now.ToString(CultureInfo.InvariantCulture)), config[PubnubInstance.InstanceId].LogVerbosity);
                     if (!networkAvailable)
                     {
                         PNStatusCategory errorCategory =  PNStatusCategory.PNNetworkIssuesCategory;
@@ -911,7 +911,7 @@ namespace PubnubApi.EndPoint
         {
             if (netState != null && ((netState.Channels != null && netState.Channels.Length > 0) || (netState.ChannelGroups != null && netState.ChannelGroups.Length > 0)))
             {
-                LoggingMethod.WriteToLog(pubnubLog, string.Format("DateTime {0}, SubscribeManager ReconnectNetwork interval = {1} sec", DateTime.Now.ToString(CultureInfo.InvariantCulture), PubnubNetworkTcpCheckIntervalInSeconds), config.ContainsKey(PubnubInstance.InstanceId) ? config[PubnubInstance.InstanceId].LogVerbosity : PNLogVerbosity.NONE);
+                LoggingMethod.WriteToLog(pubnubLog, string.Format(CultureInfo.InvariantCulture, "DateTime {0}, SubscribeManager ReconnectNetwork interval = {1} sec", DateTime.Now.ToString(CultureInfo.InvariantCulture), PubnubNetworkTcpCheckIntervalInSeconds), config.ContainsKey(PubnubInstance.InstanceId) ? config[PubnubInstance.InstanceId].LogVerbosity : PNLogVerbosity.NONE);
 
                 System.Threading.Timer timer;
 
@@ -969,7 +969,7 @@ namespace PubnubApi.EndPoint
                 }
                 if (networkConnection)
                 {
-                    LoggingMethod.WriteToLog(pubnubLog, string.Format("DateTime {0}, Network available for SubscribeManager Manual Reconnect", DateTime.Now.ToString(CultureInfo.InvariantCulture)), config.ContainsKey(PubnubInstance.InstanceId) ? config[PubnubInstance.InstanceId].LogVerbosity : PNLogVerbosity.NONE);
+                    LoggingMethod.WriteToLog(pubnubLog, string.Format(CultureInfo.InvariantCulture, "DateTime {0}, Network available for SubscribeManager Manual Reconnect", DateTime.Now.ToString(CultureInfo.InvariantCulture)), config.ContainsKey(PubnubInstance.InstanceId) ? config[PubnubInstance.InstanceId].LogVerbosity : PNLogVerbosity.NONE);
                     if (!string.IsNullOrEmpty(channel) && ChannelInternetStatus[PubnubInstance.InstanceId].ContainsKey(channel))
                     {
                         ChannelInternetStatus[PubnubInstance.InstanceId].AddOrUpdate(channel, networkConnection, (key, oldValue) => networkConnection);
@@ -981,7 +981,7 @@ namespace PubnubApi.EndPoint
                 }
                 else
                 {
-                    LoggingMethod.WriteToLog(pubnubLog, string.Format("DateTime {0}, No network for SubscribeManager Manual Reconnect", DateTime.Now.ToString(CultureInfo.InvariantCulture)), config.ContainsKey(PubnubInstance.InstanceId) ? config[PubnubInstance.InstanceId].LogVerbosity : PNLogVerbosity.NONE);
+                    LoggingMethod.WriteToLog(pubnubLog, string.Format(CultureInfo.InvariantCulture, "DateTime {0}, No network for SubscribeManager Manual Reconnect", DateTime.Now.ToString(CultureInfo.InvariantCulture)), config.ContainsKey(PubnubInstance.InstanceId) ? config[PubnubInstance.InstanceId].LogVerbosity : PNLogVerbosity.NONE);
 
                     PNStatusCategory errorCategory = PNStatusCategory.PNNetworkIssuesCategory;
                     PNStatus status = new StatusBuilder(config.ContainsKey(PubnubInstance.InstanceId) ? config[PubnubInstance.InstanceId] : null, jsonLibrary).CreateStatusResponse<T>(PNOperationType.PNSubscribeOperation, errorCategory, null, (int)HttpStatusCode.NotFound, new PNException("SDK Network related error"));
@@ -1000,12 +1000,12 @@ namespace PubnubApi.EndPoint
             }
             else
             {
-                LoggingMethod.WriteToLog(pubnubLog, string.Format("DateTime {0}, No channels/channelgroups for SubscribeManager Manual Reconnect", DateTime.Now.ToString(CultureInfo.InvariantCulture)), config.ContainsKey(PubnubInstance.InstanceId) ? config[PubnubInstance.InstanceId].LogVerbosity : PNLogVerbosity.NONE);
+                LoggingMethod.WriteToLog(pubnubLog, string.Format(CultureInfo.InvariantCulture, "DateTime {0}, No channels/channelgroups for SubscribeManager Manual Reconnect", DateTime.Now.ToString(CultureInfo.InvariantCulture)), config.ContainsKey(PubnubInstance.InstanceId) ? config[PubnubInstance.InstanceId].LogVerbosity : PNLogVerbosity.NONE);
                 return false;
             }
 
 
-            LoggingMethod.WriteToLog(pubnubLog, string.Format("DateTime {0}, SubscribeManager Manual Reconnect", DateTime.Now.ToString(CultureInfo.InvariantCulture)), config.ContainsKey(PubnubInstance.InstanceId) ? config[PubnubInstance.InstanceId].LogVerbosity : PNLogVerbosity.NONE);
+            LoggingMethod.WriteToLog(pubnubLog, string.Format(CultureInfo.InvariantCulture, "DateTime {0}, SubscribeManager Manual Reconnect", DateTime.Now.ToString(CultureInfo.InvariantCulture)), config.ContainsKey(PubnubInstance.InstanceId) ? config[PubnubInstance.InstanceId].LogVerbosity : PNLogVerbosity.NONE);
             SubscribeDisconnected[PubnubInstance.InstanceId] = false;
 
             Task.Factory.StartNew(() =>
@@ -1027,10 +1027,10 @@ namespace PubnubApi.EndPoint
             {
                 return false;
             }
-            LoggingMethod.WriteToLog(pubnubLog, string.Format("DateTime {0}, SubscribeManager Manual Disconnect", DateTime.Now.ToString(CultureInfo.InvariantCulture)), config.ContainsKey(PubnubInstance.InstanceId) ? config[PubnubInstance.InstanceId].LogVerbosity : PNLogVerbosity.NONE);
+            LoggingMethod.WriteToLog(pubnubLog, string.Format(CultureInfo.InvariantCulture, "DateTime {0}, SubscribeManager Manual Disconnect", DateTime.Now.ToString(CultureInfo.InvariantCulture)), config.ContainsKey(PubnubInstance.InstanceId) ? config[PubnubInstance.InstanceId].LogVerbosity : PNLogVerbosity.NONE);
             SubscribeDisconnected[PubnubInstance.InstanceId] = true;
             TerminateCurrentSubscriberRequest();
-            TerminatePresenceHeartbeatTimer();
+            PubnubCoreBase.TerminatePresenceHeartbeatTimer();
             TerminateReconnectTimer();
 
             return true;
@@ -1042,12 +1042,12 @@ namespace PubnubApi.EndPoint
             {
                 if (SubscribeDisconnected[PubnubInstance.InstanceId])
                 {
-                    LoggingMethod.WriteToLog(pubnubLog, string.Format("DateTime {0}, SubscribeManager - SubscribeDisconnected. No heartbeat check.", DateTime.Now.ToString(CultureInfo.InvariantCulture)), config.ContainsKey(PubnubInstance.InstanceId) ? config[PubnubInstance.InstanceId].LogVerbosity : PNLogVerbosity.NONE);
+                    LoggingMethod.WriteToLog(pubnubLog, string.Format(CultureInfo.InvariantCulture, "DateTime {0}, SubscribeManager - SubscribeDisconnected. No heartbeat check.", DateTime.Now.ToString(CultureInfo.InvariantCulture)), config.ContainsKey(PubnubInstance.InstanceId) ? config[PubnubInstance.InstanceId].LogVerbosity : PNLogVerbosity.NONE);
                     return;
                 }
                 if (!config.ContainsKey(PubnubInstance.InstanceId))
                 {
-                    LoggingMethod.WriteToLog(pubnubLog, string.Format("DateTime {0}, InstanceId Not Available. So No heartbeat check.", DateTime.Now.ToString(CultureInfo.InvariantCulture)), config.ContainsKey(PubnubInstance.InstanceId) ? config[PubnubInstance.InstanceId].LogVerbosity : PNLogVerbosity.NONE);
+                    LoggingMethod.WriteToLog(pubnubLog, string.Format(CultureInfo.InvariantCulture, "DateTime {0}, InstanceId Not Available. So No heartbeat check.", DateTime.Now.ToString(CultureInfo.InvariantCulture)), config.ContainsKey(PubnubInstance.InstanceId) ? config[PubnubInstance.InstanceId].LogVerbosity : PNLogVerbosity.NONE);
                     return;
                 }
 
@@ -1062,11 +1062,11 @@ namespace PubnubApi.EndPoint
                         DateTime lastSubscribeRequestTime = SubscribeRequestTracker[PubnubInstance.InstanceId];
                         if ((DateTime.Now - lastSubscribeRequestTime).TotalSeconds < config[PubnubInstance.InstanceId].SubscribeTimeout)
                         {
-                            LoggingMethod.WriteToLog(pubnubLog, string.Format("DateTime {0}, SubscribeManager - ok. expected subscribe within threshold limit of SubscribeTimeout. No action needed", DateTime.Now.ToString(CultureInfo.InvariantCulture)), config[PubnubInstance.InstanceId].LogVerbosity);
+                            LoggingMethod.WriteToLog(pubnubLog, string.Format(CultureInfo.InvariantCulture, "DateTime {0}, SubscribeManager - ok. expected subscribe within threshold limit of SubscribeTimeout. No action needed", DateTime.Now.ToString(CultureInfo.InvariantCulture)), config[PubnubInstance.InstanceId].LogVerbosity);
                         }
                         else if ((DateTime.Now - lastSubscribeRequestTime).TotalSeconds > 2 * (config[PubnubInstance.InstanceId].SubscribeTimeout - config[PubnubInstance.InstanceId].SubscribeTimeout/2))
                         {
-                            LoggingMethod.WriteToLog(pubnubLog, string.Format("DateTime {0}, SubscribeManager - **No auto subscribe within threshold limit of SubscribeTimeout**. Calling MultiChannelSubscribeRequest", DateTime.Now.ToString(CultureInfo.InvariantCulture)), config[PubnubInstance.InstanceId].LogVerbosity);
+                            LoggingMethod.WriteToLog(pubnubLog, string.Format(CultureInfo.InvariantCulture, "DateTime {0}, SubscribeManager - **No auto subscribe within threshold limit of SubscribeTimeout**. Calling MultiChannelSubscribeRequest", DateTime.Now.ToString(CultureInfo.InvariantCulture)), config[PubnubInstance.InstanceId].LogVerbosity);
                             Task.Factory.StartNew(() =>
                             {
                                 TerminateCurrentSubscriberRequest();
@@ -1075,7 +1075,7 @@ namespace PubnubApi.EndPoint
                         }
                         else
                         {
-                            LoggingMethod.WriteToLog(pubnubLog, string.Format("DateTime {0}, SubscribeManager - **No auto subscribe within threshold limit of SubscribeTimeout**. Calling TerminateCurrentSubscriberRequest", DateTime.Now.ToString(CultureInfo.InvariantCulture)), config[PubnubInstance.InstanceId].LogVerbosity);
+                            LoggingMethod.WriteToLog(pubnubLog, string.Format(CultureInfo.InvariantCulture, "DateTime {0}, SubscribeManager - **No auto subscribe within threshold limit of SubscribeTimeout**. Calling TerminateCurrentSubscriberRequest", DateTime.Now.ToString(CultureInfo.InvariantCulture)), config[PubnubInstance.InstanceId].LogVerbosity);
                             Task.Factory.StartNew(() =>
                             {
                                 TerminateCurrentSubscriberRequest();
@@ -1084,7 +1084,7 @@ namespace PubnubApi.EndPoint
                     }
                     else
                     {
-                        LoggingMethod.WriteToLog(pubnubLog, string.Format("DateTime {0}, SubscribeManager - StartSubscribeHeartbeatCheckCallback - No network or no pubnub instance mapping", DateTime.Now.ToString(CultureInfo.InvariantCulture)), config[PubnubInstance.InstanceId].LogVerbosity);
+                        LoggingMethod.WriteToLog(pubnubLog, string.Format(CultureInfo.InvariantCulture, "DateTime {0}, SubscribeManager - StartSubscribeHeartbeatCheckCallback - No network or no pubnub instance mapping", DateTime.Now.ToString(CultureInfo.InvariantCulture)), config[PubnubInstance.InstanceId].LogVerbosity);
                         if (PubnubInstance != null && !networkConnection)
                         {
                             PNStatus status = new StatusBuilder(config[PubnubInstance.InstanceId], jsonLibrary).CreateStatusResponse<T>(PNOperationType.PNSubscribeOperation, PNStatusCategory.PNNetworkIssuesCategory, null, (int)System.Net.HttpStatusCode.NotFound, new PNException("Internet connection problem during subscribe heartbeat."));
@@ -1108,7 +1108,7 @@ namespace PubnubApi.EndPoint
                 }
                 else
                 {
-                    LoggingMethod.WriteToLog(pubnubLog, string.Format("DateTime {0}, SubscribeManager - StartSubscribeHeartbeatCheckCallback - No channels/cgs avaialable", DateTime.Now.ToString(CultureInfo.InvariantCulture)), config[PubnubInstance.InstanceId].LogVerbosity);
+                    LoggingMethod.WriteToLog(pubnubLog, string.Format(CultureInfo.InvariantCulture, "DateTime {0}, SubscribeManager - StartSubscribeHeartbeatCheckCallback - No channels/cgs avaialable", DateTime.Now.ToString(CultureInfo.InvariantCulture)), config[PubnubInstance.InstanceId].LogVerbosity);
                     try
                     {
                         SubscribeHeartbeatCheckTimer.Change(Timeout.Infinite, Timeout.Infinite);
@@ -1119,7 +1119,7 @@ namespace PubnubApi.EndPoint
             }
             catch (Exception ex)
             {
-                LoggingMethod.WriteToLog(pubnubLog, string.Format("DateTime {0}, SubscribeManager - StartSubscribeHeartbeatCheckCallback - EXCEPTION: {1}", DateTime.Now.ToString(CultureInfo.InvariantCulture),ex), config[PubnubInstance.InstanceId].LogVerbosity);
+                LoggingMethod.WriteToLog(pubnubLog, string.Format(CultureInfo.InvariantCulture, "DateTime {0}, SubscribeManager - StartSubscribeHeartbeatCheckCallback - EXCEPTION: {1}", DateTime.Now.ToString(CultureInfo.InvariantCulture),ex), config[PubnubInstance.InstanceId].LogVerbosity);
             }
         }
 
@@ -1203,7 +1203,7 @@ namespace PubnubApi.EndPoint
                                 ConnectionErrors++;
                                 UpdatePubnubNetworkTcpCheckIntervalInSeconds();
 
-                                LoggingMethod.WriteToLog(pubnubLog, string.Format("DateTime {0}, channel={1} {2} reconnectNetworkCallback. Retry", DateTime.Now.ToString(CultureInfo.InvariantCulture), channel, netState.ResponseType), config.ContainsKey(PubnubInstance.InstanceId) ? config[PubnubInstance.InstanceId].LogVerbosity : PNLogVerbosity.NONE);
+                                LoggingMethod.WriteToLog(pubnubLog, string.Format(CultureInfo.InvariantCulture, "DateTime {0}, channel={1} {2} reconnectNetworkCallback. Retry", DateTime.Now.ToString(CultureInfo.InvariantCulture), channel, netState.ResponseType), config.ContainsKey(PubnubInstance.InstanceId) ? config[PubnubInstance.InstanceId].LogVerbosity : PNLogVerbosity.NONE);
 
                                 if (netState.Channels != null && netState.Channels.Length > 0)
                                 {
@@ -1226,7 +1226,7 @@ namespace PubnubApi.EndPoint
                         {
                             if (ChannelReconnectTimer[PubnubInstance.InstanceId].ContainsKey(channel))
                             {
-                                LoggingMethod.WriteToLog(pubnubLog, string.Format("DateTime {0}, {1} {2} terminating ch reconnectimer", DateTime.Now.ToString(CultureInfo.InvariantCulture), channel, netState.ResponseType), config.ContainsKey(PubnubInstance.InstanceId) ? config[PubnubInstance.InstanceId].LogVerbosity : PNLogVerbosity.NONE);
+                                LoggingMethod.WriteToLog(pubnubLog, string.Format(CultureInfo.InvariantCulture, "DateTime {0}, {1} {2} terminating ch reconnectimer", DateTime.Now.ToString(CultureInfo.InvariantCulture), channel, netState.ResponseType), config.ContainsKey(PubnubInstance.InstanceId) ? config[PubnubInstance.InstanceId].LogVerbosity : PNLogVerbosity.NONE);
                                 TerminateReconnectTimer();
                             }
 
@@ -1241,7 +1241,7 @@ namespace PubnubApi.EndPoint
                             }
                             Announce(status);
 
-                            LoggingMethod.WriteToLog(pubnubLog, string.Format("DateTime {0}, channel={1} {2} reconnectNetworkCallback. Internet Available : {3}", DateTime.Now.ToString(CultureInfo.InvariantCulture), channel, netState.ResponseType, channelInternetFlag.ToString()), config.ContainsKey(PubnubInstance.InstanceId) ? config[PubnubInstance.InstanceId].LogVerbosity : PNLogVerbosity.NONE);
+                            LoggingMethod.WriteToLog(pubnubLog, string.Format(CultureInfo.InvariantCulture, "DateTime {0}, channel={1} {2} reconnectNetworkCallback. Internet Available : {3}", DateTime.Now.ToString(CultureInfo.InvariantCulture), channel, netState.ResponseType, channelInternetFlag.ToString()), config.ContainsKey(PubnubInstance.InstanceId) ? config[PubnubInstance.InstanceId].LogVerbosity : PNLogVerbosity.NONE);
                             switch (netState.ResponseType)
                             {
                                 case PNOperationType.PNSubscribeOperation:
@@ -1280,7 +1280,7 @@ namespace PubnubApi.EndPoint
                                     ChannelInternetStatus[PubnubInstance.InstanceId].AddOrUpdate(channel, networkConnection, (key, oldValue) => networkConnection);
                                 }
 
-                                LoggingMethod.WriteToLog(pubnubLog, string.Format("DateTime {0}, channelgroup={1} {2} reconnectNetworkCallback. Retrying", DateTime.Now.ToString(CultureInfo.InvariantCulture), channelGroup, netState.ResponseType), config.ContainsKey(PubnubInstance.InstanceId) ? config[PubnubInstance.InstanceId].LogVerbosity : PNLogVerbosity.NONE);
+                                LoggingMethod.WriteToLog(pubnubLog, string.Format(CultureInfo.InvariantCulture, "DateTime {0}, channelgroup={1} {2} reconnectNetworkCallback. Retrying", DateTime.Now.ToString(CultureInfo.InvariantCulture), channelGroup, netState.ResponseType), config.ContainsKey(PubnubInstance.InstanceId) ? config[PubnubInstance.InstanceId].LogVerbosity : PNLogVerbosity.NONE);
 
                                 if (netState.ChannelGroups != null && netState.ChannelGroups.Length > 0)
                                 {
@@ -1302,7 +1302,7 @@ namespace PubnubApi.EndPoint
                         {
                             if (ChannelGroupReconnectTimer[PubnubInstance.InstanceId].ContainsKey(channelGroup))
                             {
-                                LoggingMethod.WriteToLog(pubnubLog, string.Format("DateTime {0}, {1} {2} terminating cg reconnectimer", DateTime.Now.ToString(CultureInfo.InvariantCulture), channelGroup, netState.ResponseType), config.ContainsKey(PubnubInstance.InstanceId) ? config[PubnubInstance.InstanceId].LogVerbosity : PNLogVerbosity.NONE);
+                                LoggingMethod.WriteToLog(pubnubLog, string.Format(CultureInfo.InvariantCulture, "DateTime {0}, {1} {2} terminating cg reconnectimer", DateTime.Now.ToString(CultureInfo.InvariantCulture), channelGroup, netState.ResponseType), config.ContainsKey(PubnubInstance.InstanceId) ? config[PubnubInstance.InstanceId].LogVerbosity : PNLogVerbosity.NONE);
                                 TerminateReconnectTimer();
                             }
 
@@ -1321,7 +1321,7 @@ namespace PubnubApi.EndPoint
                                 Announce(status);
                             }
 
-                            LoggingMethod.WriteToLog(pubnubLog, string.Format("DateTime {0}, channelgroup={1} {2} reconnectNetworkCallback. Internet Available", DateTime.Now.ToString(CultureInfo.InvariantCulture), channelGroup, netState.ResponseType), config.ContainsKey(PubnubInstance.InstanceId) ? config[PubnubInstance.InstanceId].LogVerbosity : PNLogVerbosity.NONE);
+                            LoggingMethod.WriteToLog(pubnubLog, string.Format(CultureInfo.InvariantCulture, "DateTime {0}, channelgroup={1} {2} reconnectNetworkCallback. Internet Available", DateTime.Now.ToString(CultureInfo.InvariantCulture), channelGroup, netState.ResponseType), config.ContainsKey(PubnubInstance.InstanceId) ? config[PubnubInstance.InstanceId].LogVerbosity : PNLogVerbosity.NONE);
                             switch (netState.ResponseType)
                             {
                                 case PNOperationType.PNSubscribeOperation:
@@ -1336,7 +1336,7 @@ namespace PubnubApi.EndPoint
                 }
                 else
                 {
-                    LoggingMethod.WriteToLog(pubnubLog, string.Format("DateTime {0}, Unknown request state in reconnectNetworkCallback", DateTime.Now.ToString(CultureInfo.InvariantCulture)), config.ContainsKey(PubnubInstance.InstanceId) ? config[PubnubInstance.InstanceId].LogVerbosity : PNLogVerbosity.NONE);
+                    LoggingMethod.WriteToLog(pubnubLog, string.Format(CultureInfo.InvariantCulture, "DateTime {0}, Unknown request state in reconnectNetworkCallback", DateTime.Now.ToString(CultureInfo.InvariantCulture)), config.ContainsKey(PubnubInstance.InstanceId) ? config[PubnubInstance.InstanceId].LogVerbosity : PNLogVerbosity.NONE);
                 }
             }
             catch (Exception ex)
@@ -1356,7 +1356,7 @@ namespace PubnubApi.EndPoint
                     Announce(status);
                 }
 
-                LoggingMethod.WriteToLog(pubnubLog, string.Format("DateTime {0} method:reconnectNetworkCallback \n Exception Details={1}", DateTime.Now.ToString(CultureInfo.InvariantCulture), ex), config.ContainsKey(PubnubInstance.InstanceId) ? config[PubnubInstance.InstanceId].LogVerbosity : PNLogVerbosity.NONE);
+                LoggingMethod.WriteToLog(pubnubLog, string.Format(CultureInfo.InvariantCulture, "DateTime {0} method:reconnectNetworkCallback \n Exception Details={1}", DateTime.Now.ToString(CultureInfo.InvariantCulture), ex), config.ContainsKey(PubnubInstance.InstanceId) ? config[PubnubInstance.InstanceId].LogVerbosity : PNLogVerbosity.NONE);
             }
         }
 

--- a/src/Api/PubnubApi/EndPoint/PubSub/SubscribeOperation.cs
+++ b/src/Api/PubnubApi/EndPoint/PubSub/SubscribeOperation.cs
@@ -87,9 +87,9 @@ namespace PubnubApi.EndPoint
             if (this.presenceSubscribeEnabled)
             {
                 List<string> presenceChannelNames = (this.subscribeChannelNames != null && this.subscribeChannelNames.Count > 0 && !string.IsNullOrEmpty(this.subscribeChannelNames[0])) 
-                                                ? this.subscribeChannelNames.Select(c => string.Format("{0}-pnpres",c)).ToList() : new List<string>();
+                                                ? this.subscribeChannelNames.Select(c => string.Format(CultureInfo.InvariantCulture, "{0}-pnpres", c)).ToList() : new List<string>();
                 List<string> presenceChannelGroupNames = (this.subscribeChannelGroupNames != null && this.subscribeChannelGroupNames.Count > 0 && !string.IsNullOrEmpty(this.subscribeChannelGroupNames[0])) 
-                                                ? this.subscribeChannelGroupNames.Select(c => string.Format("{0}-pnpres", c)).ToList() : new List<string>();
+                                                ? this.subscribeChannelGroupNames.Select(c => string.Format(CultureInfo.InvariantCulture, "{0}-pnpres", c)).ToList() : new List<string>();
 
                 if (this.subscribeChannelNames != null && presenceChannelNames.Count > 0)
                 {
@@ -120,12 +120,12 @@ namespace PubnubApi.EndPoint
 
             PNPlatform.Print(config, pubnubLog);
 
-            LoggingMethod.WriteToLog(pubnubLog, string.Format("DateTime {0}, requested subscribe for channel(s)={1} and channel group(s)={2}", DateTime.Now.ToString(CultureInfo.InvariantCulture), channel, channelGroup), config.LogVerbosity);
+            LoggingMethod.WriteToLog(pubnubLog, string.Format(CultureInfo.InvariantCulture, "DateTime {0}, requested subscribe for channel(s)={1} and channel group(s)={2}", DateTime.Now.ToString(CultureInfo.InvariantCulture), channel, channelGroup), config.LogVerbosity);
 
             Dictionary<string, string> initialSubscribeUrlParams = new Dictionary<string, string>();
             if (this.subscribeTimetoken >= 0)
             {
-                initialSubscribeUrlParams.Add("tt", this.subscribeTimetoken.ToString());
+                initialSubscribeUrlParams.Add("tt", this.subscribeTimetoken.ToString(CultureInfo.InvariantCulture));
             }
             if (!string.IsNullOrEmpty(config.FilterExpression) && config.FilterExpression.Trim().Length > 0)
             {

--- a/src/Api/PubnubApi/EndPoint/PubSub/UnsubscribeOperation.cs
+++ b/src/Api/PubnubApi/EndPoint/PubSub/UnsubscribeOperation.cs
@@ -64,7 +64,7 @@ namespace PubnubApi.EndPoint
             string channel = (channels != null) ? string.Join(",", channels.OrderBy(x => x).ToArray()) : "";
             string channelGroup = (channelGroups != null) ? string.Join(",", channelGroups.OrderBy(x => x).ToArray()) : "";
 
-            LoggingMethod.WriteToLog(pubnubLog, string.Format("DateTime {0}, requested unsubscribe for channel(s)={1}, cg(s)={2}", DateTime.Now.ToString(CultureInfo.InvariantCulture), channel, channelGroup), config.LogVerbosity);
+            LoggingMethod.WriteToLog(pubnubLog, string.Format(CultureInfo.InvariantCulture, "DateTime {0}, requested unsubscribe for channel(s)={1}, cg(s)={2}", DateTime.Now.ToString(CultureInfo.InvariantCulture), channel, channelGroup), config.LogVerbosity);
 
 #if NETFX_CORE || WINDOWS_UWP || UAP || NETSTANDARD10 || NETSTANDARD11 || NETSTANDARD12
             Task.Factory.StartNew(() =>

--- a/src/Api/PubnubApi/EndPoint/TelemetryManager.cs
+++ b/src/Api/PubnubApi/EndPoint/TelemetryManager.cs
@@ -180,12 +180,12 @@ namespace PubnubApi.EndPoint
                                 dicEndpointLatency.AddOrUpdate(latencyEndPoint, elapsedInfo, (o, n) => elapsedInfo);
                             }
                         }
-                        LoggingMethod.WriteToLog(pubnubLog, string.Format("DateTime {0}, TelemetryManager - StoreLatency {1} latency = {2}", DateTime.Now.ToString(CultureInfo.InvariantCulture), type, latencyMillisec), pubnubConfig.LogVerbosity);
+                        LoggingMethod.WriteToLog(pubnubLog, string.Format(CultureInfo.InvariantCulture, "DateTime {0}, TelemetryManager - StoreLatency {1} latency = {2}", DateTime.Now.ToString(CultureInfo.InvariantCulture), type, latencyMillisec), pubnubConfig.LogVerbosity);
                     }
                 }
                 catch (Exception ex)
                 {
-                    LoggingMethod.WriteToLog(pubnubLog, string.Format("DateTime {0}, TelemetryManager - StoreLatency error: {1}", DateTime.Now.ToString(CultureInfo.InvariantCulture), ex), pubnubConfig.LogVerbosity);
+                    LoggingMethod.WriteToLog(pubnubLog, string.Format(CultureInfo.InvariantCulture, "DateTime {0}, TelemetryManager - StoreLatency error: {1}", DateTime.Now.ToString(CultureInfo.InvariantCulture), ex), pubnubConfig.LogVerbosity);
                 }
             }, CancellationToken.None, TaskCreationOptions.PreferFairness, TaskScheduler.Default).ConfigureAwait(false);
         }
@@ -214,7 +214,7 @@ namespace PubnubApi.EndPoint
                     }
                     catch (Exception ex)
                     {
-                        LoggingMethod.WriteToLog(pubnubLog, string.Format("DateTime {0}, TelemetryManager - GetOperationsLatency error: {1}", DateTime.Now.ToString(CultureInfo.InvariantCulture), ex), pubnubConfig.LogVerbosity);
+                        LoggingMethod.WriteToLog(pubnubLog, string.Format(CultureInfo.InvariantCulture, "DateTime {0}, TelemetryManager - GetOperationsLatency error: {1}", DateTime.Now.ToString(CultureInfo.InvariantCulture), ex), pubnubConfig.LogVerbosity);
                     }
                     return dictionaryOpsLatency;
                 }, CancellationToken.None, TaskCreationOptions.None, TaskScheduler.Default).ConfigureAwait(false);
@@ -243,7 +243,7 @@ namespace PubnubApi.EndPoint
                                     Dictionary<double, long> dicOutdatedLatencies = enumerableOutdatedLatencies.ToDictionary(item => item.Key, item => item.Value);
                                     if (dicOutdatedLatencies != null && dicOutdatedLatencies.Count > 0)
                                     {
-                                        LoggingMethod.WriteToLog(pubnubLog, string.Format("DateTime {0}, TelemetryManager - CleanupTelemetryData => {1} dicOutdatedLatencies count = {2}", DateTime.Now.ToString(CultureInfo.InvariantCulture), opKey, dicOutdatedLatencies.Count), pubnubConfig.LogVerbosity);
+                                        LoggingMethod.WriteToLog(pubnubLog, string.Format(CultureInfo.InvariantCulture, "DateTime {0}, TelemetryManager - CleanupTelemetryData => {1} dicOutdatedLatencies count = {2}", DateTime.Now.ToString(CultureInfo.InvariantCulture), opKey, dicOutdatedLatencies.Count), pubnubConfig.LogVerbosity);
                                         double[] outLatencyKeys = dicOutdatedLatencies.Keys.ToArray<double>();
                                         for (int outdateIndex = 0; outdateIndex < outLatencyKeys.Length; outdateIndex++)
                                         {
@@ -255,7 +255,7 @@ namespace PubnubApi.EndPoint
                                                 long removeOutdatedLatency;
                                                 if (!currentEndPointLatency.TryRemove(outKey, out removeOutdatedLatency))
                                                 {
-                                                    LoggingMethod.WriteToLog(pubnubLog, string.Format("DateTime {0}, TelemetryManager - CleanupTelemetryData => removed failed for key = {1}", DateTime.Now.ToString(CultureInfo.InvariantCulture), outKey), pubnubConfig.LogVerbosity);
+                                                    LoggingMethod.WriteToLog(pubnubLog, string.Format(CultureInfo.InvariantCulture, "DateTime {0}, TelemetryManager - CleanupTelemetryData => removed failed for key = {1}", DateTime.Now.ToString(CultureInfo.InvariantCulture), outKey), pubnubConfig.LogVerbosity);
                                                 }
                                             }
                                         }
@@ -266,7 +266,7 @@ namespace PubnubApi.EndPoint
                     }
                     catch (Exception ex)
                     {
-                        LoggingMethod.WriteToLog(pubnubLog, string.Format("DateTime {0}, TelemetryManager - CleanupTelemetryData => Exception = {1}", DateTime.Now.ToString(CultureInfo.InvariantCulture), ex), pubnubConfig.LogVerbosity);
+                        LoggingMethod.WriteToLog(pubnubLog, string.Format(CultureInfo.InvariantCulture, "DateTime {0}, TelemetryManager - CleanupTelemetryData => Exception = {1}", DateTime.Now.ToString(CultureInfo.InvariantCulture), ex), pubnubConfig.LogVerbosity);
                     }
                 }
             }, CancellationToken.None, TaskCreationOptions.PreferFairness, TaskScheduler.Default).ConfigureAwait(false);

--- a/src/Api/PubnubApi/EndPoint/TokenManager.cs
+++ b/src/Api/PubnubApi/EndPoint/TokenManager.cs
@@ -70,11 +70,11 @@ namespace PubnubApi.EndPoint
                 {
                     string refinedToken = token.Replace('_', '/').Replace('-', '+');
                     byte[] tokenByteArray = Convert.FromBase64String(refinedToken);
-                    LoggingMethod.WriteToLog(pubnubLog, string.Format("DateTime {0} Token Bytes = {1}", DateTime.Now.ToString(System.Globalization.CultureInfo.InvariantCulture), GetDisplayableBytes(tokenByteArray)), PNLogVerbosity.BODY);
+                    LoggingMethod.WriteToLog(pubnubLog, string.Format(CultureInfo.InvariantCulture, "DateTime {0} Token Bytes = {1}", DateTime.Now.ToString(System.Globalization.CultureInfo.InvariantCulture), GetDisplayableBytes(tokenByteArray)), PNLogVerbosity.BODY);
                     using (System.IO.MemoryStream ms = new System.IO.MemoryStream(tokenByteArray))
                     {
                         CBORObject cborObj = CBORObject.DecodeFromBytes(tokenByteArray);
-                        LoggingMethod.WriteToLog(pubnubLog, string.Format("DateTime {0}, RAW CBOR {1}", DateTime.Now.ToString(CultureInfo.InvariantCulture), cborObj.ToJSONString()), (pubnubConfig != null) ? pubnubConfig.LogVerbosity : PNLogVerbosity.NONE);
+                        LoggingMethod.WriteToLog(pubnubLog, string.Format(CultureInfo.InvariantCulture, "DateTime {0}, RAW CBOR {1}", DateTime.Now.ToString(CultureInfo.InvariantCulture), cborObj.ToJSONString()), (pubnubConfig != null) ? pubnubConfig.LogVerbosity : PNLogVerbosity.NONE);
 
                         if (cborObj != null)
                         {
@@ -118,7 +118,7 @@ namespace PubnubApi.EndPoint
         {
             foreach (KeyValuePair<CBORObject, CBORObject> kvp in cbor.Entries)
             {
-                if (kvp.Key.Type.ToString().Equals("ByteString"))
+                if (kvp.Key.Type.ToString().Equals("ByteString", StringComparison.OrdinalIgnoreCase))
                 {
 #if NETSTANDARD10 || NETSTANDARD11
                     UTF8Encoding utf8 = new UTF8Encoding(true, true);
@@ -129,14 +129,14 @@ namespace PubnubApi.EndPoint
 #endif
                     ParseCBORValue(key, parent, kvp, ref pnGrantTokenDecoded);
                 }
-                else if (kvp.Key.Type.ToString().Equals("TextString"))
+                else if (kvp.Key.Type.ToString().Equals("TextString", StringComparison.OrdinalIgnoreCase))
                 {
-                    LoggingMethod.WriteToLog(pubnubLog, string.Format("DateTime {0}, TextString Key {1}-{2}-{3}", DateTime.Now.ToString(CultureInfo.InvariantCulture), kvp.Key.ToString(), kvp.Value.ToString(), kvp.Value.Type), (pubnubConfig != null) ? pubnubConfig.LogVerbosity : PNLogVerbosity.NONE);
+                    LoggingMethod.WriteToLog(pubnubLog, string.Format(CultureInfo.InvariantCulture, "DateTime {0}, TextString Key {1}-{2}-{3}", DateTime.Now.ToString(CultureInfo.InvariantCulture), kvp.Key.ToString(), kvp.Value.ToString(), kvp.Value.Type), (pubnubConfig != null) ? pubnubConfig.LogVerbosity : PNLogVerbosity.NONE);
                     ParseCBORValue(kvp.Key.ToString(), parent, kvp, ref pnGrantTokenDecoded);
                 }
                 else
                 {
-                    LoggingMethod.WriteToLog(pubnubLog, string.Format("DateTime {0}, Others Key {1}-{2}-{3}-{4}", DateTime.Now.ToString(CultureInfo.InvariantCulture), kvp.Key, kvp.Key.Type, kvp.Value, kvp.Value.Type), (pubnubConfig != null) ? pubnubConfig.LogVerbosity : PNLogVerbosity.NONE);
+                    LoggingMethod.WriteToLog(pubnubLog, string.Format(CultureInfo.InvariantCulture, "DateTime {0}, Others Key {1}-{2}-{3}-{4}", DateTime.Now.ToString(CultureInfo.InvariantCulture), kvp.Key, kvp.Key.Type, kvp.Value, kvp.Value.Type), (pubnubConfig != null) ? pubnubConfig.LogVerbosity : PNLogVerbosity.NONE);
                 }
 
             }
@@ -144,13 +144,13 @@ namespace PubnubApi.EndPoint
 
         private void ParseCBORValue(string key, string parent, KeyValuePair<CBORObject, CBORObject> kvp, ref PNTokenContent pnGrantTokenDecoded)
         {
-            if (kvp.Value.Type.ToString().Equals("Map"))
+            if (kvp.Value.Type.ToString().Equals("Map", StringComparison.OrdinalIgnoreCase))
             {
-                LoggingMethod.WriteToLog(pubnubLog, string.Format("DateTime {0}, Map Key {1}", DateTime.Now.ToString(CultureInfo.InvariantCulture), key), (pubnubConfig != null) ? pubnubConfig.LogVerbosity : PNLogVerbosity.NONE);
-                var p = string.Format("{0}{1}{2}", parent, string.IsNullOrEmpty(parent) ? "" : ":", key);
+                LoggingMethod.WriteToLog(pubnubLog, string.Format(CultureInfo.InvariantCulture, "DateTime {0}, Map Key {1}", DateTime.Now.ToString(CultureInfo.InvariantCulture), key), (pubnubConfig != null) ? pubnubConfig.LogVerbosity : PNLogVerbosity.NONE);
+                var p = string.Format(CultureInfo.InvariantCulture, "{0}{1}{2}", parent, string.IsNullOrEmpty(parent) ? "" : ":", key);
                 ParseCBOR(kvp.Value, p, ref pnGrantTokenDecoded);
             }
-            else if (kvp.Value.Type.ToString().Equals("ByteString"))
+            else if (kvp.Value.Type.ToString().Equals("ByteString", StringComparison.OrdinalIgnoreCase))
             {
 #if NETSTANDARD10 || NETSTANDARD11
                     UTF8Encoding utf8 = new UTF8Encoding(true, true);
@@ -159,30 +159,30 @@ namespace PubnubApi.EndPoint
 #else
                 string val = System.Text.Encoding.ASCII.GetString(kvp.Value.GetByteString());
 #endif
-                LoggingMethod.WriteToLog(pubnubLog, string.Format("DateTime {0}, ByteString Value {1}-{2}", DateTime.Now.ToString(CultureInfo.InvariantCulture), key, val), (pubnubConfig != null) ? pubnubConfig.LogVerbosity : PNLogVerbosity.NONE);
+                LoggingMethod.WriteToLog(pubnubLog, string.Format(CultureInfo.InvariantCulture, "DateTime {0}, ByteString Value {1}-{2}", DateTime.Now.ToString(CultureInfo.InvariantCulture), key, val), (pubnubConfig != null) ? pubnubConfig.LogVerbosity : PNLogVerbosity.NONE);
                 FillGrantToken(parent, key, kvp.Value, typeof(string), ref pnGrantTokenDecoded);
             }
-            else if (kvp.Value.Type.ToString().Equals("Integer"))
+            else if (kvp.Value.Type.ToString().Equals("Integer", StringComparison.OrdinalIgnoreCase))
             {
-                LoggingMethod.WriteToLog(pubnubLog, string.Format("DateTime {0}, Integer Value {1}-{2}", DateTime.Now.ToString(CultureInfo.InvariantCulture), key, kvp.Value), (pubnubConfig != null) ? pubnubConfig.LogVerbosity : PNLogVerbosity.NONE);
+                LoggingMethod.WriteToLog(pubnubLog, string.Format(CultureInfo.InvariantCulture, "DateTime {0}, Integer Value {1}-{2}", DateTime.Now.ToString(CultureInfo.InvariantCulture), key, kvp.Value), (pubnubConfig != null) ? pubnubConfig.LogVerbosity : PNLogVerbosity.NONE);
                 FillGrantToken(parent, key, kvp.Value, typeof(int), ref pnGrantTokenDecoded);
             }
-            else if (kvp.Value.Type.ToString().Equals("TextString"))
+            else if (kvp.Value.Type.ToString().Equals("TextString", StringComparison.OrdinalIgnoreCase))
             {
-                LoggingMethod.WriteToLog(pubnubLog, string.Format("DateTime {0}, TextString Value {1}-{2}", DateTime.Now.ToString(CultureInfo.InvariantCulture), key, kvp.Value), (pubnubConfig != null) ? pubnubConfig.LogVerbosity : PNLogVerbosity.NONE);
+                LoggingMethod.WriteToLog(pubnubLog, string.Format(CultureInfo.InvariantCulture, "DateTime {0}, TextString Value {1}-{2}", DateTime.Now.ToString(CultureInfo.InvariantCulture), key, kvp.Value), (pubnubConfig != null) ? pubnubConfig.LogVerbosity : PNLogVerbosity.NONE);
                 FillGrantToken(parent, key, kvp.Value, typeof(string), ref pnGrantTokenDecoded);
             }
             else
             {
-                LoggingMethod.WriteToLog(pubnubLog, string.Format("DateTime {0}, Others Key Value {1}-{2}-{3}-{4}", DateTime.Now.ToString(CultureInfo.InvariantCulture), kvp.Key.Type, kvp.Value.Type, key, kvp.Value), (pubnubConfig != null) ? pubnubConfig.LogVerbosity : PNLogVerbosity.NONE);
+                LoggingMethod.WriteToLog(pubnubLog, string.Format(CultureInfo.InvariantCulture, "DateTime {0}, Others Key Value {1}-{2}-{3}-{4}", DateTime.Now.ToString(CultureInfo.InvariantCulture), kvp.Key.Type, kvp.Value.Type, key, kvp.Value), (pubnubConfig != null) ? pubnubConfig.LogVerbosity : PNLogVerbosity.NONE);
             }
         }
 
         private string ReplaceBoundaryQuotes(string key)
         {
             if (key != null && !string.IsNullOrEmpty(key) && key.Length >= 2 
-                && key.Substring(0, 1).CompareTo("\"") == 0
-                && key.Substring(key.Length - 1, 1).CompareTo("\"") == 0)
+                && string.Equals(key.Substring(0, 1), "\"", StringComparison.OrdinalIgnoreCase)
+                && string.Equals(key.Substring(key.Length - 1, 1), "\"", StringComparison.OrdinalIgnoreCase))
             {
                 key = key.Remove(key.Length - 1, 1).Remove(0, 1);
                 key = Regex.Unescape(key);

--- a/src/Api/PubnubApi/HttpUtility/HttpUtility.cs
+++ b/src/Api/PubnubApi/HttpUtility/HttpUtility.cs
@@ -10,7 +10,7 @@ namespace PubnubApi
             string queryResult = "";
             if (query == null)
             {
-                throw new ArgumentNullException("query");
+                throw new ArgumentNullException(nameof(query), "invalid.");
             }
 
             if ((query.Length > 0) && (query[0] == '?'))

--- a/src/Api/PubnubApi/JsonDataParse/PNChannelMembersJsonDataParse.cs
+++ b/src/Api/PubnubApi/JsonDataParse/PNChannelMembersJsonDataParse.cs
@@ -67,7 +67,7 @@ namespace PubnubApi
                     else if (dicObj.ContainsKey("totalCount") && dicObj["totalCount"] != null)
                     {
                         int usersCount;
-                        Int32.TryParse(dicObj["totalCount"].ToString(), out usersCount);
+                        var _ = Int32.TryParse(dicObj["totalCount"].ToString(), out usersCount);
                         result.TotalCount = usersCount;
                     }
                     else if (dicObj.ContainsKey("next") && dicObj["next"] != null)

--- a/src/Api/PubnubApi/JsonDataParse/PNGetAllChannelMetadataJsonDataParse.cs
+++ b/src/Api/PubnubApi/JsonDataParse/PNGetAllChannelMetadataJsonDataParse.cs
@@ -71,7 +71,7 @@ namespace PubnubApi
                     else if (dicObj.ContainsKey("totalCount") && dicObj["totalCount"] != null)
                     {
                         int chMetadataCount;
-                        Int32.TryParse(dicObj["totalCount"].ToString(), out chMetadataCount);
+                        var _ = Int32.TryParse(dicObj["totalCount"].ToString(), out chMetadataCount);
                         result.TotalCount = chMetadataCount;
                     }
                     else if (dicObj.ContainsKey("next") && dicObj["next"] != null)

--- a/src/Api/PubnubApi/JsonDataParse/PNGetAllUuidMetadataJsonDataParse.cs
+++ b/src/Api/PubnubApi/JsonDataParse/PNGetAllUuidMetadataJsonDataParse.cs
@@ -75,7 +75,7 @@ namespace PubnubApi
                     else if (dicObj.ContainsKey("totalCount") && dicObj["totalCount"] != null)
                     {
                         int usersCount;
-                        Int32.TryParse(dicObj["totalCount"].ToString(), out usersCount);
+                        var _ = Int32.TryParse(dicObj["totalCount"].ToString(), out usersCount);
                         result.TotalCount = usersCount;
                     }
                     else if (dicObj.ContainsKey("next") && dicObj["next"] != null)

--- a/src/Api/PubnubApi/JsonDataParse/PNMembershipsJsonDataParse.cs
+++ b/src/Api/PubnubApi/JsonDataParse/PNMembershipsJsonDataParse.cs
@@ -65,7 +65,7 @@ namespace PubnubApi
                     else if (dicObj.ContainsKey("totalCount") && dicObj["totalCount"] != null)
                     {
                         int usersCount;
-                        Int32.TryParse(dicObj["totalCount"].ToString(), out usersCount);
+                        var _ = Int32.TryParse(dicObj["totalCount"].ToString(), out usersCount);
                         result.TotalCount = usersCount;
                     }
                     else if (dicObj.ContainsKey("next") && dicObj["next"] != null)

--- a/src/Api/PubnubApi/JsonDataParse/PNPublishFileMessageJsonDataParse.cs
+++ b/src/Api/PubnubApi/JsonDataParse/PNPublishFileMessageJsonDataParse.cs
@@ -14,7 +14,7 @@ namespace PubnubApi
             if (listObject.Count >= 2)
             {
                 long publishTimetoken;
-                Int64.TryParse(listObject[2].ToString(), out publishTimetoken);
+                var _ = Int64.TryParse(listObject[2].ToString(), out publishTimetoken);
                 result = new PNPublishFileMessageResult
                 {
                     Timetoken = publishTimetoken

--- a/src/Api/PubnubApi/JsonDataParse/PNRemoveMessageActionJsonDataParse.cs
+++ b/src/Api/PubnubApi/JsonDataParse/PNRemoveMessageActionJsonDataParse.cs
@@ -14,7 +14,7 @@ namespace PubnubApi
             if (removeMsgActionDicObj != null && removeMsgActionDicObj.ContainsKey("status"))
             {
                 int status;
-                int.TryParse(removeMsgActionDicObj["status"].ToString(), out status);
+                var _ = int.TryParse(removeMsgActionDicObj["status"].ToString(), out status);
                 if (status == 200)
                 {
                     result = new PNRemoveMessageActionResult();

--- a/src/Api/PubnubApi/Log/PNPlatform.cs
+++ b/src/Api/PubnubApi/Log/PNPlatform.cs
@@ -11,39 +11,39 @@ namespace PubnubApi
         public static void Print(PNConfiguration config, IPubnubLog log)
         {
 #if NETSTANDARD10
-                        LoggingMethod.WriteToLog(log, string.Format("DateTime {0} PLATFORM = NETSTANDARD10", DateTime.Now.ToString(CultureInfo.InvariantCulture)), config.LogVerbosity);
+                        LoggingMethod.WriteToLog(log, string.Format(CultureInfo.InvariantCulture, "DateTime {0} PLATFORM = NETSTANDARD10", DateTime.Now.ToString(CultureInfo.InvariantCulture)), config.LogVerbosity);
 #elif NETSTANDARD11
-                        LoggingMethod.WriteToLog(log, string.Format("DateTime {0} PLATFORM = NETSTANDARD11", DateTime.Now.ToString(CultureInfo.InvariantCulture)), config.LogVerbosity);
+                        LoggingMethod.WriteToLog(log, string.Format(CultureInfo.InvariantCulture, "DateTime {0} PLATFORM = NETSTANDARD11", DateTime.Now.ToString(CultureInfo.InvariantCulture)), config.LogVerbosity);
 #elif NETSTANDARD12
-                        LoggingMethod.WriteToLog(log, string.Format("DateTime {0} PLATFORM = NETSTANDARD12", DateTime.Now.ToString(CultureInfo.InvariantCulture)), config.LogVerbosity);
+                        LoggingMethod.WriteToLog(log, string.Format(CultureInfo.InvariantCulture, "DateTime {0} PLATFORM = NETSTANDARD12", DateTime.Now.ToString(CultureInfo.InvariantCulture)), config.LogVerbosity);
 #elif NETSTANDARD13
-                        LoggingMethod.WriteToLog(log, string.Format("DateTime {0} PLATFORM = NETSTANDARD13", DateTime.Now.ToString(CultureInfo.InvariantCulture)), config.LogVerbosity);
+                        LoggingMethod.WriteToLog(log, string.Format(CultureInfo.InvariantCulture, "DateTime {0} PLATFORM = NETSTANDARD13", DateTime.Now.ToString(CultureInfo.InvariantCulture)), config.LogVerbosity);
 #elif NETSTANDARD14
-                        LoggingMethod.WriteToLog(log, string.Format("DateTime {0} PLATFORM = NETSTANDARD14", DateTime.Now.ToString(CultureInfo.InvariantCulture)), config.LogVerbosity);
+                        LoggingMethod.WriteToLog(log, string.Format(CultureInfo.InvariantCulture, "DateTime {0} PLATFORM = NETSTANDARD14", DateTime.Now.ToString(CultureInfo.InvariantCulture)), config.LogVerbosity);
 #elif (UNITY && NETSTANDARD20) || (UNITY && NET60)
                         PrintUnity(config, log);
 #elif !UNITY && NETSTANDARD20
-                        LoggingMethod.WriteToLog(log, string.Format("DateTime {0} PLATFORM = NETSTANDARD20", DateTime.Now.ToString(CultureInfo.InvariantCulture)), config.LogVerbosity);
+                        LoggingMethod.WriteToLog(log, string.Format(CultureInfo.InvariantCulture, "DateTime {0} PLATFORM = NETSTANDARD20", DateTime.Now.ToString(CultureInfo.InvariantCulture)), config.LogVerbosity);
 #elif !UNITY && NET60
-                        LoggingMethod.WriteToLog(log, string.Format("DateTime {0} PLATFORM = NET60", DateTime.Now.ToString(CultureInfo.InvariantCulture)), config.LogVerbosity);
+                        LoggingMethod.WriteToLog(log, string.Format(CultureInfo.InvariantCulture, "DateTime {0} PLATFORM = NET60", DateTime.Now.ToString(CultureInfo.InvariantCulture)), config.LogVerbosity);
 #elif UAP
-                        LoggingMethod.WriteToLog(log, string.Format("DateTime {0} PLATFORM = UAP", DateTime.Now.ToString(CultureInfo.InvariantCulture)), config.LogVerbosity);
+                        LoggingMethod.WriteToLog(log, string.Format(CultureInfo.InvariantCulture, "DateTime {0} PLATFORM = UAP", DateTime.Now.ToString(CultureInfo.InvariantCulture)), config.LogVerbosity);
 #elif NETFX_CORE
-                        LoggingMethod.WriteToLog(log, string.Format("DateTime {0} PLATFORM = NETFX_CORE", DateTime.Now.ToString(CultureInfo.InvariantCulture)), config.LogVerbosity);
+                        LoggingMethod.WriteToLog(log, string.Format(CultureInfo.InvariantCulture, "DateTime {0} PLATFORM = NETFX_CORE", DateTime.Now.ToString(CultureInfo.InvariantCulture)), config.LogVerbosity);
 #elif WINDOWS_UWP
-                        LoggingMethod.WriteToLog(log, string.Format("DateTime {0} PLATFORM = WINDOWS_UWP", DateTime.Now.ToString(CultureInfo.InvariantCulture)), config.LogVerbosity);
+                        LoggingMethod.WriteToLog(log, string.Format(CultureInfo.InvariantCulture, "DateTime {0} PLATFORM = WINDOWS_UWP", DateTime.Now.ToString(CultureInfo.InvariantCulture)), config.LogVerbosity);
 #elif NET35
-                        LoggingMethod.WriteToLog(log, string.Format("DateTime {0} PLATFORM = NET35", DateTime.Now.ToString(CultureInfo.InvariantCulture)), config.LogVerbosity);
+                        LoggingMethod.WriteToLog(log, string.Format(CultureInfo.InvariantCulture, "DateTime {0} PLATFORM = NET35", DateTime.Now.ToString(CultureInfo.InvariantCulture)), config.LogVerbosity);
 #elif NET40
-                        LoggingMethod.WriteToLog(log, string.Format("DateTime {0} PLATFORM = NET40", DateTime.Now.ToString(CultureInfo.InvariantCulture)), config.LogVerbosity);
+                        LoggingMethod.WriteToLog(log, string.Format(CultureInfo.InvariantCulture, "DateTime {0} PLATFORM = NET40", DateTime.Now.ToString(CultureInfo.InvariantCulture)), config.LogVerbosity);
 #elif NET45
-                        LoggingMethod.WriteToLog(log, string.Format("DateTime {0} PLATFORM = NET45", DateTime.Now.ToString(CultureInfo.InvariantCulture)), config.LogVerbosity);
+                        LoggingMethod.WriteToLog(log, string.Format(CultureInfo.InvariantCulture, "DateTime {0} PLATFORM = NET45", DateTime.Now.ToString(CultureInfo.InvariantCulture)), config.LogVerbosity);
 #elif NET461
-            LoggingMethod.WriteToLog(log, string.Format("DateTime {0} PLATFORM = NET461", DateTime.Now.ToString(CultureInfo.InvariantCulture)), config.LogVerbosity);
+            LoggingMethod.WriteToLog(log, string.Format(CultureInfo.InvariantCulture, "DateTime {0} PLATFORM = NET461", DateTime.Now.ToString(CultureInfo.InvariantCulture)), config.LogVerbosity);
 #elif NET48
-            LoggingMethod.WriteToLog(log, string.Format("DateTime {0} PLATFORM = NET48", DateTime.Now.ToString(CultureInfo.InvariantCulture)), config.LogVerbosity);
+            LoggingMethod.WriteToLog(log, string.Format(CultureInfo.InvariantCulture, "DateTime {0} PLATFORM = NET48", DateTime.Now.ToString(CultureInfo.InvariantCulture)), config.LogVerbosity);
 #else
-            LoggingMethod.WriteToLog(log, string.Format("DateTime {0} PLATFORM = UNKNOWN", DateTime.Now.ToString(CultureInfo.InvariantCulture)), config.LogVerbosity);
+            LoggingMethod.WriteToLog(log, string.Format(CultureInfo.InvariantCulture, "DateTime {0} PLATFORM = UNKNOWN", DateTime.Now.ToString(CultureInfo.InvariantCulture)), config.LogVerbosity);
 #endif
         }
 
@@ -51,21 +51,21 @@ namespace PubnubApi
         private static void PrintUnity(PNConfiguration config, IPubnubLog log)
         {
 #if UNITY_IOS || UNITY_IPHONE
-                        LoggingMethod.WriteToLog(log, string.Format("DateTime {0} PLATFORM = UNITY_IOS", DateTime.Now.ToString(CultureInfo.InvariantCulture)), config.LogVerbosity);
+                        LoggingMethod.WriteToLog(log, string.Format(CultureInfo.InvariantCulture, "DateTime {0} PLATFORM = UNITY_IOS", DateTime.Now.ToString(CultureInfo.InvariantCulture)), config.LogVerbosity);
 #elif UNITY_STANDALONE_WIN
-                        LoggingMethod.WriteToLog(log, string.Format("DateTime {0} PLATFORM = UNITY_STANDALONE_WIN", DateTime.Now.ToString(CultureInfo.InvariantCulture)), config.LogVerbosity);
+                        LoggingMethod.WriteToLog(log, string.Format(CultureInfo.InvariantCulture, "DateTime {0} PLATFORM = UNITY_STANDALONE_WIN", DateTime.Now.ToString(CultureInfo.InvariantCulture)), config.LogVerbosity);
 #elif UNITY_STANDALONE_OSX
-                        LoggingMethod.WriteToLog(log, string.Format("DateTime {0} PLATFORM = UNITY_STANDALONE_OSX", DateTime.Now.ToString(CultureInfo.InvariantCulture)), config.LogVerbosity);
+                        LoggingMethod.WriteToLog(log, string.Format(CultureInfo.InvariantCulture, "DateTime {0} PLATFORM = UNITY_STANDALONE_OSX", DateTime.Now.ToString(CultureInfo.InvariantCulture)), config.LogVerbosity);
 #elif UNITY_ANDROID
-                        LoggingMethod.WriteToLog(log, string.Format("DateTime {0} PLATFORM = UNITY_ANDROID", DateTime.Now.ToString(CultureInfo.InvariantCulture)), config.LogVerbosity);
+                        LoggingMethod.WriteToLog(log, string.Format(CultureInfo.InvariantCulture, "DateTime {0} PLATFORM = UNITY_ANDROID", DateTime.Now.ToString(CultureInfo.InvariantCulture)), config.LogVerbosity);
 #elif UNITY_STANDALONE_LINUX
-                        LoggingMethod.WriteToLog(log, string.Format("DateTime {0} PLATFORM = UNITY_STANDALONE_LINUX", DateTime.Now.ToString(CultureInfo.InvariantCulture)), config.LogVerbosity);
+                        LoggingMethod.WriteToLog(log, string.Format(CultureInfo.InvariantCulture, "DateTime {0} PLATFORM = UNITY_STANDALONE_LINUX", DateTime.Now.ToString(CultureInfo.InvariantCulture)), config.LogVerbosity);
 #elif UNITY_WEBPLAYER
-                        LoggingMethod.WriteToLog(log, string.Format("DateTime {0} PLATFORM = UNITY_WEBPLAYER", DateTime.Now.ToString(CultureInfo.InvariantCulture)), config.LogVerbosity);
+                        LoggingMethod.WriteToLog(log, string.Format(CultureInfo.InvariantCulture, "DateTime {0} PLATFORM = UNITY_WEBPLAYER", DateTime.Now.ToString(CultureInfo.InvariantCulture)), config.LogVerbosity);
 #elif UNITY_WEBGL
-                        LoggingMethod.WriteToLog(log, string.Format("DateTime {0} PLATFORM = UNITY_WEBGL", DateTime.Now.ToString(CultureInfo.InvariantCulture)), config.LogVerbosity);
+                        LoggingMethod.WriteToLog(log, string.Format(CultureInfo.InvariantCulture, "DateTime {0} PLATFORM = UNITY_WEBGL", DateTime.Now.ToString(CultureInfo.InvariantCulture)), config.LogVerbosity);
 #else
-            LoggingMethod.WriteToLog(log, string.Format("DateTime {0} PLATFORM = UNITY", DateTime.Now.ToString(CultureInfo.InvariantCulture)), config.LogVerbosity);
+            LoggingMethod.WriteToLog(log, string.Format(CultureInfo.InvariantCulture, "DateTime {0} PLATFORM = UNITY", DateTime.Now.ToString(CultureInfo.InvariantCulture)), config.LogVerbosity);
 #endif
         }
 #endif

--- a/src/Api/PubnubApi/Model/Consumer/AccessManager/PNTokenPermissionMappingBase.cs
+++ b/src/Api/PubnubApi/Model/Consumer/AccessManager/PNTokenPermissionMappingBase.cs
@@ -18,7 +18,7 @@ namespace PubnubApi
         [Obsolete("Channels is deprecated, please use Spaces instead.")]
         public Dictionary<string, PNTokenAuthValues> Channels { get; set; }
 
-        [Obsolete]
+        [Obsolete("ChannelGroups is deprecated.")]
         public Dictionary<string, PNTokenAuthValues> ChannelGroups { get; set; }
 
         [Obsolete("Uuids is deprecated, please use Users instead.")]

--- a/src/Api/PubnubApi/Model/PNStatusCategoryHelper.cs
+++ b/src/Api/PubnubApi/Model/PNStatusCategoryHelper.cs
@@ -23,8 +23,8 @@ namespace PubnubApi
                     ret = PNStatusCategory.PNNetworkIssuesCategory;
                     break;
                 default:
-                    if (string.Compare(webExceptionStatus.ToString(), "SecureChannelFailure", StringComparison.CurrentCultureIgnoreCase) == 0 
-                        || string.Compare(webExceptionStatus.ToString(),"NameResolutionFailure", StringComparison.CurrentCultureIgnoreCase) == 0)
+                    if (string.Equals(webExceptionStatus.ToString(), "SecureChannelFailure", StringComparison.OrdinalIgnoreCase) 
+                        || string.Equals(webExceptionStatus.ToString(),"NameResolutionFailure", StringComparison.OrdinalIgnoreCase))
                     {
                         ret = PNStatusCategory.PNNetworkIssuesCategory;
                     }

--- a/src/Api/PubnubApi/NewtonsoftJsonDotNet.cs
+++ b/src/Api/PubnubApi/NewtonsoftJsonDotNet.cs
@@ -195,20 +195,20 @@ namespace PubnubApi
             {
                 ret = true;
             }
-            LoggingMethod.WriteToLog(pubnubLog, string.Format("DateTime: {0}, NET35/40 IsGenericTypeForMessage = {1}", DateTime.Now.ToString(CultureInfo.InvariantCulture), ret.ToString()), config.LogVerbosity);
+            LoggingMethod.WriteToLog(pubnubLog, string.Format(CultureInfo.InvariantCulture, "DateTime: {0}, NET35/40 IsGenericTypeForMessage = {1}", DateTime.Now.ToString(CultureInfo.InvariantCulture), ret.ToString()), config.LogVerbosity);
 #elif (NETSTANDARD10 || NETSTANDARD11 || NETSTANDARD12 || NETSTANDARD13 || NETSTANDARD14 || NETSTANDARD20 || NET60 || UAP || NETFX_CORE || WINDOWS_UWP)
             if (typeof(T).GetTypeInfo().IsGenericType && typeof(T).GetGenericTypeDefinition() == typeof(PNMessageResult<>))
             {
                 ret = true;
             }
-            LoggingMethod.WriteToLog(pubnubLog, string.Format("DateTime: {0}, typeof(T).GetTypeInfo().IsGenericType = {1}", DateTime.Now.ToString(CultureInfo.InvariantCulture), typeof(T).GetTypeInfo().IsGenericType.ToString()), config.LogVerbosity);
+            LoggingMethod.WriteToLog(pubnubLog, string.Format(CultureInfo.InvariantCulture, "DateTime: {0}, typeof(T).GetTypeInfo().IsGenericType = {1}", DateTime.Now.ToString(CultureInfo.InvariantCulture), typeof(T).GetTypeInfo().IsGenericType.ToString()), config.LogVerbosity);
             if (typeof(T).GetTypeInfo().IsGenericType)
             {
-                LoggingMethod.WriteToLog(pubnubLog, string.Format("DateTime: {0}, typeof(T).GetGenericTypeDefinition() = {1}", DateTime.Now.ToString(CultureInfo.InvariantCulture), typeof(T).GetGenericTypeDefinition().ToString()), config.LogVerbosity);
+                LoggingMethod.WriteToLog(pubnubLog, string.Format(CultureInfo.InvariantCulture, "DateTime: {0}, typeof(T).GetGenericTypeDefinition() = {1}", DateTime.Now.ToString(CultureInfo.InvariantCulture), typeof(T).GetGenericTypeDefinition().ToString()), config.LogVerbosity);
             }
-            LoggingMethod.WriteToLog(pubnubLog, string.Format("DateTime: {0}, PCL/CORE IsGenericTypeForMessage = {1}", DateTime.Now.ToString(CultureInfo.InvariantCulture), ret.ToString()), config.LogVerbosity);
+            LoggingMethod.WriteToLog(pubnubLog, string.Format(CultureInfo.InvariantCulture, "DateTime: {0}, PCL/CORE IsGenericTypeForMessage = {1}", DateTime.Now.ToString(CultureInfo.InvariantCulture), ret.ToString()), config.LogVerbosity);
 #endif
-            LoggingMethod.WriteToLog(pubnubLog, string.Format("DateTime: {0}, IsGenericTypeForMessage = {1}", DateTime.Now.ToString(CultureInfo.InvariantCulture), ret.ToString()), config.LogVerbosity);
+            LoggingMethod.WriteToLog(pubnubLog, string.Format(CultureInfo.InvariantCulture, "DateTime: {0}, IsGenericTypeForMessage = {1}", DateTime.Now.ToString(CultureInfo.InvariantCulture), ret.ToString()), config.LogVerbosity);
             return ret;
         }
 
@@ -261,7 +261,7 @@ namespace PubnubApi
                 //Set Time
                 PropertyInfo timeProp = specific.GetProperty("Timetoken");
                 long timetoken;
-                Int64.TryParse(listObject[2].ToString(), out timetoken);
+                var _ = Int64.TryParse(listObject[2].ToString(), out timetoken);
                 timeProp.SetValue(message, timetoken, null);
 
                 //Set Publisher
@@ -477,7 +477,7 @@ namespace PubnubApi
                 if (listObject.Count >= 2)
                 {
                     long publishTimetoken;
-                    Int64.TryParse(listObject[2].ToString(), out publishTimetoken);
+                    var _ = Int64.TryParse(listObject[2].ToString(), out publishTimetoken);
                     result = new PNPublishResult
                     {
                         Timetoken = publishTimetoken
@@ -540,7 +540,7 @@ namespace PubnubApi
                         ack.UserMetadata = listObject[1];
                     }
 
-                    if (ack.Event != null && ack.Event.ToLower() == "interval")
+                    if (ack.Event != null && ack.Event.ToLowerInvariant() == "interval")
                     {
                         if (presenceDicObj.ContainsKey("join"))
                         {
@@ -970,7 +970,7 @@ namespace PubnubApi
                     ack.Message = removeChFromCgDicObj["message"].ToString();
                     ack.Service = removeChFromCgDicObj["service"].ToString();
 
-                    ack.Error = Convert.ToBoolean(removeChFromCgDicObj["error"].ToString());
+                    ack.Error = Convert.ToBoolean(removeChFromCgDicObj["error"].ToString(), CultureInfo.InvariantCulture);
 
                     ack.ChannelGroup = listObject[1].ToString();
                 }
@@ -999,7 +999,7 @@ namespace PubnubApi
                     ack.Service = removeCgDicObj["service"].ToString();
                     ack.Message = removeCgDicObj["message"].ToString();
 
-                    ack.Error = Convert.ToBoolean(removeCgDicObj["error"].ToString());
+                    ack.Error = Convert.ToBoolean(removeCgDicObj["error"].ToString(), CultureInfo.InvariantCulture);
                 }
 
                 ret = (T)Convert.ChangeType(ack, typeof(PNChannelGroupsDeleteGroupResult), CultureInfo.InvariantCulture);
@@ -1011,7 +1011,7 @@ namespace PubnubApi
 
                 Int64 timetoken = 0;
 
-                Int64.TryParse(listObject[0].ToString(), out timetoken);
+                var _ = Int64.TryParse(listObject[0].ToString(), out timetoken);
 
                 PNTimeResult result = new PNTimeResult
                 {

--- a/src/Api/PubnubApi/PNConfiguration.cs
+++ b/src/Api/PubnubApi/PNConfiguration.cs
@@ -10,7 +10,7 @@ namespace PubnubApi
         private int presenceHeartbeatTimeout;
         private int presenceHeartbeatInterval;
         private UserId _userId;
-        private bool uuidSetFromConstructor = false;
+        private bool uuidSetFromConstructor;
 
         internal void ResetUuidSetFromConstructor()
         {

--- a/src/Api/PubnubApi/Properties/AssemblyInfo.cs
+++ b/src/Api/PubnubApi/Properties/AssemblyInfo.cs
@@ -11,8 +11,8 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyProduct("Pubnub C# SDK")]
 [assembly: AssemblyCopyright("Copyright ©  2021")]
 [assembly: AssemblyTrademark("")]
-[assembly: AssemblyVersion("6.12.0.0")]
-[assembly: AssemblyFileVersion("6.12.0.0")]
+[assembly: AssemblyVersion("6.13.0.0")]
+[assembly: AssemblyFileVersion("6.13.0.0")]
 // Setting ComVisible to false makes the types in this assembly not visible
 // to COM components.  If you need to access a type in this assembly from
 // COM, set the ComVisible attribute to true on that type.

--- a/src/Api/PubnubApi/Pubnub.cs
+++ b/src/Api/PubnubApi/Pubnub.cs
@@ -25,7 +25,7 @@ namespace PubnubApi
             var assemblyName = new AssemblyName(assembly.FullName);
             string assemblyVersion = assemblyName.Version.ToString();
 #endif
-            Version = string.Format("{0}CSharp{1}", PNPlatform.Get(), assemblyVersion);
+            Version = string.Format(CultureInfo.InvariantCulture, "{0}CSharp{1}", PNPlatform.Get(), assemblyVersion);
         }
 
         #region "PubNub API Channel Methods"
@@ -424,7 +424,7 @@ namespace PubnubApi
             {
                 if (pubnubLog != null && pubnubConfig != null)
                 {
-                    LoggingMethod.WriteToLog(pubnubLog, string.Format("DateTime: {0}, UserId cannot be null/empty.", DateTime.Now.ToString(CultureInfo.InvariantCulture)), pubnubConfig.ContainsKey(InstanceId) ? pubnubConfig[InstanceId].LogVerbosity : PNLogVerbosity.NONE);
+                    LoggingMethod.WriteToLog(pubnubLog, string.Format(CultureInfo.InvariantCulture, "DateTime: {0}, UserId cannot be null/empty.", DateTime.Now.ToString(CultureInfo.InvariantCulture)), pubnubConfig.ContainsKey(InstanceId) ? pubnubConfig[InstanceId].LogVerbosity : PNLogVerbosity.NONE);
                 }
                 throw new MissingMemberException("UserId cannot be null/empty");
             }
@@ -883,7 +883,7 @@ namespace PubnubApi
                 config.PresenceTimeout = 20;
                 if (pubnubLog != null)
                 {
-                    LoggingMethod.WriteToLog(pubnubLog, string.Format("DateTime: {0}, WARNING: The PresenceTimeout cannot be less than 20, defaulting the value to 20. Please update the settings in your code.", DateTime.Now.ToString(CultureInfo.InvariantCulture)), config.LogVerbosity);
+                    LoggingMethod.WriteToLog(pubnubLog, string.Format(CultureInfo.InvariantCulture, "DateTime: {0}, WARNING: The PresenceTimeout cannot be less than 20, defaulting the value to 20. Please update the settings in your code.", DateTime.Now.ToString(CultureInfo.InvariantCulture)), config.LogVerbosity);
                 }
             }
             if (config != null)
@@ -892,7 +892,7 @@ namespace PubnubApi
                 {
                     if (pubnubLog != null)
                     {
-                        LoggingMethod.WriteToLog(pubnubLog, string.Format("DateTime: {0}, PNConfiguration.Uuid or PNConfiguration.UserId is required to use the SDK.", DateTime.Now.ToString(CultureInfo.InvariantCulture)), config.LogVerbosity);
+                        LoggingMethod.WriteToLog(pubnubLog, string.Format(CultureInfo.InvariantCulture, "DateTime: {0}, PNConfiguration.Uuid or PNConfiguration.UserId is required to use the SDK.", DateTime.Now.ToString(CultureInfo.InvariantCulture)), config.LogVerbosity);
                     }
                     throw new MissingMemberException("PNConfiguration.UserId is required to use the SDK");
                 }

--- a/src/Api/PubnubApi/PubnubApi.csproj
+++ b/src/Api/PubnubApi/PubnubApi.csproj
@@ -13,7 +13,7 @@
 
   <PropertyGroup>
     <PackageId>Pubnub</PackageId>
-    <PackageVersion>6.12.0.0</PackageVersion>
+    <PackageVersion>6.13.0.0</PackageVersion>
     <Title>PubNub C# .NET - Web Data Push API</Title>
     <Authors>Pandu Masabathula</Authors>
     <Owners>PubNub</Owners>
@@ -21,7 +21,9 @@
     <PackageIconUrl>http://pubnub.s3.amazonaws.com/2011/powered-by-pubnub/pubnub-icon-600x600.png</PackageIconUrl>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
     <RepositoryUrl>https://github.com/pubnub/c-sharp/</RepositoryUrl>
-    <PackageReleaseNotes>Encode comma char for push related multi channels.</PackageReleaseNotes>
+    <PackageReleaseNotes>Added null check for PublishFileMessage PNStatus in SendFileOperation.
+Removed invalid Content-Type in ObjectsV2 request headers targeting .Net Frameworks.
+Added CultureInfo.InvariantCulture to string formatting.</PackageReleaseNotes>
     <PackageTags>Web Data Push Real-time Notifications ESB Message Broadcasting Distributed Computing</PackageTags>
     <!--<Summary>PubNub is a Massively Scalable Web Push Service for Web and Mobile Games.  This is a cloud-based service for broadcasting messages to thousands of web and mobile clients simultaneously</Summary>-->
     <Description>PubNub is a Massively Scalable Web Push Service for Web and Mobile Games.  This is a cloud-based service for broadcasting messages to thousands of web and mobile clients simultaneously</Description>

--- a/src/Api/PubnubApi/PubnubCoreBase.cs
+++ b/src/Api/PubnubApi/PubnubCoreBase.cs
@@ -331,7 +331,7 @@ namespace PubnubApi
                 Dictionary<string, object> timeAndRegionDictionary = timetokenObj["t"] as Dictionary<string, object>;
                 if (timeAndRegionDictionary != null && timeAndRegionDictionary.Count > 0 && timeAndRegionDictionary.ContainsKey("t"))
                 {
-                    Int64.TryParse(timeAndRegionDictionary["t"].ToString(), out jsonTimetoken);
+                    var _ = Int64.TryParse(timeAndRegionDictionary["t"].ToString(), out jsonTimetoken);
                 }
             }
             else
@@ -342,12 +342,12 @@ namespace PubnubApi
                     Dictionary<string, object> timeAndRegionDictionary = timetokenObj["t"] as Dictionary<string, object>;
                     if (timeAndRegionDictionary != null && timeAndRegionDictionary.Count > 0 && timeAndRegionDictionary.ContainsKey("t"))
                     {
-                        Int64.TryParse(timeAndRegionDictionary["t"].ToString(), out jsonTimetoken);
+                        var _ = Int64.TryParse(timeAndRegionDictionary["t"].ToString(), out jsonTimetoken);
                     }
                 }
                 else
                 {
-                    Int64.TryParse(result[1].ToString(), out jsonTimetoken);
+                    var _ = Int64.TryParse(result[1].ToString(), out jsonTimetoken);
                 }
             }
 
@@ -364,7 +364,7 @@ namespace PubnubApi
                 Dictionary<string, object> timeAndRegionDictionary = timetokenObj["t"] as Dictionary<string, object>;
                 if (timeAndRegionDictionary != null && timeAndRegionDictionary.Count > 0 && timeAndRegionDictionary.ContainsKey("r"))
                 {
-                    Int32.TryParse(timeAndRegionDictionary["r"].ToString(), out jsonRegion);
+                    var _ = Int32.TryParse(timeAndRegionDictionary["r"].ToString(), out jsonRegion);
                 }
             }
             else
@@ -375,7 +375,7 @@ namespace PubnubApi
                     Dictionary<string, object> timeAndRegionDictionary = timetokenObj["t"] as Dictionary<string, object>;
                     if (timeAndRegionDictionary != null && timeAndRegionDictionary.Count > 0 && timeAndRegionDictionary.ContainsKey("r"))
                     {
-                        Int32.TryParse(timeAndRegionDictionary["r"].ToString(), out jsonRegion);
+                        var _ = Int32.TryParse(timeAndRegionDictionary["r"].ToString(), out jsonRegion);
                     }
                 }
             }
@@ -427,7 +427,7 @@ namespace PubnubApi
                                     break;
                                 case "e":
                                     int subscriptionTypeIndicator;
-                                    Int32.TryParse(dicItem[key].ToString(), out subscriptionTypeIndicator);
+                                    var _ = Int32.TryParse(dicItem[key].ToString(), out subscriptionTypeIndicator);
                                     msg.MessageType = subscriptionTypeIndicator;
                                     break;
                                 case "f":
@@ -441,7 +441,7 @@ namespace PubnubApi
                                     break;
                                 case "s":
                                     int seqNum;
-                                    Int32.TryParse(dicItem[key].ToString(), out seqNum);
+                                    _ = Int32.TryParse(dicItem[key].ToString(), out seqNum);
                                     msg.SequenceNumber = seqNum;
                                     break;
                                 case "o":
@@ -452,13 +452,13 @@ namespace PubnubApi
 
                                         foreach (string metaKey in ttOriginMetaData.Keys)
                                         {
-                                            if (metaKey.ToLowerInvariant().Equals("t", StringComparison.CurrentCultureIgnoreCase))
+                                            if (metaKey.ToLowerInvariant().Equals("t", StringComparison.OrdinalIgnoreCase))
                                             {
                                                 long timetoken;
-                                                Int64.TryParse(ttOriginMetaData[metaKey].ToString(), out timetoken);
+                                                _ = Int64.TryParse(ttOriginMetaData[metaKey].ToString(), out timetoken);
                                                 ttMeta.Timetoken = timetoken;
                                             }
-                                            else if (metaKey.ToLowerInvariant().Equals("r", StringComparison.CurrentCultureIgnoreCase))
+                                            else if (metaKey.ToLowerInvariant().Equals("r", StringComparison.OrdinalIgnoreCase))
                                             {
                                                 ttMeta.Region = ttOriginMetaData[metaKey].ToString();
                                             }
@@ -479,7 +479,7 @@ namespace PubnubApi
                                             if (currentMetaKey.Equals("t", StringComparison.OrdinalIgnoreCase))
                                             {
                                                 long timetoken;
-                                                Int64.TryParse(ttPublishMetaData[metaKey].ToString(), out timetoken);
+                                                _ = Int64.TryParse(ttPublishMetaData[metaKey].ToString(), out timetoken);
                                                 ttMeta.Timetoken = timetoken;
                                             }
                                             else if (currentMetaKey.Equals("r", StringComparison.OrdinalIgnoreCase))
@@ -517,14 +517,14 @@ namespace PubnubApi
                     isTargetOfDedup = true;
                     if (pubnubConfig.TryGetValue(PubnubInstance.InstanceId, out currentConfig) && pubnubLog.TryGetValue(PubnubInstance.InstanceId, out currentLog))
                     {
-                        LoggingMethod.WriteToLog(currentLog, string.Format("DateTime: {0}, Dedupe - Duplicate skipped - msg = {1}", DateTime.Now.ToString(CultureInfo.InvariantCulture), jsonLib.SerializeToJsonString(message)), currentConfig.LogVerbosity);
+                        LoggingMethod.WriteToLog(currentLog, string.Format(CultureInfo.InvariantCulture, "DateTime: {0}, Dedupe - Duplicate skipped - msg = {1}", DateTime.Now.ToString(CultureInfo.InvariantCulture), jsonLib.SerializeToJsonString(message)), currentConfig.LogVerbosity);
                     }
                 }
                 else
                 {
                     if (pubnubConfig.TryGetValue(PubnubInstance.InstanceId, out currentConfig) && pubnubLog.TryGetValue(PubnubInstance.InstanceId, out currentLog))
                     {
-                        LoggingMethod.WriteToLog(currentLog, string.Format("DateTime: {0}, Dedupe - AddEntry - msg = {1}", DateTime.Now.ToString(CultureInfo.InvariantCulture), jsonLib.SerializeToJsonString(message)), currentConfig.LogVerbosity);
+                        LoggingMethod.WriteToLog(currentLog, string.Format(CultureInfo.InvariantCulture, "DateTime: {0}, Dedupe - AddEntry - msg = {1}", DateTime.Now.ToString(CultureInfo.InvariantCulture), jsonLib.SerializeToJsonString(message)), currentConfig.LogVerbosity);
                     }
                     pubnubSubscribeDuplicationManager.AddEntry(message);
                 }
@@ -534,7 +534,7 @@ namespace PubnubApi
                 //Log and ignore any exception due to Dedupe manager
                 if (pubnubConfig.TryGetValue(PubnubInstance.InstanceId, out currentConfig) && pubnubLog.TryGetValue(PubnubInstance.InstanceId, out currentLog))
                 {
-                    LoggingMethod.WriteToLog(currentLog, string.Format("DateTime: {0}, IsTargetForDedup - dedupe error = {1}", DateTime.Now.ToString(CultureInfo.InvariantCulture), ex), currentConfig.LogVerbosity);
+                    LoggingMethod.WriteToLog(currentLog, string.Format(CultureInfo.InvariantCulture, "DateTime: {0}, IsTargetForDedup - dedupe error = {1}", DateTime.Now.ToString(CultureInfo.InvariantCulture), ex), currentConfig.LogVerbosity);
                 }
             }
 
@@ -573,7 +573,7 @@ namespace PubnubApi
             {
                 if (currentConfig != null && currentLog != null)
                 {
-                    LoggingMethod.WriteToLog(currentLog, string.Format("DateTime: {0}, IsZeroTimeTokenRequest - Exception = {1}", DateTime.Now.ToString(CultureInfo.InvariantCulture), ex), currentConfig.LogVerbosity);
+                    LoggingMethod.WriteToLog(currentLog, string.Format(CultureInfo.InvariantCulture, "DateTime: {0}, IsZeroTimeTokenRequest - Exception = {1}", DateTime.Now.ToString(CultureInfo.InvariantCulture), ex), currentConfig.LogVerbosity);
                 }
             }
             return ret;
@@ -639,7 +639,7 @@ namespace PubnubApi
 
                             if (currentConfig != null && currentLog != null)
                             {
-                                LoggingMethod.WriteToLog(currentLog, string.Format("DateTime: {0}, ResponseToUserCallback - messageList.Count = {1}", DateTime.Now.ToString(CultureInfo.InvariantCulture), messageList.Count), currentConfig.LogVerbosity);
+                                LoggingMethod.WriteToLog(currentLog, string.Format(CultureInfo.InvariantCulture, "DateTime: {0}, ResponseToUserCallback - messageList.Count = {1}", DateTime.Now.ToString(CultureInfo.InvariantCulture), messageList.Count), currentConfig.LogVerbosity);
                             }
                             for (int messageIndex = 0; messageIndex < messageList.Count; messageIndex++)
                             {
@@ -648,7 +648,7 @@ namespace PubnubApi
                                 {
                                     if (currentConfig != null && currentLog != null && currentConfig.DedupOnSubscribe && IsTargetForDedup(currentMessage))
                                     {
-                                        LoggingMethod.WriteToLog(currentLog, string.Format("DateTime: {0}, ResponseToUserCallback - messageList for loop - messageIndex = {1} => IsTargetForDedup", DateTime.Now.ToString(CultureInfo.InvariantCulture), messageIndex), currentConfig.LogVerbosity);
+                                        LoggingMethod.WriteToLog(currentLog, string.Format(CultureInfo.InvariantCulture, "DateTime: {0}, ResponseToUserCallback - messageList for loop - messageIndex = {1} => IsTargetForDedup", DateTime.Now.ToString(CultureInfo.InvariantCulture), messageIndex), currentConfig.LogVerbosity);
                                         continue;
                                     }
 
@@ -681,13 +681,13 @@ namespace PubnubApi
                                             }
                                             else
                                             {
-                                                LoggingMethod.WriteToLog(currentLog, string.Format("DateTime: {0}, ResponseToUserCallback - Legacy Objects V1. Ignoring this.", DateTime.Now.ToString(CultureInfo.InvariantCulture)), currentConfig.LogVerbosity);
+                                                LoggingMethod.WriteToLog(currentLog, string.Format(CultureInfo.InvariantCulture, "DateTime: {0}, ResponseToUserCallback - Legacy Objects V1. Ignoring this.", DateTime.Now.ToString(CultureInfo.InvariantCulture)), currentConfig.LogVerbosity);
                                                 continue;
                                             }
                                         }
                                         else
                                         {
-                                            LoggingMethod.WriteToLog(currentLog, string.Format("DateTime: {0}, ResponseToUserCallback - MessageType =2 but NOT valid format to process", DateTime.Now.ToString(CultureInfo.InvariantCulture)), currentConfig.LogVerbosity);
+                                            LoggingMethod.WriteToLog(currentLog, string.Format(CultureInfo.InvariantCulture, "DateTime: {0}, ResponseToUserCallback - MessageType =2 but NOT valid format to process", DateTime.Now.ToString(CultureInfo.InvariantCulture)), currentConfig.LogVerbosity);
                                             continue;
                                         }
                                     }
@@ -848,7 +848,7 @@ namespace PubnubApi
                                     {
                                         if (currentConfig != null && currentLog != null)
                                         {
-                                            LoggingMethod.WriteToLog(currentLog, string.Format("DateTime: {0}, ResponseToUserCallback - payload = {1}", DateTime.Now.ToString(CultureInfo.InvariantCulture), jsonLib.SerializeToJsonString(payloadContainer)), currentConfig.LogVerbosity);
+                                            LoggingMethod.WriteToLog(currentLog, string.Format(CultureInfo.InvariantCulture, "DateTime: {0}, ResponseToUserCallback - payload = {1}", DateTime.Now.ToString(CultureInfo.InvariantCulture), jsonLib.SerializeToJsonString(payloadContainer)), currentConfig.LogVerbosity);
                                         }
                                         ResponseBuilder responseBuilder = new ResponseBuilder(currentConfig, jsonLib, currentLog);
                                         PNMessageResult<T> userMessage = responseBuilder.JsonToObject<PNMessageResult<T>>(payloadContainer, true);
@@ -863,7 +863,7 @@ namespace PubnubApi
                                 {
                                     if (currentConfig != null && currentLog != null)
                                     {
-                                        LoggingMethod.WriteToLog(currentLog, string.Format("DateTime: {0}, ResponseToUserCallback - messageList for loop - messageIndex = {1} => null message", DateTime.Now.ToString(CultureInfo.InvariantCulture), messageIndex), currentConfig.LogVerbosity);
+                                        LoggingMethod.WriteToLog(currentLog, string.Format(CultureInfo.InvariantCulture, "DateTime: {0}, ResponseToUserCallback - messageList for loop - messageIndex = {1} => null message", DateTime.Now.ToString(CultureInfo.InvariantCulture), messageIndex), currentConfig.LogVerbosity);
                                     }
                                 }
                             }
@@ -980,7 +980,7 @@ namespace PubnubApi
             {
                 if (currentConfig != null && currentLog != null)
                 {
-                    LoggingMethod.WriteToLog(currentLog, string.Format("DateTime: {0}, ResponseToUserCallback - Exception = {1}", DateTime.Now.ToString(CultureInfo.InvariantCulture), ex), currentConfig.LogVerbosity);
+                    LoggingMethod.WriteToLog(currentLog, string.Format(CultureInfo.InvariantCulture, "DateTime: {0}, ResponseToUserCallback - Exception = {1}", DateTime.Now.ToString(CultureInfo.InvariantCulture), ex), currentConfig.LogVerbosity);
                 }
             }
         }
@@ -1053,7 +1053,7 @@ namespace PubnubApi
 
                 if (PubnubInstance == null)
                 {
-                    System.Diagnostics.Debug.WriteLine(string.Format("DateTime {0}, PubnubInstance is null. Exiting UrlProcessRequest", DateTime.Now.ToString(CultureInfo.InvariantCulture)));
+                    System.Diagnostics.Debug.WriteLine(string.Format(CultureInfo.InvariantCulture, "DateTime {0}, PubnubInstance is null. Exiting UrlProcessRequest", DateTime.Now.ToString(CultureInfo.InvariantCulture)));
                     return new Tuple<string, PNStatus>("", null);
                 }
 
@@ -1061,11 +1061,11 @@ namespace PubnubApi
                 {
                     channel = (pubnubRequestState.Channels != null && pubnubRequestState.Channels.Length > 0) ? string.Join(",", pubnubRequestState.Channels.OrderBy(x => x).ToArray()) : ",";
 
-                    if (ChannelRequest.ContainsKey(PubnubInstance.InstanceId) && !channel.Equals(",", StringComparison.CurrentCultureIgnoreCase) && !ChannelRequest[PubnubInstance.InstanceId].ContainsKey(channel) && (pubnubRequestState.ResponseType == PNOperationType.PNSubscribeOperation || pubnubRequestState.ResponseType == PNOperationType.Presence))
+                    if (ChannelRequest.ContainsKey(PubnubInstance.InstanceId) && !channel.Equals(",", StringComparison.OrdinalIgnoreCase) && !ChannelRequest[PubnubInstance.InstanceId].ContainsKey(channel) && (pubnubRequestState.ResponseType == PNOperationType.PNSubscribeOperation || pubnubRequestState.ResponseType == PNOperationType.Presence))
                     {
                         if (pubnubConfig.TryGetValue(PubnubInstance.InstanceId, out currentConfig) && pubnubLog.TryGetValue(PubnubInstance.InstanceId, out currentLog))
                         {
-                            LoggingMethod.WriteToLog(currentLog, string.Format("DateTime {0}, UrlProcessRequest ChannelRequest PubnubInstance.InstanceId Channel NOT matching", DateTime.Now.ToString(CultureInfo.InvariantCulture)), currentConfig.LogVerbosity);
+                            LoggingMethod.WriteToLog(currentLog, string.Format(CultureInfo.InvariantCulture, "DateTime {0}, UrlProcessRequest ChannelRequest PubnubInstance.InstanceId Channel NOT matching", DateTime.Now.ToString(CultureInfo.InvariantCulture)), currentConfig.LogVerbosity);
                         }
                         return new Tuple<string, PNStatus>("", null);
                     }
@@ -1096,7 +1096,7 @@ namespace PubnubApi
 
                 if (pubnubConfig.TryGetValue(PubnubInstance.InstanceId, out currentConfig) && pubnubLog.TryGetValue(PubnubInstance.InstanceId, out currentLog))
                 {
-                    LoggingMethod.WriteToLog(currentLog, string.Format("DateTime {0}, Request={1}", DateTime.Now.ToString(CultureInfo.InvariantCulture), requestUri.ToString()), currentConfig.LogVerbosity);
+                    LoggingMethod.WriteToLog(currentLog, string.Format(CultureInfo.InvariantCulture, "DateTime {0}, Request={1}", DateTime.Now.ToString(CultureInfo.InvariantCulture), requestUri.ToString()), currentConfig.LogVerbosity);
                 }
 
                 if (pubnubRequestState != null && pubnubRequestState.ResponseType == PNOperationType.PNSubscribeOperation)
@@ -1137,14 +1137,14 @@ namespace PubnubApi
                 {
                     if (pubnubConfig.TryGetValue(PubnubInstance.InstanceId, out currentConfig) && pubnubLog.TryGetValue(PubnubInstance.InstanceId, out currentLog))
                     {
-                        LoggingMethod.WriteToLog(currentLog, string.Format("DateTime {0},Received JSON but SubscribeDisconnected = {1} for request={2}", DateTime.Now.ToString(CultureInfo.InvariantCulture), jsonString, requestUri), currentConfig.LogVerbosity);
+                        LoggingMethod.WriteToLog(currentLog, string.Format(CultureInfo.InvariantCulture, "DateTime {0},Received JSON but SubscribeDisconnected = {1} for request={2}", DateTime.Now.ToString(CultureInfo.InvariantCulture), jsonString, requestUri), currentConfig.LogVerbosity);
                     }
                     throw new OperationCanceledException("Disconnected");
                 }
 
                 if (pubnubConfig.TryGetValue(PubnubInstance.InstanceId, out currentConfig) && pubnubLog.TryGetValue(PubnubInstance.InstanceId, out currentLog))
                 {
-                    LoggingMethod.WriteToLog(currentLog, string.Format("DateTime {0}, JSON= {1} for request={2}", DateTime.Now.ToString(CultureInfo.InvariantCulture), jsonString, requestUri), currentConfig.LogVerbosity);
+                    LoggingMethod.WriteToLog(currentLog, string.Format(CultureInfo.InvariantCulture, "DateTime {0}, JSON= {1} for request={2}", DateTime.Now.ToString(CultureInfo.InvariantCulture), jsonString, requestUri), currentConfig.LogVerbosity);
                 }
                 PNStatus errStatus = GetStatusIfError<T>(pubnubRequestState, jsonString);
                 if (errStatus == null && pubnubRequestState != null)
@@ -1207,7 +1207,7 @@ namespace PubnubApi
 
                     if (PubnubInstance != null && pubnubConfig.TryGetValue(PubnubInstance.InstanceId, out currentConfig) && pubnubLog.TryGetValue(PubnubInstance.InstanceId, out currentLog))
                     {
-                        LoggingMethod.WriteToLog(currentLog, string.Format("DateTime {0} PubnubBaseCore UrlProcessRequest Exception={1}", DateTime.Now.ToString(CultureInfo.InvariantCulture), webEx != null ? webEx.ToString() : exceptionMessage), currentConfig.LogVerbosity);
+                        LoggingMethod.WriteToLog(currentLog, string.Format(CultureInfo.InvariantCulture, "DateTime {0} PubnubBaseCore UrlProcessRequest Exception={1}", DateTime.Now.ToString(CultureInfo.InvariantCulture), webEx != null ? webEx.ToString() : exceptionMessage), currentConfig.LogVerbosity);
                     }
                 }
 
@@ -1230,7 +1230,7 @@ namespace PubnubApi
 
                 if (PubnubInstance == null)
                 {
-                    System.Diagnostics.Debug.WriteLine(string.Format("DateTime {0}, PubnubInstance is null. Exiting UrlProcessRequest", DateTime.Now.ToString(CultureInfo.InvariantCulture)));
+                    System.Diagnostics.Debug.WriteLine(string.Format(CultureInfo.InvariantCulture, "DateTime {0}, PubnubInstance is null. Exiting UrlProcessRequest", DateTime.Now.ToString(CultureInfo.InvariantCulture)));
                     return new Tuple<byte[], PNStatus>(null, null);
                 }
 
@@ -1238,11 +1238,11 @@ namespace PubnubApi
                 {
                     channel = (pubnubRequestState.Channels != null && pubnubRequestState.Channels.Length > 0) ? string.Join(",", pubnubRequestState.Channels.OrderBy(x => x).ToArray()) : ",";
 
-                    if (ChannelRequest.ContainsKey(PubnubInstance.InstanceId) && !channel.Equals(",", StringComparison.CurrentCultureIgnoreCase) && !ChannelRequest[PubnubInstance.InstanceId].ContainsKey(channel) && (pubnubRequestState.ResponseType == PNOperationType.PNSubscribeOperation || pubnubRequestState.ResponseType == PNOperationType.Presence))
+                    if (ChannelRequest.ContainsKey(PubnubInstance.InstanceId) && !channel.Equals(",", StringComparison.OrdinalIgnoreCase) && !ChannelRequest[PubnubInstance.InstanceId].ContainsKey(channel) && (pubnubRequestState.ResponseType == PNOperationType.PNSubscribeOperation || pubnubRequestState.ResponseType == PNOperationType.Presence))
                     {
                         if (pubnubConfig.TryGetValue(PubnubInstance.InstanceId, out currentConfig) && pubnubLog.TryGetValue(PubnubInstance.InstanceId, out currentLog))
                         {
-                            LoggingMethod.WriteToLog(currentLog, string.Format("DateTime {0}, UrlProcessRequest ChannelRequest PubnubInstance.InstanceId Channel NOT matching", DateTime.Now.ToString(CultureInfo.InvariantCulture)), currentConfig.LogVerbosity);
+                            LoggingMethod.WriteToLog(currentLog, string.Format(CultureInfo.InvariantCulture, "DateTime {0}, UrlProcessRequest ChannelRequest PubnubInstance.InstanceId Channel NOT matching", DateTime.Now.ToString(CultureInfo.InvariantCulture)), currentConfig.LogVerbosity);
                         }
                         return new Tuple<byte[], PNStatus>(null, null);
                     }
@@ -1273,7 +1273,7 @@ namespace PubnubApi
 
                 if (pubnubConfig.TryGetValue(PubnubInstance.InstanceId, out currentConfig) && pubnubLog.TryGetValue(PubnubInstance.InstanceId, out currentLog))
                 {
-                    LoggingMethod.WriteToLog(currentLog, string.Format("DateTime {0}, Request={1}", DateTime.Now.ToString(CultureInfo.InvariantCulture), requestUri.ToString()), currentConfig.LogVerbosity);
+                    LoggingMethod.WriteToLog(currentLog, string.Format(CultureInfo.InvariantCulture, "DateTime {0}, Request={1}", DateTime.Now.ToString(CultureInfo.InvariantCulture), requestUri.ToString()), currentConfig.LogVerbosity);
                 }
 
                 if (pubnubRequestState != null && pubnubRequestState.ResponseType == PNOperationType.PNSubscribeOperation)
@@ -1289,7 +1289,7 @@ namespace PubnubApi
 #endif
                 if (streamBytes != null && pubnubConfig.TryGetValue(PubnubInstance.InstanceId, out currentConfig) && pubnubLog.TryGetValue(PubnubInstance.InstanceId, out currentLog))
                 {
-                    LoggingMethod.WriteToLog(currentLog, string.Format("DateTime {0}, Stream length= {1} for request={2}", DateTime.Now.ToString(CultureInfo.InvariantCulture), streamBytes.Length, requestUri), currentConfig.LogVerbosity);
+                    LoggingMethod.WriteToLog(currentLog, string.Format(CultureInfo.InvariantCulture, "DateTime {0}, Stream length= {1} for request={2}", DateTime.Now.ToString(CultureInfo.InvariantCulture), streamBytes.Length, requestUri), currentConfig.LogVerbosity);
                 }
                 PNStatus errStatus = GetStatusIfError<T>(pubnubRequestState, null);
                 if (errStatus == null && pubnubRequestState != null)
@@ -1351,7 +1351,7 @@ namespace PubnubApi
 
                     if (PubnubInstance != null && pubnubConfig.TryGetValue(PubnubInstance.InstanceId, out currentConfig) && pubnubLog.TryGetValue(PubnubInstance.InstanceId, out currentLog))
                     {
-                        LoggingMethod.WriteToLog(currentLog, string.Format("DateTime {0} PubnubBaseCore UrlProcessRequest Exception={1}", DateTime.Now.ToString(CultureInfo.InvariantCulture), webEx != null ? webEx.ToString() : exceptionMessage), currentConfig.LogVerbosity);
+                        LoggingMethod.WriteToLog(currentLog, string.Format(CultureInfo.InvariantCulture, "DateTime {0} PubnubBaseCore UrlProcessRequest Exception={1}", DateTime.Now.ToString(CultureInfo.InvariantCulture), webEx != null ? webEx.ToString() : exceptionMessage), currentConfig.LogVerbosity);
                     }
                 }
 
@@ -1399,7 +1399,7 @@ namespace PubnubApi
             {
                 Dictionary<string, object> deserializeStatus = jsonLib.DeserializeToDictionaryOfObject(jsonString);
                 int statusCode = 0; //default. assuming all is ok 
-                if (deserializeStatus.Count >= 1 && deserializeStatus.ContainsKey("error") && string.Equals(deserializeStatus["error"].ToString(), "true", StringComparison.CurrentCultureIgnoreCase))
+                if (deserializeStatus.Count >= 1 && deserializeStatus.ContainsKey("error") && string.Equals(deserializeStatus["error"].ToString(), "true", StringComparison.OrdinalIgnoreCase))
                 {
                     if (pubnubConfig.TryGetValue(PubnubInstance.InstanceId, out currentConfig))
                     {
@@ -1418,7 +1418,7 @@ namespace PubnubApi
                         status = new StatusBuilder(currentConfig, jsonLib).CreateStatusResponse<T>(type, category, asyncRequestState, statusCode, new PNException(jsonString));
                     }
                 }
-                else if (deserializeStatus.Count >= 1 && deserializeStatus.ContainsKey("status") && string.Equals(deserializeStatus["status"].ToString(), "error", StringComparison.CurrentCultureIgnoreCase) && deserializeStatus.ContainsKey("error"))
+                else if (deserializeStatus.Count >= 1 && deserializeStatus.ContainsKey("status") && string.Equals(deserializeStatus["status"].ToString(), "error", StringComparison.OrdinalIgnoreCase) && deserializeStatus.ContainsKey("error"))
                 {
                     string errorMessageJson = deserializeStatus["error"].ToString();
                     Dictionary<string, object> errorDic = jsonLib.DeserializeToDictionaryOfObject(errorMessageJson);
@@ -1438,7 +1438,7 @@ namespace PubnubApi
                 }
                 else if (deserializeStatus.ContainsKey("status") && deserializeStatus.ContainsKey("message"))
                 {
-                    Int32.TryParse(deserializeStatus["status"].ToString(), out statusCode);
+                    var _ = Int32.TryParse(deserializeStatus["status"].ToString(), out statusCode);
                     string statusMessage = deserializeStatus["message"].ToString();
 
                     if (statusCode != 200)
@@ -1759,19 +1759,19 @@ namespace PubnubApi
                     object channelUserStateValue = channelUserStateDictionary[channelUserStateKey];
                     if (channelUserStateValue == null)
                     {
-                        jsonStateBuilder.AppendFormat("\"{0}\":{1}", channelUserStateKey, string.Format("\"{0}\"", "null"));
+                        jsonStateBuilder.AppendFormat(CultureInfo.InvariantCulture, "\"{0}\":{1}", channelUserStateKey, string.Format(CultureInfo.InvariantCulture, "\"{0}\"", "null"));
                     }
                     else if (channelUserStateValue.GetType().ToString() == "System.Boolean")
                     {
-                        jsonStateBuilder.AppendFormat("\"{0}\":{1}", channelUserStateKey, channelUserStateValue.ToString().ToLowerInvariant());
+                        jsonStateBuilder.AppendFormat(CultureInfo.InvariantCulture, "\"{0}\":{1}", channelUserStateKey, channelUserStateValue.ToString().ToLowerInvariant());
                     }
                     else
                     {
-                        jsonStateBuilder.AppendFormat("\"{0}\":{1}", channelUserStateKey, (channelUserStateValue.GetType().ToString() == "System.String") ? string.Format("\"{0}\"", channelUserStateValue) : channelUserStateValue);
+                        jsonStateBuilder.AppendFormat(CultureInfo.InvariantCulture, "\"{0}\":{1}", channelUserStateKey, (channelUserStateValue.GetType().ToString() == "System.String") ? string.Format(CultureInfo.InvariantCulture, "\"{0}\"", channelUserStateValue) : channelUserStateValue);
                     }
                     if (keyIndex < channelUserStateKeys.Length - 1)
                     {
-                        jsonStateBuilder.Append(",");
+                        jsonStateBuilder.Append(',');
                     }
                 }
             }
@@ -1785,19 +1785,19 @@ namespace PubnubApi
                     object channelGroupUserStateValue = channelGroupUserStateDictionary[channelGroupUserStateKey];
                     if (channelGroupUserStateValue == null)
                     {
-                        jsonStateBuilder.AppendFormat("\"{0}\":{1}", channelGroupUserStateKey, string.Format("\"{0}\"", "null"));
+                        jsonStateBuilder.AppendFormat(CultureInfo.InvariantCulture, "\"{0}\":{1}", channelGroupUserStateKey, string.Format(CultureInfo.InvariantCulture, "\"{0}\"", "null"));
                     }
                     else if (channelGroupUserStateValue.GetType().ToString() == "System.Boolean")
                     {
-                        jsonStateBuilder.AppendFormat("\"{0}\":{1}", channelGroupUserStateKey, channelGroupUserStateValue.ToString().ToLowerInvariant());
+                        jsonStateBuilder.AppendFormat(CultureInfo.InvariantCulture, "\"{0}\":{1}", channelGroupUserStateKey, channelGroupUserStateValue.ToString().ToLowerInvariant());
                     }
                     else
                     {
-                        jsonStateBuilder.AppendFormat("\"{0}\":{1}", channelGroupUserStateKey, (channelGroupUserStateValue.GetType().ToString() == "System.String") ? string.Format("\"{0}\"", channelGroupUserStateValue) : channelGroupUserStateValue);
+                        jsonStateBuilder.AppendFormat(CultureInfo.InvariantCulture, "\"{0}\":{1}", channelGroupUserStateKey, (channelGroupUserStateValue.GetType().ToString() == "System.String") ? string.Format(CultureInfo.InvariantCulture, "\"{0}\"", channelGroupUserStateValue) : channelGroupUserStateValue);
                     }
                     if (keyIndex < channelGroupUserStateKeys.Length - 1)
                     {
-                        jsonStateBuilder.Append(",");
+                        jsonStateBuilder.Append(',');
                     }
                 }
             }
@@ -1818,10 +1818,10 @@ namespace PubnubApi
                     string currentJsonState = BuildJsonUserState(channels[index], "", local);
                     if (!string.IsNullOrEmpty(currentJsonState))
                     {
-                        currentJsonState = string.Format("\"{0}\":{{{1}}}", channels[index], currentJsonState);
+                        currentJsonState = string.Format(CultureInfo.InvariantCulture, "\"{0}\":{{{1}}}", channels[index], currentJsonState);
                         if (jsonStateBuilder.Length > 0)
                         {
-                            jsonStateBuilder.Append(",");
+                            jsonStateBuilder.Append(',');
                         }
                         jsonStateBuilder.Append(currentJsonState);
                     }
@@ -1835,10 +1835,10 @@ namespace PubnubApi
                     string currentJsonState = BuildJsonUserState("", channelGroups[index], local);
                     if (!string.IsNullOrEmpty(currentJsonState))
                     {
-                        currentJsonState = string.Format("\"{0}\":{{{1}}}", channelGroups[index], currentJsonState);
+                        currentJsonState = string.Format(CultureInfo.InvariantCulture, "\"{0}\":{{{1}}}", channelGroups[index], currentJsonState);
                         if (jsonStateBuilder.Length > 0)
                         {
-                            jsonStateBuilder.Append(",");
+                            jsonStateBuilder.Append(',');
                         }
                         jsonStateBuilder.Append(currentJsonState);
                     }
@@ -1847,7 +1847,7 @@ namespace PubnubApi
 
             if (jsonStateBuilder.Length > 0)
             {
-                retJsonUserState = string.Format("{{{0}}}", jsonStateBuilder);
+                retJsonUserState = string.Format(CultureInfo.InvariantCulture, "{{{0}}}", jsonStateBuilder);
             }
 
             return retJsonUserState;
@@ -1870,7 +1870,7 @@ namespace PubnubApi
                 {
                     if (pubnubConfig.TryGetValue(PubnubInstance.InstanceId, out currentConfig) && pubnubLog.TryGetValue(PubnubInstance.InstanceId, out currentLog))
                     {
-                        LoggingMethod.WriteToLog(currentLog, string.Format("DateTime: {0}, TerminatePendingWebRequest - {1}", DateTime.Now.ToString(CultureInfo.InvariantCulture), state.Request.RequestUri.ToString()), currentConfig.LogVerbosity);
+                        LoggingMethod.WriteToLog(currentLog, string.Format(CultureInfo.InvariantCulture, "DateTime: {0}, TerminatePendingWebRequest - {1}", DateTime.Now.ToString(CultureInfo.InvariantCulture), state.Request.RequestUri.ToString()), currentConfig.LogVerbosity);
                     }
                     state.Request.Abort();
                 }
@@ -1924,11 +1924,11 @@ namespace PubnubApi
                     {
                         if (removeKey)
                         {
-                            LoggingMethod.WriteToLog(currentLog, string.Format("DateTime {0} Remove web request from dictionary in RemoveChannelDictionary for channel= {1}", DateTime.Now.ToString(CultureInfo.InvariantCulture), channel), currentConfig.LogVerbosity);
+                            LoggingMethod.WriteToLog(currentLog, string.Format(CultureInfo.InvariantCulture, "DateTime {0} Remove web request from dictionary in RemoveChannelDictionary for channel= {1}", DateTime.Now.ToString(CultureInfo.InvariantCulture), channel), currentConfig.LogVerbosity);
                         }
                         else
                         {
-                            LoggingMethod.WriteToLog(currentLog, string.Format("DateTime {0} Unable to remove web request from dictionary in RemoveChannelDictionary for channel= {1}", DateTime.Now.ToString(CultureInfo.InvariantCulture), channel), currentConfig.LogVerbosity);
+                            LoggingMethod.WriteToLog(currentLog, string.Format(CultureInfo.InvariantCulture, "DateTime {0} Unable to remove web request from dictionary in RemoveChannelDictionary for channel= {1}", DateTime.Now.ToString(CultureInfo.InvariantCulture), channel), currentConfig.LogVerbosity);
                         }
                     }
                 }
@@ -1949,11 +1949,11 @@ namespace PubnubApi
                             {
                                 if (removeKey)
                                 {
-                                    LoggingMethod.WriteToLog(currentLog, string.Format("DateTime {0} Remove web request from dictionary in RemoveChannelDictionary for channel= {1}", DateTime.Now.ToString(CultureInfo.InvariantCulture), key), currentConfig.LogVerbosity);
+                                    LoggingMethod.WriteToLog(currentLog, string.Format(CultureInfo.InvariantCulture, "DateTime {0} Remove web request from dictionary in RemoveChannelDictionary for channel= {1}", DateTime.Now.ToString(CultureInfo.InvariantCulture), key), currentConfig.LogVerbosity);
                                 }
                                 else
                                 {
-                                    LoggingMethod.WriteToLog(currentLog, string.Format("DateTime {0} Unable to remove web request from dictionary in RemoveChannelDictionary for channel= {1}", DateTime.Now.ToString(CultureInfo.InvariantCulture), key), currentConfig.LogVerbosity);
+                                    LoggingMethod.WriteToLog(currentLog, string.Format(CultureInfo.InvariantCulture, "DateTime {0} Unable to remove web request from dictionary in RemoveChannelDictionary for channel= {1}", DateTime.Now.ToString(CultureInfo.InvariantCulture), key), currentConfig.LogVerbosity);
                                 }
                             }
                         }
@@ -1988,11 +1988,11 @@ namespace PubnubApi
                         {
                             if (removeKey)
                             {
-                                LoggingMethod.WriteToLog(currentLog, string.Format("DateTime {0} RemoveUserState from local user state dictionary for channel= {1}", DateTime.Now.ToString(CultureInfo.InvariantCulture), key), currentConfig.LogVerbosity);
+                                LoggingMethod.WriteToLog(currentLog, string.Format(CultureInfo.InvariantCulture, "DateTime {0} RemoveUserState from local user state dictionary for channel= {1}", DateTime.Now.ToString(CultureInfo.InvariantCulture), key), currentConfig.LogVerbosity);
                             }
                             else
                             {
-                                LoggingMethod.WriteToLog(currentLog, string.Format("DateTime {0} Unable to RemoveUserState from local user state dictionary for channel= {1}", DateTime.Now.ToString(CultureInfo.InvariantCulture), key), currentConfig.LogVerbosity);
+                                LoggingMethod.WriteToLog(currentLog, string.Format(CultureInfo.InvariantCulture, "DateTime {0} Unable to RemoveUserState from local user state dictionary for channel= {1}", DateTime.Now.ToString(CultureInfo.InvariantCulture), key), currentConfig.LogVerbosity);
                             }
                         }
                     }
@@ -2012,11 +2012,11 @@ namespace PubnubApi
                         {
                             if (removeKey)
                             {
-                                LoggingMethod.WriteToLog(currentLog, string.Format("DateTime {0} RemoveUserState from user state dictionary for channel= {1}", DateTime.Now.ToString(CultureInfo.InvariantCulture), key), currentConfig.LogVerbosity);
+                                LoggingMethod.WriteToLog(currentLog, string.Format(CultureInfo.InvariantCulture, "DateTime {0} RemoveUserState from user state dictionary for channel= {1}", DateTime.Now.ToString(CultureInfo.InvariantCulture), key), currentConfig.LogVerbosity);
                             }
                             else
                             {
-                                LoggingMethod.WriteToLog(currentLog, string.Format("DateTime {0} Unable to RemoveUserState from user state dictionary for channel= {1}", DateTime.Now.ToString(CultureInfo.InvariantCulture), key), currentConfig.LogVerbosity);
+                                LoggingMethod.WriteToLog(currentLog, string.Format(CultureInfo.InvariantCulture, "DateTime {0} Unable to RemoveUserState from user state dictionary for channel= {1}", DateTime.Now.ToString(CultureInfo.InvariantCulture), key), currentConfig.LogVerbosity);
                             }
                         }
                     }
@@ -2036,11 +2036,11 @@ namespace PubnubApi
                         {
                             if (removeKey)
                             {
-                                LoggingMethod.WriteToLog(currentLog, string.Format("DateTime {0} RemoveUserState from local user state dictionary for channelgroup= {1}", DateTime.Now.ToString(CultureInfo.InvariantCulture), key), currentConfig.LogVerbosity);
+                                LoggingMethod.WriteToLog(currentLog, string.Format(CultureInfo.InvariantCulture, "DateTime {0} RemoveUserState from local user state dictionary for channelgroup= {1}", DateTime.Now.ToString(CultureInfo.InvariantCulture), key), currentConfig.LogVerbosity);
                             }
                             else
                             {
-                                LoggingMethod.WriteToLog(currentLog, string.Format("DateTime {0} Unable to RemoveUserState from local user state dictionary for channelgroup= {1}", DateTime.Now.ToString(CultureInfo.InvariantCulture), key), currentConfig.LogVerbosity);
+                                LoggingMethod.WriteToLog(currentLog, string.Format(CultureInfo.InvariantCulture, "DateTime {0} Unable to RemoveUserState from local user state dictionary for channelgroup= {1}", DateTime.Now.ToString(CultureInfo.InvariantCulture), key), currentConfig.LogVerbosity);
                             }
                         }
                     }
@@ -2061,11 +2061,11 @@ namespace PubnubApi
                         {
                             if (removeKey)
                             {
-                                LoggingMethod.WriteToLog(currentLog, string.Format("DateTime {0} RemoveUserState from user state dictionary for channelgroup= {1}", DateTime.Now.ToString(CultureInfo.InvariantCulture), key), currentConfig.LogVerbosity);
+                                LoggingMethod.WriteToLog(currentLog, string.Format(CultureInfo.InvariantCulture, "DateTime {0} RemoveUserState from user state dictionary for channelgroup= {1}", DateTime.Now.ToString(CultureInfo.InvariantCulture), key), currentConfig.LogVerbosity);
                             }
                             else
                             {
-                                LoggingMethod.WriteToLog(currentLog, string.Format("DateTime {0} Unable to RemoveUserState from user state dictionary for channelgroup= {1}", DateTime.Now.ToString(CultureInfo.InvariantCulture), key), currentConfig.LogVerbosity);
+                                LoggingMethod.WriteToLog(currentLog, string.Format(CultureInfo.InvariantCulture, "DateTime {0} Unable to RemoveUserState from user state dictionary for channelgroup= {1}", DateTime.Now.ToString(CultureInfo.InvariantCulture), key), currentConfig.LogVerbosity);
                             }
                         }
                     }
@@ -2073,7 +2073,7 @@ namespace PubnubApi
             }
         }
 
-        protected void TerminatePresenceHeartbeatTimer()
+        protected static void TerminatePresenceHeartbeatTimer()
         {
             if (PresenceHeartbeatTimer != null)
             {
@@ -2130,7 +2130,7 @@ namespace PubnubApi
                         ConnectionErrors = 1;
                         if (pubnubLog.TryGetValue(PubnubInstance.InstanceId, out currentLog))
                         {
-                            LoggingMethod.WriteToLog(currentLog, string.Format("DateTime {0}, EXPONENTIAL timerInterval > MAXEXPONENTIALBACKOFF", DateTime.Now.ToString(CultureInfo.InvariantCulture)), currentConfig.LogVerbosity);
+                            LoggingMethod.WriteToLog(currentLog, string.Format(CultureInfo.InvariantCulture, "DateTime {0}, EXPONENTIAL timerInterval > MAXEXPONENTIALBACKOFF", DateTime.Now.ToString(CultureInfo.InvariantCulture)), currentConfig.LogVerbosity);
                         }
                     }
                     else if (timerInterval < 1)
@@ -2139,7 +2139,7 @@ namespace PubnubApi
                     }
                     if (pubnubLog.TryGetValue(PubnubInstance.InstanceId, out currentLog))
                     {
-                        LoggingMethod.WriteToLog(currentLog, string.Format("DateTime {0}, EXPONENTIAL timerInterval = {1}", DateTime.Now.ToString(CultureInfo.InvariantCulture), timerInterval.ToString()), currentConfig.LogVerbosity);
+                        LoggingMethod.WriteToLog(currentLog, string.Format(CultureInfo.InvariantCulture, "DateTime {0}, EXPONENTIAL timerInterval = {1}", DateTime.Now.ToString(CultureInfo.InvariantCulture), timerInterval.ToString(CultureInfo.InvariantCulture)), currentConfig.LogVerbosity);
                     }
                 }
                 else if (currentConfig.ReconnectionPolicy == PNReconnectionPolicy.LINEAR)
@@ -2192,7 +2192,7 @@ namespace PubnubApi
                             {
                                 if (pubnubConfig.TryGetValue(PubnubInstance.InstanceId, out currentConfig) && pubnubLog.TryGetValue(PubnubInstance.InstanceId, out currentLog))
                                 {
-                                    LoggingMethod.WriteToLog(currentLog, string.Format("DateTime {0} TerminateReconnectTimer(null) - Unable to remove channel reconnect timer reference from collection for {1}", DateTime.Now.ToString(CultureInfo.InvariantCulture), key), currentConfig.LogVerbosity);
+                                    LoggingMethod.WriteToLog(currentLog, string.Format(CultureInfo.InvariantCulture, "DateTime {0} TerminateReconnectTimer(null) - Unable to remove channel reconnect timer reference from collection for {1}", DateTime.Now.ToString(CultureInfo.InvariantCulture), key), currentConfig.LogVerbosity);
                                 }
                             }
                         }
@@ -2229,7 +2229,7 @@ namespace PubnubApi
                             {
                                 if (pubnubConfig.TryGetValue(PubnubInstance.InstanceId, out currentConfig) && pubnubLog.TryGetValue(PubnubInstance.InstanceId, out currentLog))
                                 {
-                                    LoggingMethod.WriteToLog(currentLog, string.Format("DateTime {0} TerminateReconnectTimer(null) - Unable to remove channelgroup reconnect timer reference from collection for {1}", DateTime.Now.ToString(CultureInfo.InvariantCulture), groupKey), currentConfig.LogVerbosity);
+                                    LoggingMethod.WriteToLog(currentLog, string.Format(CultureInfo.InvariantCulture, "DateTime {0} TerminateReconnectTimer(null) - Unable to remove channelgroup reconnect timer reference from collection for {1}", DateTime.Now.ToString(CultureInfo.InvariantCulture), groupKey), currentConfig.LogVerbosity);
                                 }
                             }
                         }
@@ -2240,7 +2240,7 @@ namespace PubnubApi
             {
                 if (pubnubConfig.TryGetValue(PubnubInstance.InstanceId, out currentConfig) && pubnubLog.TryGetValue(PubnubInstance.InstanceId, out currentLog))
                 {
-                    LoggingMethod.WriteToLog(currentLog, string.Format("DateTime {0} TerminateReconnectTimer exception: {1}", DateTime.Now.ToString(CultureInfo.InvariantCulture), ex), currentConfig.LogVerbosity);
+                    LoggingMethod.WriteToLog(currentLog, string.Format(CultureInfo.InvariantCulture, "DateTime {0} TerminateReconnectTimer exception: {1}", DateTime.Now.ToString(CultureInfo.InvariantCulture), ex), currentConfig.LogVerbosity);
                 }
             }
         }
@@ -2282,7 +2282,7 @@ namespace PubnubApi
             TerminatePendingWebRequest();
             TerminateReconnectTimer();
             RemoveUserState();
-            TerminatePresenceHeartbeatTimer();
+            PubnubCoreBase.TerminatePresenceHeartbeatTimer();
             TerminateTelemetry();
             TerminateDedupeManager();
             TerminateTokenManagerCollection();
@@ -2317,8 +2317,8 @@ namespace PubnubApi
                 ChannelGroupUserState[PubnubInstance.InstanceId].Clear();
             }
 
-            if (MultiChannelSubscribe.Count > 0 && MultiChannelSubscribe.Where(t => t.Value.Keys.Count > 0).Count() == 0
-                 && MultiChannelGroupSubscribe.Count > 0 && MultiChannelGroupSubscribe.Where(t => t.Value.Keys.Count > 0).Count() == 0)
+            if (MultiChannelSubscribe.Count > 0 && !MultiChannelSubscribe.Where(t => t.Value.Keys.Count > 0).Any()
+                 && MultiChannelGroupSubscribe.Count > 0 && !MultiChannelGroupSubscribe.Where(t => t.Value.Keys.Count > 0).Any())
             {
                 RemoveHttpClients();
             }
@@ -2372,7 +2372,7 @@ namespace PubnubApi
                     IPubnubLog currentLog;
                     if (pubnubConfig.TryGetValue(PubnubInstance.InstanceId, out currentConfig) && pubnubLog.TryGetValue(PubnubInstance.InstanceId, out currentLog))
                     {
-                        LoggingMethod.WriteToLog(currentLog, string.Format("DateTime {0} TerminateCurrentSubsciberRequest {1}", DateTime.Now.ToString(CultureInfo.InvariantCulture), request.RequestUri.ToString()), currentConfig.LogVerbosity);
+                        LoggingMethod.WriteToLog(currentLog, string.Format(CultureInfo.InvariantCulture, "DateTime {0} TerminateCurrentSubsciberRequest {1}", DateTime.Now.ToString(CultureInfo.InvariantCulture), request.RequestUri.ToString()), currentConfig.LogVerbosity);
                     }
                     try
                     {

--- a/src/Api/PubnubApi/PubnubHttp.cs
+++ b/src/Api/PubnubApi/PubnubHttp.cs
@@ -150,7 +150,7 @@ namespace PubnubApi
 
         async Task<string> IPubnubHttp.SendRequestAndGetJsonResponseWithPATCH<T>(Uri requestUri, RequestState<T> pubnubRequestState, HttpWebRequest request, byte[] patchData, string contentType)
         {
-            LoggingMethod.WriteToLog(pubnubLog, string.Format(CultureInfo.InvariantCulture, "DateTime: {0}, patchData = {1}", DateTime.Now.ToString(CultureInfo.InvariantCulture), patchData), pubnubConfig.LogVerbosity);
+            LoggingMethod.WriteToLog(pubnubLog, string.Format(CultureInfo.InvariantCulture, "DateTime: {0}, patchData = {1}", DateTime.Now.ToString(CultureInfo.InvariantCulture), Encoding.UTF8.GetString(patchData)), pubnubConfig.LogVerbosity);
             if (pubnubConfig.UseClassicHttpWebRequest)
             {
                 return await SendRequestAndGetJsonResponseClassicHttpWithPATCH(pubnubRequestState, request, patchData).ConfigureAwait(false);
@@ -818,9 +818,6 @@ namespace PubnubApi
                 stopWatch.Start();
 
                 request.ContentType = "application/json";
-#if NET35 || NET40 || NET45 || NET461 || NET48
-                request.Headers.Add("Content-Type", string.IsNullOrEmpty(contentType) ? "application/json" : contentType);
-#endif
 
                 using (var requestStream = await Task<Stream>.Factory.FromAsync(request.BeginGetRequestStream, request.EndGetRequestStream, pubnubRequestState).ConfigureAwait(false))
                 {

--- a/src/Api/PubnubApi/PubnubHttp.cs
+++ b/src/Api/PubnubApi/PubnubHttp.cs
@@ -126,7 +126,7 @@ namespace PubnubApi
 
         async Task<string> IPubnubHttp.SendRequestAndGetJsonResponseWithPOST<T>(Uri requestUri, RequestState<T> pubnubRequestState, HttpWebRequest request, byte[] postData, string contentType)
         {
-            LoggingMethod.WriteToLog(pubnubLog, string.Format("DateTime: {0}, postData bytearray len= {1}", DateTime.Now.ToString(CultureInfo.InvariantCulture), postData.Length), pubnubConfig.LogVerbosity);
+            LoggingMethod.WriteToLog(pubnubLog, string.Format(CultureInfo.InvariantCulture, "DateTime: {0}, postData bytearray len= {1}", DateTime.Now.ToString(CultureInfo.InvariantCulture), postData.Length), pubnubConfig.LogVerbosity);
             if (pubnubConfig.UseClassicHttpWebRequest)
             {
                 return await SendRequestAndGetJsonResponseClassicHttpWithPOST(pubnubRequestState, request, postData, contentType).ConfigureAwait(false);
@@ -150,7 +150,7 @@ namespace PubnubApi
 
         async Task<string> IPubnubHttp.SendRequestAndGetJsonResponseWithPATCH<T>(Uri requestUri, RequestState<T> pubnubRequestState, HttpWebRequest request, byte[] patchData, string contentType)
         {
-            LoggingMethod.WriteToLog(pubnubLog, string.Format("DateTime: {0}, patchData = {1}", DateTime.Now.ToString(CultureInfo.InvariantCulture), patchData), pubnubConfig.LogVerbosity);
+            LoggingMethod.WriteToLog(pubnubLog, string.Format(CultureInfo.InvariantCulture, "DateTime: {0}, patchData = {1}", DateTime.Now.ToString(CultureInfo.InvariantCulture), patchData), pubnubConfig.LogVerbosity);
             if (pubnubConfig.UseClassicHttpWebRequest)
             {
                 return await SendRequestAndGetJsonResponseClassicHttpWithPATCH(pubnubRequestState, request, patchData).ConfigureAwait(false);
@@ -180,7 +180,7 @@ namespace PubnubApi
             CancellationTokenSource cts = new CancellationTokenSource();
             try
             {
-                LoggingMethod.WriteToLog(pubnubLog, string.Format("DateTime: {0}, Inside SendRequestAndGetJsonResponseHttpClient", DateTime.Now.ToString(CultureInfo.InvariantCulture)), pubnubConfig.LogVerbosity);
+                LoggingMethod.WriteToLog(pubnubLog, string.Format(CultureInfo.InvariantCulture, "DateTime: {0}, Inside SendRequestAndGetJsonResponseHttpClient", DateTime.Now.ToString(CultureInfo.InvariantCulture)), pubnubConfig.LogVerbosity);
                 cts.CancelAfter(GetTimeoutInSecondsForResponseType(pubnubRequestState.ResponseType) * 1000);
                 System.Diagnostics.Stopwatch stopWatch = new System.Diagnostics.Stopwatch();
                 stopWatch.Start();
@@ -209,12 +209,12 @@ namespace PubnubApi
                         jsonString = await streamReader.ReadToEndAsync().ConfigureAwait(false);
                         pubnubRequestState.GotJsonResponse = true;
                     }
-                    System.Diagnostics.Debug.WriteLine(string.Format("DateTime {0}, Got HttpResponseMessage for {1}", DateTime.Now.ToString(CultureInfo.InvariantCulture), requestUri));
+                    System.Diagnostics.Debug.WriteLine(string.Format(CultureInfo.InvariantCulture, "DateTime {0}, Got HttpResponseMessage for {1}", DateTime.Now.ToString(CultureInfo.InvariantCulture), requestUri));
                 }
                 else
                 {
                     stopWatch.Stop();
-                    System.Diagnostics.Debug.WriteLine(string.Format("DateTime {0}, No HttpResponseMessage for {1}", DateTime.Now.ToString(CultureInfo.InvariantCulture), requestUri));
+                    System.Diagnostics.Debug.WriteLine(string.Format(CultureInfo.InvariantCulture, "DateTime {0}, No HttpResponseMessage for {1}", DateTime.Now.ToString(CultureInfo.InvariantCulture), requestUri));
                 }
 
             }
@@ -234,22 +234,22 @@ namespace PubnubApi
                                 jsonString = await streamReader.ReadToEndAsync().ConfigureAwait(false);
                                 System.Diagnostics.Debug.WriteLine(jsonString);
                                 System.Diagnostics.Debug.WriteLine("");
-                                System.Diagnostics.Debug.WriteLine(string.Format("DateTime {0}, Retrieved JSON from HttpClient WebException response", DateTime.Now.ToString(CultureInfo.InvariantCulture)));
+                                System.Diagnostics.Debug.WriteLine(string.Format(CultureInfo.InvariantCulture, "DateTime {0}, Retrieved JSON from HttpClient WebException response", DateTime.Now.ToString(CultureInfo.InvariantCulture)));
                                 return jsonString;
                             }
                         }
                     }
                     
-                    LoggingMethod.WriteToLog(pubnubLog, string.Format("DateTime: {0}, SendRequestAndGetJsonResponseHttpClient InnerException WebException status {1}", DateTime.Now.ToString(CultureInfo.InvariantCulture), ((WebException)httpReqEx.InnerException).Status.ToString()), pubnubConfig.LogVerbosity);
+                    LoggingMethod.WriteToLog(pubnubLog, string.Format(CultureInfo.InvariantCulture, "DateTime: {0}, SendRequestAndGetJsonResponseHttpClient InnerException WebException status {1}", DateTime.Now.ToString(CultureInfo.InvariantCulture), ((WebException)httpReqEx.InnerException).Status.ToString()), pubnubConfig.LogVerbosity);
                     throw httpReqEx.InnerException;
                 }
 
-                LoggingMethod.WriteToLog(pubnubLog, string.Format("DateTime: {0}, SendRequestAndGetJsonResponseHttpClient HttpRequestException {1}", DateTime.Now.ToString(CultureInfo.InvariantCulture), httpReqEx.Message), pubnubConfig.LogVerbosity);
+                LoggingMethod.WriteToLog(pubnubLog, string.Format(CultureInfo.InvariantCulture, "DateTime: {0}, SendRequestAndGetJsonResponseHttpClient HttpRequestException {1}", DateTime.Now.ToString(CultureInfo.InvariantCulture), httpReqEx.Message), pubnubConfig.LogVerbosity);
                 throw;
             }
             catch (Exception ex)
             {
-                LoggingMethod.WriteToLog(pubnubLog, string.Format("DateTime: {0}, SendRequestAndGetJsonResponseHttpClient Exception {1}", DateTime.Now.ToString(CultureInfo.InvariantCulture), ex.Message), pubnubConfig.LogVerbosity);
+                LoggingMethod.WriteToLog(pubnubLog, string.Format(CultureInfo.InvariantCulture, "DateTime: {0}, SendRequestAndGetJsonResponseHttpClient Exception {1}", DateTime.Now.ToString(CultureInfo.InvariantCulture), ex.Message), pubnubConfig.LogVerbosity);
                 throw;
             }
             finally
@@ -271,7 +271,7 @@ namespace PubnubApi
             CancellationTokenSource cts = new CancellationTokenSource();
             try
             {
-                LoggingMethod.WriteToLog(pubnubLog, string.Format("DateTime: {0}, Inside SendRequestAndGetStreamResponseHttpClient", DateTime.Now.ToString(CultureInfo.InvariantCulture)), pubnubConfig.LogVerbosity);
+                LoggingMethod.WriteToLog(pubnubLog, string.Format(CultureInfo.InvariantCulture, "DateTime: {0}, Inside SendRequestAndGetStreamResponseHttpClient", DateTime.Now.ToString(CultureInfo.InvariantCulture)), pubnubConfig.LogVerbosity);
                 cts.CancelAfter(GetTimeoutInSecondsForResponseType(pubnubRequestState.ResponseType) * 1000);
                 System.Diagnostics.Stopwatch stopWatch = new System.Diagnostics.Stopwatch();
                 stopWatch.Start();
@@ -289,12 +289,12 @@ namespace PubnubApi
                         stream.CopyTo(ms);
                         streamBytes = ms.ToArray();
                     }
-                    System.Diagnostics.Debug.WriteLine(string.Format("DateTime {0}, Got HttpResponseMessage for {1}", DateTime.Now.ToString(CultureInfo.InvariantCulture), requestUri));
+                    System.Diagnostics.Debug.WriteLine(string.Format(CultureInfo.InvariantCulture, "DateTime {0}, Got HttpResponseMessage for {1}", DateTime.Now.ToString(CultureInfo.InvariantCulture), requestUri));
                 }
                 else
                 {
                     stopWatch.Stop();
-                    System.Diagnostics.Debug.WriteLine(string.Format("DateTime {0}, No HttpResponseMessage for {1}", DateTime.Now.ToString(CultureInfo.InvariantCulture), requestUri));
+                    System.Diagnostics.Debug.WriteLine(string.Format(CultureInfo.InvariantCulture, "DateTime {0}, No HttpResponseMessage for {1}", DateTime.Now.ToString(CultureInfo.InvariantCulture), requestUri));
                 }
 
             }
@@ -313,21 +313,21 @@ namespace PubnubApi
                             {
                                 errorStream.CopyTo(ms);
                                 streamBytes = ms.ToArray();
-                                System.Diagnostics.Debug.WriteLine(string.Format("DateTime {0}, Retrieved Stream Bytes from HttpClient WebException response", DateTime.Now.ToString(CultureInfo.InvariantCulture)));
+                                System.Diagnostics.Debug.WriteLine(string.Format(CultureInfo.InvariantCulture, "DateTime {0}, Retrieved Stream Bytes from HttpClient WebException response", DateTime.Now.ToString(CultureInfo.InvariantCulture)));
                             }
                         }
                     }
 
-                    LoggingMethod.WriteToLog(pubnubLog, string.Format("DateTime: {0}, SendRequestAndGetStreamResponseHttpClient InnerException WebException status {1}", DateTime.Now.ToString(CultureInfo.InvariantCulture), ((WebException)httpReqEx.InnerException).Status.ToString()), pubnubConfig.LogVerbosity);
+                    LoggingMethod.WriteToLog(pubnubLog, string.Format(CultureInfo.InvariantCulture, "DateTime: {0}, SendRequestAndGetStreamResponseHttpClient InnerException WebException status {1}", DateTime.Now.ToString(CultureInfo.InvariantCulture), ((WebException)httpReqEx.InnerException).Status.ToString()), pubnubConfig.LogVerbosity);
                     throw httpReqEx.InnerException;
                 }
 
-                LoggingMethod.WriteToLog(pubnubLog, string.Format("DateTime: {0}, SendRequestAndGetStreamResponseHttpClient HttpRequestException {1}", DateTime.Now.ToString(CultureInfo.InvariantCulture), httpReqEx.Message), pubnubConfig.LogVerbosity);
+                LoggingMethod.WriteToLog(pubnubLog, string.Format(CultureInfo.InvariantCulture, "DateTime: {0}, SendRequestAndGetStreamResponseHttpClient HttpRequestException {1}", DateTime.Now.ToString(CultureInfo.InvariantCulture), httpReqEx.Message), pubnubConfig.LogVerbosity);
                 throw;
             }
             catch (Exception ex)
             {
-                LoggingMethod.WriteToLog(pubnubLog, string.Format("DateTime: {0}, SendRequestAndGetStreamResponseHttpClient Exception {1}", DateTime.Now.ToString(CultureInfo.InvariantCulture), ex.Message), pubnubConfig.LogVerbosity);
+                LoggingMethod.WriteToLog(pubnubLog, string.Format(CultureInfo.InvariantCulture, "DateTime: {0}, SendRequestAndGetStreamResponseHttpClient Exception {1}", DateTime.Now.ToString(CultureInfo.InvariantCulture), ex.Message), pubnubConfig.LogVerbosity);
                 throw;
             }
             finally
@@ -349,7 +349,7 @@ namespace PubnubApi
             CancellationTokenSource cts = new CancellationTokenSource();
             try
             {
-                System.Diagnostics.Debug.WriteLine(string.Format("DateTime {0}, SendRequestAndGetJsonResponseHttpClientPOST Before httpClient.GetAsync", DateTime.Now.ToString(CultureInfo.InvariantCulture)));
+                System.Diagnostics.Debug.WriteLine(string.Format(CultureInfo.InvariantCulture, "DateTime {0}, SendRequestAndGetJsonResponseHttpClientPOST Before httpClient.GetAsync", DateTime.Now.ToString(CultureInfo.InvariantCulture)));
                 cts.CancelAfter(GetTimeoutInSecondsForResponseType(pubnubRequestState.ResponseType) * 1000);
                 System.Diagnostics.Stopwatch stopWatch = new System.Diagnostics.Stopwatch();
                 stopWatch.Start();
@@ -379,7 +379,7 @@ namespace PubnubApi
                     {
                         await pubnubTelemetryMgr.StoreLatency(stopWatch.ElapsedMilliseconds, pubnubRequestState.ResponseType).ConfigureAwait(false);
                     }
-                    System.Diagnostics.Debug.WriteLine(string.Format("DateTime {0}, Got POST HttpResponseMessage for {1}", DateTime.Now.ToString(CultureInfo.InvariantCulture), requestUri));
+                    System.Diagnostics.Debug.WriteLine(string.Format(CultureInfo.InvariantCulture, "DateTime {0}, Got POST HttpResponseMessage for {1}", DateTime.Now.ToString(CultureInfo.InvariantCulture), requestUri));
                     if ((int)response.StatusCode == 204 && pubnubRequestState.ResponseType == PNOperationType.PNFileUploadOperation)
                     {
                         return "{}";
@@ -397,7 +397,7 @@ namespace PubnubApi
                 else
                 {
                     stopWatch.Stop();
-                    System.Diagnostics.Debug.WriteLine(string.Format("DateTime {0}, No POST HttpResponseMessage for {1}", DateTime.Now.ToString(CultureInfo.InvariantCulture), requestUri));
+                    System.Diagnostics.Debug.WriteLine(string.Format(CultureInfo.InvariantCulture, "DateTime {0}, No POST HttpResponseMessage for {1}", DateTime.Now.ToString(CultureInfo.InvariantCulture), requestUri));
                 }
 
             }
@@ -417,22 +417,22 @@ namespace PubnubApi
                                 jsonString = await streamReader.ReadToEndAsync().ConfigureAwait(false);
                                 System.Diagnostics.Debug.WriteLine(jsonString);
                                 System.Diagnostics.Debug.WriteLine("");
-                                System.Diagnostics.Debug.WriteLine(string.Format("DateTime {0}, Retrieved JSON from HttpClient POST WebException response", DateTime.Now.ToString(CultureInfo.InvariantCulture)));
+                                System.Diagnostics.Debug.WriteLine(string.Format(CultureInfo.InvariantCulture, "DateTime {0}, Retrieved JSON from HttpClient POST WebException response", DateTime.Now.ToString(CultureInfo.InvariantCulture)));
                                 return jsonString;
                             }
                         }
                     }
 
-                    LoggingMethod.WriteToLog(pubnubLog, string.Format("DateTime: {0}, SendRequestAndGetJsonResponseHttpClientPOST InnerException WebException status {1}", DateTime.Now.ToString(CultureInfo.InvariantCulture), ((WebException)httpReqEx.InnerException).Status.ToString()), pubnubConfig.LogVerbosity);
+                    LoggingMethod.WriteToLog(pubnubLog, string.Format(CultureInfo.InvariantCulture, "DateTime: {0}, SendRequestAndGetJsonResponseHttpClientPOST InnerException WebException status {1}", DateTime.Now.ToString(CultureInfo.InvariantCulture), ((WebException)httpReqEx.InnerException).Status.ToString()), pubnubConfig.LogVerbosity);
                     throw httpReqEx.InnerException;
                 }
 
-                LoggingMethod.WriteToLog(pubnubLog, string.Format("DateTime: {0}, SendRequestAndGetJsonResponseHttpClientPOST HttpRequestException {1}", DateTime.Now.ToString(CultureInfo.InvariantCulture), httpReqEx.Message), pubnubConfig.LogVerbosity);
+                LoggingMethod.WriteToLog(pubnubLog, string.Format(CultureInfo.InvariantCulture, "DateTime: {0}, SendRequestAndGetJsonResponseHttpClientPOST HttpRequestException {1}", DateTime.Now.ToString(CultureInfo.InvariantCulture), httpReqEx.Message), pubnubConfig.LogVerbosity);
                 throw;
             }
             catch (Exception ex)
             {
-                LoggingMethod.WriteToLog(pubnubLog, string.Format("DateTime: {0}, SendRequestAndGetJsonResponseHttpClientPOST Exception {1}", DateTime.Now.ToString(CultureInfo.InvariantCulture), ex.Message), pubnubConfig.LogVerbosity);
+                LoggingMethod.WriteToLog(pubnubLog, string.Format(CultureInfo.InvariantCulture, "DateTime: {0}, SendRequestAndGetJsonResponseHttpClientPOST Exception {1}", DateTime.Now.ToString(CultureInfo.InvariantCulture), ex.Message), pubnubConfig.LogVerbosity);
                 throw;
             }
             finally
@@ -454,7 +454,7 @@ namespace PubnubApi
             CancellationTokenSource cts = new CancellationTokenSource();
             try
             {
-                System.Diagnostics.Debug.WriteLine(string.Format("DateTime {0}, SendRequestAndGetJsonResponseHttpClientWithPATCH Before httpClient.SendAsync", DateTime.Now.ToString(CultureInfo.InvariantCulture)));
+                System.Diagnostics.Debug.WriteLine(string.Format(CultureInfo.InvariantCulture, "DateTime {0}, SendRequestAndGetJsonResponseHttpClientWithPATCH Before httpClient.SendAsync", DateTime.Now.ToString(CultureInfo.InvariantCulture)));
                 cts.CancelAfter(GetTimeoutInSecondsForResponseType(pubnubRequestState.ResponseType) * 1000);
                 System.Diagnostics.Stopwatch stopWatch = new System.Diagnostics.Stopwatch();
                 stopWatch.Start();
@@ -496,12 +496,12 @@ namespace PubnubApi
                         jsonString = await streamReader.ReadToEndAsync().ConfigureAwait(false);
                         pubnubRequestState.GotJsonResponse = true;
                     }
-                    System.Diagnostics.Debug.WriteLine(string.Format("DateTime {0}, Got POST HttpResponseMessage for {1}", DateTime.Now.ToString(CultureInfo.InvariantCulture), requestUri));
+                    System.Diagnostics.Debug.WriteLine(string.Format(CultureInfo.InvariantCulture, "DateTime {0}, Got POST HttpResponseMessage for {1}", DateTime.Now.ToString(CultureInfo.InvariantCulture), requestUri));
                 }
                 else
                 {
                     stopWatch.Stop();
-                    System.Diagnostics.Debug.WriteLine(string.Format("DateTime {0}, No POST HttpResponseMessage for {1}", DateTime.Now.ToString(CultureInfo.InvariantCulture), requestUri));
+                    System.Diagnostics.Debug.WriteLine(string.Format(CultureInfo.InvariantCulture, "DateTime {0}, No POST HttpResponseMessage for {1}", DateTime.Now.ToString(CultureInfo.InvariantCulture), requestUri));
                 }
 
             }
@@ -521,22 +521,22 @@ namespace PubnubApi
                                 jsonString = await streamReader.ReadToEndAsync().ConfigureAwait(false);
                                 System.Diagnostics.Debug.WriteLine(jsonString);
                                 System.Diagnostics.Debug.WriteLine("");
-                                System.Diagnostics.Debug.WriteLine(string.Format("DateTime {0}, Retrieved JSON from HttpClient POST WebException response", DateTime.Now.ToString(CultureInfo.InvariantCulture)));
+                                System.Diagnostics.Debug.WriteLine(string.Format(CultureInfo.InvariantCulture, "DateTime {0}, Retrieved JSON from HttpClient POST WebException response", DateTime.Now.ToString(CultureInfo.InvariantCulture)));
                                 return jsonString;
                             }
                         }
                     }
 
-                    LoggingMethod.WriteToLog(pubnubLog, string.Format("DateTime: {0}, SendRequestAndGetJsonResponseHttpClientPOST InnerException WebException status {1}", DateTime.Now.ToString(CultureInfo.InvariantCulture), ((WebException)httpReqEx.InnerException).Status.ToString()), pubnubConfig.LogVerbosity);
+                    LoggingMethod.WriteToLog(pubnubLog, string.Format(CultureInfo.InvariantCulture, "DateTime: {0}, SendRequestAndGetJsonResponseHttpClientPOST InnerException WebException status {1}", DateTime.Now.ToString(CultureInfo.InvariantCulture), ((WebException)httpReqEx.InnerException).Status.ToString()), pubnubConfig.LogVerbosity);
                     throw httpReqEx.InnerException;
                 }
 
-                LoggingMethod.WriteToLog(pubnubLog, string.Format("DateTime: {0}, SendRequestAndGetJsonResponseHttpClientPOST HttpRequestException {1}", DateTime.Now.ToString(CultureInfo.InvariantCulture), httpReqEx.Message), pubnubConfig.LogVerbosity);
+                LoggingMethod.WriteToLog(pubnubLog, string.Format(CultureInfo.InvariantCulture, "DateTime: {0}, SendRequestAndGetJsonResponseHttpClientPOST HttpRequestException {1}", DateTime.Now.ToString(CultureInfo.InvariantCulture), httpReqEx.Message), pubnubConfig.LogVerbosity);
                 throw;
             }
             catch (Exception ex)
             {
-                LoggingMethod.WriteToLog(pubnubLog, string.Format("DateTime: {0}, SendRequestAndGetJsonResponseHttpClientPOST Exception {1}", DateTime.Now.ToString(CultureInfo.InvariantCulture), ex.Message), pubnubConfig.LogVerbosity);
+                LoggingMethod.WriteToLog(pubnubLog, string.Format(CultureInfo.InvariantCulture, "DateTime: {0}, SendRequestAndGetJsonResponseHttpClientPOST Exception {1}", DateTime.Now.ToString(CultureInfo.InvariantCulture), ex.Message), pubnubConfig.LogVerbosity);
                 throw;
             }
             finally
@@ -555,11 +555,11 @@ namespace PubnubApi
         async Task<string> SendRequestAndGetJsonResponseTaskFactory<T>(RequestState<T> pubnubRequestState, HttpWebRequest request)
         {
             HttpWebResponse response = null;
-            LoggingMethod.WriteToLog(pubnubLog, string.Format("DateTime: {0}, Inside SendRequestAndGetJsonResponseTaskFactory", DateTime.Now.ToString(CultureInfo.InvariantCulture)), pubnubConfig.LogVerbosity);
+            LoggingMethod.WriteToLog(pubnubLog, string.Format(CultureInfo.InvariantCulture, "DateTime: {0}, Inside SendRequestAndGetJsonResponseTaskFactory", DateTime.Now.ToString(CultureInfo.InvariantCulture)), pubnubConfig.LogVerbosity);
             try
             {
                 request.Method = FindHttpGetOrDeleteMethod(pubnubRequestState);
-                new Timer(OnPubnubWebRequestTimeout<T>, pubnubRequestState, GetTimeoutInSecondsForResponseType(pubnubRequestState.ResponseType) * 1000, Timeout.Infinite);
+                var _ = new Timer(OnPubnubWebRequestTimeout<T>, pubnubRequestState, GetTimeoutInSecondsForResponseType(pubnubRequestState.ResponseType) * 1000, Timeout.Infinite);
                 System.Diagnostics.Stopwatch stopWatch = new System.Diagnostics.Stopwatch();
                 stopWatch.Start();
                 response = await Task.Factory.FromAsync<HttpWebResponse>(request.BeginGetResponse, asyncPubnubResult => (HttpWebResponse)request.EndGetResponse(asyncPubnubResult), pubnubRequestState).ConfigureAwait(false);
@@ -569,7 +569,7 @@ namespace PubnubApi
                     await pubnubTelemetryMgr.StoreLatency(stopWatch.ElapsedMilliseconds, pubnubRequestState.ResponseType).ConfigureAwait(false);
                 }
                 pubnubRequestState.Response = response;
-                System.Diagnostics.Debug.WriteLine(string.Format("DateTime {0}, Got PubnubWebResponse for {1}", DateTime.Now.ToString(CultureInfo.InvariantCulture), request.RequestUri.ToString()));
+                System.Diagnostics.Debug.WriteLine(string.Format(CultureInfo.InvariantCulture, "DateTime {0}, Got PubnubWebResponse for {1}", DateTime.Now.ToString(CultureInfo.InvariantCulture), request.RequestUri.ToString()));
                 using (StreamReader streamReader = new StreamReader(response.GetResponseStream()))
                 {
                     //Need to return this response 
@@ -581,7 +581,7 @@ namespace PubnubApi
                     System.Diagnostics.Debug.WriteLine(jsonString);
                     pubnubRequestState.GotJsonResponse = true;
                     System.Diagnostics.Debug.WriteLine("");
-                    System.Diagnostics.Debug.WriteLine(string.Format("DateTime {0}, Retrieved JSON", DateTime.Now.ToString(CultureInfo.InvariantCulture)));
+                    System.Diagnostics.Debug.WriteLine(string.Format(CultureInfo.InvariantCulture, "DateTime {0}, Retrieved JSON", DateTime.Now.ToString(CultureInfo.InvariantCulture)));
 
                     if (pubnubRequestState.Response != null)
                     {
@@ -610,13 +610,13 @@ namespace PubnubApi
 #endif
                         System.Diagnostics.Debug.WriteLine(jsonString);
                         System.Diagnostics.Debug.WriteLine("");
-                        System.Diagnostics.Debug.WriteLine(string.Format("DateTime {0}, Retrieved JSON from WebException response", DateTime.Now.ToString(CultureInfo.InvariantCulture)));
+                        System.Diagnostics.Debug.WriteLine(string.Format(CultureInfo.InvariantCulture, "DateTime {0}, Retrieved JSON from WebException response", DateTime.Now.ToString(CultureInfo.InvariantCulture)));
                         return jsonString;
                     }
                 }
 
-                if (ex.Message.IndexOf("The request was aborted: The request was canceled") == -1
-                                && ex.Message.IndexOf("Machine suspend mode enabled. No request will be processed.") == -1)
+                if (ex.Message.IndexOf("The request was aborted: The request was canceled", StringComparison.OrdinalIgnoreCase) == -1
+                                && ex.Message.IndexOf("Machine suspend mode enabled. No request will be processed.", StringComparison.OrdinalIgnoreCase) == -1)
                 {
                     throw;
                 }
@@ -632,11 +632,11 @@ namespace PubnubApi
         {
             HttpWebResponse response = null;
             byte[] streamBytes;
-            LoggingMethod.WriteToLog(pubnubLog, string.Format("DateTime: {0}, Inside SendRequestAndGetStreamResponseTaskFactory", DateTime.Now.ToString(CultureInfo.InvariantCulture)), pubnubConfig.LogVerbosity);
+            LoggingMethod.WriteToLog(pubnubLog, string.Format(CultureInfo.InvariantCulture, "DateTime: {0}, Inside SendRequestAndGetStreamResponseTaskFactory", DateTime.Now.ToString(CultureInfo.InvariantCulture)), pubnubConfig.LogVerbosity);
             try
             {
                 request.Method = FindHttpGetOrDeleteMethod(pubnubRequestState);
-                new Timer(OnPubnubWebRequestTimeout<T>, pubnubRequestState, GetTimeoutInSecondsForResponseType(pubnubRequestState.ResponseType) * 1000, Timeout.Infinite);
+                var _ = new Timer(OnPubnubWebRequestTimeout<T>, pubnubRequestState, GetTimeoutInSecondsForResponseType(pubnubRequestState.ResponseType) * 1000, Timeout.Infinite);
                 System.Diagnostics.Stopwatch stopWatch = new System.Diagnostics.Stopwatch();
                 stopWatch.Start();
                 response = await Task.Factory.FromAsync<HttpWebResponse>(request.BeginGetResponse, asyncPubnubResult => (HttpWebResponse)request.EndGetResponse(asyncPubnubResult), pubnubRequestState).ConfigureAwait(false);
@@ -646,9 +646,9 @@ namespace PubnubApi
                     await pubnubTelemetryMgr.StoreLatency(stopWatch.ElapsedMilliseconds, pubnubRequestState.ResponseType).ConfigureAwait(false);
                 }
                 pubnubRequestState.Response = response;
-                System.Diagnostics.Debug.WriteLine(string.Format("DateTime {0}, Got PubnubWebResponse for {1}", DateTime.Now.ToString(CultureInfo.InvariantCulture), request.RequestUri.ToString()));
+                System.Diagnostics.Debug.WriteLine(string.Format(CultureInfo.InvariantCulture, "DateTime {0}, Got PubnubWebResponse for {1}", DateTime.Now.ToString(CultureInfo.InvariantCulture), request.RequestUri.ToString()));
                 int statusCode = (int)pubnubRequestState.Response.StatusCode;
-                System.Diagnostics.Debug.WriteLine(string.Format("DateTime {0}, status code = {1}", DateTime.Now.ToString(CultureInfo.InvariantCulture), statusCode));
+                System.Diagnostics.Debug.WriteLine(string.Format(CultureInfo.InvariantCulture, "DateTime {0}, status code = {1}", DateTime.Now.ToString(CultureInfo.InvariantCulture), statusCode));
                 using (Stream stream = response.GetResponseStream())
                 {
                     long totalSize = 0;
@@ -671,11 +671,11 @@ namespace PubnubApi
                         }
                         streamBytes = ms.ToArray();
                     }
-                    System.Diagnostics.Debug.WriteLine(string.Format("DateTime {0}, totalsize = {1}; received = {2}", DateTime.Now.ToString(CultureInfo.InvariantCulture), totalSize, receivedSize));
+                    System.Diagnostics.Debug.WriteLine(string.Format(CultureInfo.InvariantCulture, "DateTime {0}, totalsize = {1}; received = {2}", DateTime.Now.ToString(CultureInfo.InvariantCulture), totalSize, receivedSize));
                     //Need to return this response 
                     pubnubRequestState.GotJsonResponse = true;
                     System.Diagnostics.Debug.WriteLine("");
-                    System.Diagnostics.Debug.WriteLine(string.Format("DateTime {0}, Retrieved Stream", DateTime.Now.ToString(CultureInfo.InvariantCulture)));
+                    System.Diagnostics.Debug.WriteLine(string.Format(CultureInfo.InvariantCulture, "DateTime {0}, Retrieved Stream", DateTime.Now.ToString(CultureInfo.InvariantCulture)));
 
                     if (pubnubRequestState.Response != null)
                     {
@@ -691,8 +691,8 @@ namespace PubnubApi
             }
             catch (WebException ex)
             {
-                if (ex.Message.IndexOf("The request was aborted: The request was canceled") == -1
-                                && ex.Message.IndexOf("Machine suspend mode enabled. No request will be processed.") == -1)
+                if (ex.Message.IndexOf("The request was aborted: The request was canceled", StringComparison.OrdinalIgnoreCase) == -1
+                                && ex.Message.IndexOf("Machine suspend mode enabled. No request will be processed.", StringComparison.OrdinalIgnoreCase) == -1)
                 {
                     throw;
                 }
@@ -700,14 +700,14 @@ namespace PubnubApi
             }
             catch (Exception ex)
             {
-                System.Diagnostics.Debug.WriteLine(string.Format("DateTime {0}, Exception in SendRequestAndGetStreamResponseTaskFactory {1}", DateTime.Now.ToString(CultureInfo.InvariantCulture), ex));
+                System.Diagnostics.Debug.WriteLine(string.Format(CultureInfo.InvariantCulture, "DateTime {0}, Exception in SendRequestAndGetStreamResponseTaskFactory {1}", DateTime.Now.ToString(CultureInfo.InvariantCulture), ex));
                 throw;
             }
         }
 
         async Task<string> SendRequestAndGetJsonResponseTaskFactoryWithPOST<T>(RequestState<T> pubnubRequestState, HttpWebRequest request, byte[] postData, string contentType)
         {
-            System.Diagnostics.Debug.WriteLine(string.Format("DateTime {0}, Before Task.Factory.FromAsync With POST", DateTime.Now.ToString(CultureInfo.InvariantCulture)));
+            System.Diagnostics.Debug.WriteLine(string.Format(CultureInfo.InvariantCulture, "DateTime {0}, Before Task.Factory.FromAsync With POST", DateTime.Now.ToString(CultureInfo.InvariantCulture)));
             try
             {
                 request.Method = "POST";
@@ -737,9 +737,9 @@ namespace PubnubApi
                     await pubnubTelemetryMgr.StoreLatency(stopWatch.ElapsedMilliseconds, pubnubRequestState.ResponseType).ConfigureAwait(false);
                 }
                 pubnubRequestState.Response = response as HttpWebResponse;
-                System.Diagnostics.Debug.WriteLine(string.Format("DateTime {0}, Got PubnubWebResponse With POST for {1}", DateTime.Now.ToString(CultureInfo.InvariantCulture), request.RequestUri.ToString()));
+                System.Diagnostics.Debug.WriteLine(string.Format(CultureInfo.InvariantCulture, "DateTime {0}, Got PubnubWebResponse With POST for {1}", DateTime.Now.ToString(CultureInfo.InvariantCulture), request.RequestUri.ToString()));
                 int statusCode = (int)pubnubRequestState.Response.StatusCode;
-                System.Diagnostics.Debug.WriteLine(string.Format("DateTime {0}, statusCode {1}", DateTime.Now.ToString(CultureInfo.InvariantCulture), statusCode));
+                System.Diagnostics.Debug.WriteLine(string.Format(CultureInfo.InvariantCulture, "DateTime {0}, statusCode {1}", DateTime.Now.ToString(CultureInfo.InvariantCulture), statusCode));
                 if (statusCode == 204 && pubnubRequestState.ResponseType == PNOperationType.PNFileUploadOperation)
                 {
                     return "{}";
@@ -756,7 +756,7 @@ namespace PubnubApi
 #endif
                         System.Diagnostics.Debug.WriteLine(jsonString);
                         System.Diagnostics.Debug.WriteLine("");
-                        System.Diagnostics.Debug.WriteLine(string.Format("DateTime {0}, Retrieved JSON With POST", DateTime.Now.ToString(CultureInfo.InvariantCulture)));
+                        System.Diagnostics.Debug.WriteLine(string.Format(CultureInfo.InvariantCulture, "DateTime {0}, Retrieved JSON With POST", DateTime.Now.ToString(CultureInfo.InvariantCulture)));
                         pubnubRequestState.GotJsonResponse = true;
 
                         if (pubnubRequestState.Response != null)
@@ -787,13 +787,13 @@ namespace PubnubApi
 #endif
                         System.Diagnostics.Debug.WriteLine(jsonString);
                         System.Diagnostics.Debug.WriteLine("");
-                        System.Diagnostics.Debug.WriteLine(string.Format("DateTime {0}, Retrieved JSON  With POST from WebException response", DateTime.Now.ToString(CultureInfo.InvariantCulture)));
+                        System.Diagnostics.Debug.WriteLine(string.Format(CultureInfo.InvariantCulture, "DateTime {0}, Retrieved JSON  With POST from WebException response", DateTime.Now.ToString(CultureInfo.InvariantCulture)));
                         return jsonString;
                     }
                 }
 
-                if (ex.Message.IndexOf("The request was aborted: The request was canceled") == -1
-                                && ex.Message.IndexOf("Machine suspend mode enabled. No request will be processed.") == -1)
+                if (ex.Message.IndexOf("The request was aborted: The request was canceled", StringComparison.OrdinalIgnoreCase) == -1
+                                && ex.Message.IndexOf("Machine suspend mode enabled. No request will be processed.", StringComparison.OrdinalIgnoreCase) == -1)
                 {
                     throw;
                 }
@@ -801,14 +801,14 @@ namespace PubnubApi
             }
             catch (Exception ex)
             {
-                System.Diagnostics.Debug.WriteLine(string.Format("DateTime {0}, Exception in SendRequestAndGetJsonResponseTaskFactoryWithPOST {1}", DateTime.Now.ToString(CultureInfo.InvariantCulture), ex));
+                System.Diagnostics.Debug.WriteLine(string.Format(CultureInfo.InvariantCulture, "DateTime {0}, Exception in SendRequestAndGetJsonResponseTaskFactoryWithPOST {1}", DateTime.Now.ToString(CultureInfo.InvariantCulture), ex));
                 throw;
             }
         }
 
         async Task<string> SendRequestAndGetJsonResponseTaskFactoryWithPATCH<T>(RequestState<T> pubnubRequestState, HttpWebRequest request, byte[] patchData, string contentType)
         {
-            System.Diagnostics.Debug.WriteLine(string.Format("DateTime {0}, Before Task.Factory.FromAsync With PATCH", DateTime.Now.ToString(CultureInfo.InvariantCulture)));
+            System.Diagnostics.Debug.WriteLine(string.Format(CultureInfo.InvariantCulture, "DateTime {0}, Before Task.Factory.FromAsync With PATCH", DateTime.Now.ToString(CultureInfo.InvariantCulture)));
             try
             {
                 request.Method = "PATCH";
@@ -841,7 +841,7 @@ namespace PubnubApi
                     await pubnubTelemetryMgr.StoreLatency(stopWatch.ElapsedMilliseconds, pubnubRequestState.ResponseType).ConfigureAwait(false);
                 }
                 pubnubRequestState.Response = response as HttpWebResponse;
-                System.Diagnostics.Debug.WriteLine(string.Format("DateTime {0}, Got PubnubWebResponse With PATCH for {1}", DateTime.Now.ToString(CultureInfo.InvariantCulture), request.RequestUri.ToString()));
+                System.Diagnostics.Debug.WriteLine(string.Format(CultureInfo.InvariantCulture, "DateTime {0}, Got PubnubWebResponse With PATCH for {1}", DateTime.Now.ToString(CultureInfo.InvariantCulture), request.RequestUri.ToString()));
                 using (StreamReader streamReader = new StreamReader(response.GetResponseStream()))
                 {
                     //Need to return this response 
@@ -852,7 +852,7 @@ namespace PubnubApi
 #endif
                     System.Diagnostics.Debug.WriteLine(jsonString);
                     System.Diagnostics.Debug.WriteLine("");
-                    System.Diagnostics.Debug.WriteLine(string.Format("DateTime {0}, Retrieved JSON With PATCH", DateTime.Now.ToString(CultureInfo.InvariantCulture)));
+                    System.Diagnostics.Debug.WriteLine(string.Format(CultureInfo.InvariantCulture, "DateTime {0}, Retrieved JSON With PATCH", DateTime.Now.ToString(CultureInfo.InvariantCulture)));
                     pubnubRequestState.GotJsonResponse = true;
 
                     if (pubnubRequestState.Response != null)
@@ -882,13 +882,13 @@ namespace PubnubApi
 #endif
                         System.Diagnostics.Debug.WriteLine(jsonString);
                         System.Diagnostics.Debug.WriteLine("");
-                        System.Diagnostics.Debug.WriteLine(string.Format("DateTime {0}, Retrieved JSON  With PATCH from WebException response", DateTime.Now.ToString(CultureInfo.InvariantCulture)));
+                        System.Diagnostics.Debug.WriteLine(string.Format(CultureInfo.InvariantCulture, "DateTime {0}, Retrieved JSON  With PATCH from WebException response", DateTime.Now.ToString(CultureInfo.InvariantCulture)));
                         return jsonString;
                     }
                 }
 
-                if (ex.Message.IndexOf("The request was aborted: The request was canceled") == -1
-                                && ex.Message.IndexOf("Machine suspend mode enabled. No request will be processed.") == -1)
+                if (ex.Message.IndexOf("The request was aborted: The request was canceled", StringComparison.OrdinalIgnoreCase) == -1
+                                && ex.Message.IndexOf("Machine suspend mode enabled. No request will be processed.", StringComparison.OrdinalIgnoreCase) == -1)
                 {
                     throw;
                 }
@@ -902,12 +902,12 @@ namespace PubnubApi
 
         async Task<string> SendRequestAndGetJsonResponseClassicHttp<T>(Uri requestUri, RequestState<T> pubnubRequestState, HttpWebRequest request)
         {
-            LoggingMethod.WriteToLog(pubnubLog, string.Format("DateTime: {0}, Inside SendRequestAndGetJsonResponseClassicHttp", DateTime.Now.ToString(CultureInfo.InvariantCulture)), pubnubConfig.LogVerbosity);
+            LoggingMethod.WriteToLog(pubnubLog, string.Format(CultureInfo.InvariantCulture, "DateTime: {0}, Inside SendRequestAndGetJsonResponseClassicHttp", DateTime.Now.ToString(CultureInfo.InvariantCulture)), pubnubConfig.LogVerbosity);
             var taskComplete = new TaskCompletionSource<string>();
             try
             {
                 request.Method = FindHttpGetOrDeleteMethod<T>(pubnubRequestState);
-                System.Diagnostics.Debug.WriteLine(string.Format("DateTime {0}, Before BeginGetResponse", DateTime.Now.ToString(CultureInfo.InvariantCulture)));
+                System.Diagnostics.Debug.WriteLine(string.Format(CultureInfo.InvariantCulture, "DateTime {0}, Before BeginGetResponse", DateTime.Now.ToString(CultureInfo.InvariantCulture)));
                 System.Diagnostics.Stopwatch stopWatch = new System.Diagnostics.Stopwatch();
                 stopWatch.Start();
                 request.BeginGetResponse(new AsyncCallback(
@@ -916,7 +916,7 @@ namespace PubnubApi
                         HttpWebRequest asyncWebRequest = asyncRequestState.Request as HttpWebRequest;
                         if (asyncWebRequest != null)
                         {
-                            System.Diagnostics.Debug.WriteLine(string.Format("DateTime {0}, Before EndGetResponse", DateTime.Now.ToString(CultureInfo.InvariantCulture)));
+                            System.Diagnostics.Debug.WriteLine(string.Format(CultureInfo.InvariantCulture, "DateTime {0}, Before EndGetResponse", DateTime.Now.ToString(CultureInfo.InvariantCulture)));
                             HttpWebResponse asyncWebResponse = (HttpWebResponse)asyncWebRequest.EndGetResponse(asynchronousResult);
                             stopWatch.Stop();
                             if (pubnubTelemetryMgr != null)
@@ -924,17 +924,17 @@ namespace PubnubApi
                                 await pubnubTelemetryMgr.StoreLatency(stopWatch.ElapsedMilliseconds, pubnubRequestState.ResponseType).ConfigureAwait(false);
                             }
                             asyncRequestState.Response = asyncWebResponse;
-                            System.Diagnostics.Debug.WriteLine(string.Format("DateTime {0}, After EndGetResponse", DateTime.Now.ToString(CultureInfo.InvariantCulture)));
+                            System.Diagnostics.Debug.WriteLine(string.Format(CultureInfo.InvariantCulture, "DateTime {0}, After EndGetResponse", DateTime.Now.ToString(CultureInfo.InvariantCulture)));
                             using (StreamReader streamReader = new StreamReader(asyncWebResponse.GetResponseStream()))
                             {
-                                System.Diagnostics.Debug.WriteLine(string.Format("DateTime {0}, Inside StreamReader", DateTime.Now.ToString(CultureInfo.InvariantCulture)));
+                                System.Diagnostics.Debug.WriteLine(string.Format(CultureInfo.InvariantCulture, "DateTime {0}, Inside StreamReader", DateTime.Now.ToString(CultureInfo.InvariantCulture)));
                                 //Need to return this response 
                                 string jsonString = streamReader.ReadToEnd();
                                 asyncRequestState.GotJsonResponse = true;
 
                                 System.Diagnostics.Debug.WriteLine(jsonString);
                                 System.Diagnostics.Debug.WriteLine("");
-                                System.Diagnostics.Debug.WriteLine(string.Format("DateTime {0}, Retrieved JSON", DateTime.Now.ToString(CultureInfo.InvariantCulture)));
+                                System.Diagnostics.Debug.WriteLine(string.Format(CultureInfo.InvariantCulture, "DateTime {0}, Retrieved JSON", DateTime.Now.ToString(CultureInfo.InvariantCulture)));
                                 taskComplete.TrySetResult(jsonString);
                             }
                             if (asyncRequestState.Response != null)
@@ -968,13 +968,13 @@ namespace PubnubApi
 #endif
                         System.Diagnostics.Debug.WriteLine(jsonString);
                         System.Diagnostics.Debug.WriteLine("");
-                        System.Diagnostics.Debug.WriteLine(string.Format("DateTime {0}, Retrieved JSON from WebException response", DateTime.Now.ToString(CultureInfo.InvariantCulture)));
+                        System.Diagnostics.Debug.WriteLine(string.Format(CultureInfo.InvariantCulture, "DateTime {0}, Retrieved JSON from WebException response", DateTime.Now.ToString(CultureInfo.InvariantCulture)));
                         return jsonString;
                     }
                 }
                 
-                if (ex.Message.IndexOf("The request was aborted: The request was canceled") == -1
-                                && ex.Message.IndexOf("Machine suspend mode enabled. No request will be processed.") == -1)
+                if (ex.Message.IndexOf("The request was aborted: The request was canceled", StringComparison.OrdinalIgnoreCase) == -1
+                                && ex.Message.IndexOf("Machine suspend mode enabled. No request will be processed.", StringComparison.OrdinalIgnoreCase) == -1)
                 {
                     taskComplete.TrySetException(ex);
                 }
@@ -989,12 +989,12 @@ namespace PubnubApi
 
         async Task<byte[]> SendRequestAndGetStreamResponseClassicHttp<T>(RequestState<T> pubnubRequestState, HttpWebRequest request)
         {
-            LoggingMethod.WriteToLog(pubnubLog, string.Format("DateTime: {0}, Inside SendRequestAndGetStreamResponseClassicHttp", DateTime.Now.ToString(CultureInfo.InvariantCulture)), pubnubConfig.LogVerbosity);
+            LoggingMethod.WriteToLog(pubnubLog, string.Format(CultureInfo.InvariantCulture, "DateTime: {0}, Inside SendRequestAndGetStreamResponseClassicHttp", DateTime.Now.ToString(CultureInfo.InvariantCulture)), pubnubConfig.LogVerbosity);
             var taskComplete = new TaskCompletionSource<byte[]>();
             try
             {
                 request.Method = FindHttpGetOrDeleteMethod<T>(pubnubRequestState);
-                System.Diagnostics.Debug.WriteLine(string.Format("DateTime {0}, Before BeginGetResponse", DateTime.Now.ToString(CultureInfo.InvariantCulture)));
+                System.Diagnostics.Debug.WriteLine(string.Format(CultureInfo.InvariantCulture, "DateTime {0}, Before BeginGetResponse", DateTime.Now.ToString(CultureInfo.InvariantCulture)));
                 System.Diagnostics.Stopwatch stopWatch = new System.Diagnostics.Stopwatch();
                 stopWatch.Start();
                 request.BeginGetResponse(new AsyncCallback(
@@ -1003,7 +1003,7 @@ namespace PubnubApi
                         HttpWebRequest asyncWebRequest = asyncRequestState.Request as HttpWebRequest;
                         if (asyncWebRequest != null)
                         {
-                            System.Diagnostics.Debug.WriteLine(string.Format("DateTime {0}, Before EndGetResponse", DateTime.Now.ToString(CultureInfo.InvariantCulture)));
+                            System.Diagnostics.Debug.WriteLine(string.Format(CultureInfo.InvariantCulture, "DateTime {0}, Before EndGetResponse", DateTime.Now.ToString(CultureInfo.InvariantCulture)));
                             HttpWebResponse asyncWebResponse = (HttpWebResponse)asyncWebRequest.EndGetResponse(asynchronousResult);
                             stopWatch.Stop();
                             if (pubnubTelemetryMgr != null)
@@ -1011,17 +1011,17 @@ namespace PubnubApi
                                 await pubnubTelemetryMgr.StoreLatency(stopWatch.ElapsedMilliseconds, pubnubRequestState.ResponseType).ConfigureAwait(false);
                             }
                             asyncRequestState.Response = asyncWebResponse;
-                            System.Diagnostics.Debug.WriteLine(string.Format("DateTime {0}, After EndGetResponse", DateTime.Now.ToString(CultureInfo.InvariantCulture)));
+                            System.Diagnostics.Debug.WriteLine(string.Format(CultureInfo.InvariantCulture, "DateTime {0}, After EndGetResponse", DateTime.Now.ToString(CultureInfo.InvariantCulture)));
                             using (StreamReader streamReader = new StreamReader(asyncWebResponse.GetResponseStream()))
                             {
-                                System.Diagnostics.Debug.WriteLine(string.Format("DateTime {0}, Inside StreamReader", DateTime.Now.ToString(CultureInfo.InvariantCulture)));
+                                System.Diagnostics.Debug.WriteLine(string.Format(CultureInfo.InvariantCulture, "DateTime {0}, Inside StreamReader", DateTime.Now.ToString(CultureInfo.InvariantCulture)));
                                 //Need to return this response 
                                 string jsonString = streamReader.ReadToEnd();
                                 asyncRequestState.GotJsonResponse = true;
 
                                 System.Diagnostics.Debug.WriteLine(jsonString);
                                 System.Diagnostics.Debug.WriteLine("");
-                                System.Diagnostics.Debug.WriteLine(string.Format("DateTime {0}, Retrieved JSON", DateTime.Now.ToString(CultureInfo.InvariantCulture)));
+                                System.Diagnostics.Debug.WriteLine(string.Format(CultureInfo.InvariantCulture, "DateTime {0}, Retrieved JSON", DateTime.Now.ToString(CultureInfo.InvariantCulture)));
                                 taskComplete.TrySetResult(null);
                             }
                             if (asyncRequestState.Response != null)
@@ -1055,13 +1055,13 @@ namespace PubnubApi
 #endif
                         System.Diagnostics.Debug.WriteLine(jsonString);
                         System.Diagnostics.Debug.WriteLine("");
-                        System.Diagnostics.Debug.WriteLine(string.Format("DateTime {0}, Retrieved JSON from WebException response", DateTime.Now.ToString(CultureInfo.InvariantCulture)));
+                        System.Diagnostics.Debug.WriteLine(string.Format(CultureInfo.InvariantCulture, "DateTime {0}, Retrieved JSON from WebException response", DateTime.Now.ToString(CultureInfo.InvariantCulture)));
                         return null;
                     }
                 }
 
-                if (ex.Message.IndexOf("The request was aborted: The request was canceled") == -1
-                                && ex.Message.IndexOf("Machine suspend mode enabled. No request will be processed.") == -1)
+                if (ex.Message.IndexOf("The request was aborted: The request was canceled", StringComparison.OrdinalIgnoreCase) == -1
+                                && ex.Message.IndexOf("Machine suspend mode enabled. No request will be processed.", StringComparison.OrdinalIgnoreCase) == -1)
                 {
                     taskComplete.TrySetException(ex);
                 }
@@ -1076,7 +1076,7 @@ namespace PubnubApi
 
         async Task<string> SendRequestAndGetJsonResponseClassicHttpWithPOST<T>(RequestState<T> pubnubRequestState, HttpWebRequest request, byte[] postData, string contentType)
         {
-            LoggingMethod.WriteToLog(pubnubLog, string.Format("DateTime: {0}, Inside SendRequestAndGetJsonResponseClassicHttpWithPOST", DateTime.Now.ToString(CultureInfo.InvariantCulture)), pubnubConfig.LogVerbosity);
+            LoggingMethod.WriteToLog(pubnubLog, string.Format(CultureInfo.InvariantCulture, "DateTime: {0}, Inside SendRequestAndGetJsonResponseClassicHttpWithPOST", DateTime.Now.ToString(CultureInfo.InvariantCulture)), pubnubConfig.LogVerbosity);
             var taskComplete = new TaskCompletionSource<string>();
             try
             {
@@ -1105,7 +1105,7 @@ namespace PubnubApi
                         HttpWebRequest asyncWebRequest = asyncRequestState.Request as HttpWebRequest;
                         if (asyncWebRequest != null)
                         {
-                            System.Diagnostics.Debug.WriteLine(string.Format("DateTime {0}, Before EndGetResponse With POST ", DateTime.Now.ToString(CultureInfo.InvariantCulture)));
+                            System.Diagnostics.Debug.WriteLine(string.Format(CultureInfo.InvariantCulture, "DateTime {0}, Before EndGetResponse With POST ", DateTime.Now.ToString(CultureInfo.InvariantCulture)));
                             HttpWebResponse asyncWebResponse = (HttpWebResponse)asyncWebRequest.EndGetResponse(asynchronousResult);
                             stopWatch.Stop();
                             if (pubnubTelemetryMgr != null)
@@ -1113,17 +1113,17 @@ namespace PubnubApi
                                 await pubnubTelemetryMgr.StoreLatency(stopWatch.ElapsedMilliseconds, pubnubRequestState.ResponseType).ConfigureAwait(false);
                             }
                             asyncRequestState.Response = asyncWebResponse;
-                            System.Diagnostics.Debug.WriteLine(string.Format("DateTime {0}, After EndGetResponse With POST ", DateTime.Now.ToString(CultureInfo.InvariantCulture)));
+                            System.Diagnostics.Debug.WriteLine(string.Format(CultureInfo.InvariantCulture, "DateTime {0}, After EndGetResponse With POST ", DateTime.Now.ToString(CultureInfo.InvariantCulture)));
                             using (StreamReader streamReader = new StreamReader(asyncWebResponse.GetResponseStream()))
                             {
-                                System.Diagnostics.Debug.WriteLine(string.Format("DateTime {0}, Inside StreamReader With POST ", DateTime.Now.ToString(CultureInfo.InvariantCulture)));
+                                System.Diagnostics.Debug.WriteLine(string.Format(CultureInfo.InvariantCulture, "DateTime {0}, Inside StreamReader With POST ", DateTime.Now.ToString(CultureInfo.InvariantCulture)));
                                 //Need to return this response 
                                 string jsonString = streamReader.ReadToEnd();
                                 asyncRequestState.GotJsonResponse = true;
 
                                 System.Diagnostics.Debug.WriteLine(jsonString);
                                 System.Diagnostics.Debug.WriteLine("");
-                                System.Diagnostics.Debug.WriteLine(string.Format("DateTime {0}, Retrieved JSON With POST ", DateTime.Now.ToString(CultureInfo.InvariantCulture)));
+                                System.Diagnostics.Debug.WriteLine(string.Format(CultureInfo.InvariantCulture, "DateTime {0}, Retrieved JSON With POST ", DateTime.Now.ToString(CultureInfo.InvariantCulture)));
                                 taskComplete.TrySetResult(jsonString);
                             }
                             if (asyncRequestState.Response != null)
@@ -1158,13 +1158,13 @@ namespace PubnubApi
 #endif
                         System.Diagnostics.Debug.WriteLine(jsonString);
                         System.Diagnostics.Debug.WriteLine("");
-                        System.Diagnostics.Debug.WriteLine(string.Format("DateTime {0}, Retrieved JSON  With POST from WebException response", DateTime.Now.ToString(CultureInfo.InvariantCulture)));
+                        System.Diagnostics.Debug.WriteLine(string.Format(CultureInfo.InvariantCulture, "DateTime {0}, Retrieved JSON  With POST from WebException response", DateTime.Now.ToString(CultureInfo.InvariantCulture)));
                         return jsonString;
                     }
                 }
 
-                if (ex.Message.IndexOf("The request was aborted: The request was canceled") == -1
-                                && ex.Message.IndexOf("Machine suspend mode enabled. No request will be processed.") == -1)
+                if (ex.Message.IndexOf("The request was aborted: The request was canceled", StringComparison.OrdinalIgnoreCase) == -1
+                                && ex.Message.IndexOf("Machine suspend mode enabled. No request will be processed.", StringComparison.OrdinalIgnoreCase) == -1)
                 {
                     taskComplete.TrySetException(ex);
                 }
@@ -1179,7 +1179,7 @@ namespace PubnubApi
 
         async Task<string> SendRequestAndGetJsonResponseClassicHttpWithPATCH<T>(RequestState<T> pubnubRequestState, HttpWebRequest request, byte[] patchData)
         {
-            LoggingMethod.WriteToLog(pubnubLog, string.Format("DateTime: {0}, Inside SendRequestAndGetJsonResponseClassicHttpWithPATCH", DateTime.Now.ToString(CultureInfo.InvariantCulture)), pubnubConfig.LogVerbosity);
+            LoggingMethod.WriteToLog(pubnubLog, string.Format(CultureInfo.InvariantCulture, "DateTime: {0}, Inside SendRequestAndGetJsonResponseClassicHttpWithPATCH", DateTime.Now.ToString(CultureInfo.InvariantCulture)), pubnubConfig.LogVerbosity);
             var taskComplete = new TaskCompletionSource<string>();
             try
             {
@@ -1208,7 +1208,7 @@ namespace PubnubApi
                         HttpWebRequest asyncWebRequest = asyncRequestState.Request as HttpWebRequest;
                         if (asyncWebRequest != null)
                         {
-                            System.Diagnostics.Debug.WriteLine(string.Format("DateTime {0}, Before EndGetResponse With PATCH ", DateTime.Now.ToString(CultureInfo.InvariantCulture)));
+                            System.Diagnostics.Debug.WriteLine(string.Format(CultureInfo.InvariantCulture, "DateTime {0}, Before EndGetResponse With PATCH ", DateTime.Now.ToString(CultureInfo.InvariantCulture)));
                             HttpWebResponse asyncWebResponse = (HttpWebResponse)asyncWebRequest.EndGetResponse(asynchronousResult);
                             stopWatch.Stop();
                             if (pubnubTelemetryMgr != null)
@@ -1216,17 +1216,17 @@ namespace PubnubApi
                                 await pubnubTelemetryMgr.StoreLatency(stopWatch.ElapsedMilliseconds, pubnubRequestState.ResponseType).ConfigureAwait(false);
                             }
                             asyncRequestState.Response = asyncWebResponse;
-                            System.Diagnostics.Debug.WriteLine(string.Format("DateTime {0}, After EndGetResponse With PATCH ", DateTime.Now.ToString(CultureInfo.InvariantCulture)));
+                            System.Diagnostics.Debug.WriteLine(string.Format(CultureInfo.InvariantCulture, "DateTime {0}, After EndGetResponse With PATCH ", DateTime.Now.ToString(CultureInfo.InvariantCulture)));
                             using (StreamReader streamReader = new StreamReader(asyncWebResponse.GetResponseStream()))
                             {
-                                System.Diagnostics.Debug.WriteLine(string.Format("DateTime {0}, Inside StreamReader With PATCH ", DateTime.Now.ToString(CultureInfo.InvariantCulture)));
+                                System.Diagnostics.Debug.WriteLine(string.Format(CultureInfo.InvariantCulture, "DateTime {0}, Inside StreamReader With PATCH ", DateTime.Now.ToString(CultureInfo.InvariantCulture)));
                                 //Need to return this response 
                                 string jsonString = streamReader.ReadToEnd();
                                 asyncRequestState.GotJsonResponse = true;
 
                                 System.Diagnostics.Debug.WriteLine(jsonString);
                                 System.Diagnostics.Debug.WriteLine("");
-                                System.Diagnostics.Debug.WriteLine(string.Format("DateTime {0}, Retrieved JSON With PATCH ", DateTime.Now.ToString(CultureInfo.InvariantCulture)));
+                                System.Diagnostics.Debug.WriteLine(string.Format(CultureInfo.InvariantCulture, "DateTime {0}, Retrieved JSON With PATCH ", DateTime.Now.ToString(CultureInfo.InvariantCulture)));
                                 taskComplete.TrySetResult(jsonString);
                             }
                             if (asyncRequestState.Response != null)
@@ -1261,13 +1261,13 @@ namespace PubnubApi
 #endif
                         System.Diagnostics.Debug.WriteLine(jsonString);
                         System.Diagnostics.Debug.WriteLine("");
-                        System.Diagnostics.Debug.WriteLine(string.Format("DateTime {0}, Retrieved JSON  With PATCH from WebException response", DateTime.Now.ToString(CultureInfo.InvariantCulture)));
+                        System.Diagnostics.Debug.WriteLine(string.Format(CultureInfo.InvariantCulture, "DateTime {0}, Retrieved JSON  With PATCH from WebException response", DateTime.Now.ToString(CultureInfo.InvariantCulture)));
                         return jsonString;
                     }
                 }
 
-                if (ex.Message.IndexOf("The request was aborted: The request was canceled") == -1
-                                && ex.Message.IndexOf("Machine suspend mode enabled. No request will be processed.") == -1)
+                if (ex.Message.IndexOf("The request was aborted: The request was canceled", StringComparison.OrdinalIgnoreCase) == -1
+                                && ex.Message.IndexOf("Machine suspend mode enabled. No request will be processed.", StringComparison.OrdinalIgnoreCase) == -1)
                 {
                     taskComplete.TrySetException(ex);
                 }
@@ -1292,7 +1292,7 @@ namespace PubnubApi
                     {
                         string currentMultiChannel = (currentState.Channels == null) ? "" : string.Join(",", currentState.Channels.OrderBy(x => x).ToArray());
                         string currentMultiChannelGroup = (currentState.ChannelGroups == null) ? "" : string.Join(",", currentState.ChannelGroups.OrderBy(x => x).ToArray());
-                        LoggingMethod.WriteToLog(pubnubLog, string.Format("DateTime: {0}, OnPubnubWebRequestTimeout: client request timeout reached.Request abort for channel={1} ;channelgroup={2}", DateTime.Now.ToString(CultureInfo.InvariantCulture), currentMultiChannel, currentMultiChannelGroup), pubnubConfig.LogVerbosity);
+                        LoggingMethod.WriteToLog(pubnubLog, string.Format(CultureInfo.InvariantCulture, "DateTime: {0}, OnPubnubWebRequestTimeout: client request timeout reached.Request abort for channel={1} ;channelgroup={2}", DateTime.Now.ToString(CultureInfo.InvariantCulture), currentMultiChannel, currentMultiChannelGroup), pubnubConfig.LogVerbosity);
                         currentState.Timeout = true;
                         try
                         {
@@ -1303,7 +1303,7 @@ namespace PubnubApi
                 }
                 else
                 {
-                    LoggingMethod.WriteToLog(pubnubLog, string.Format("DateTime: {0}, OnPubnubWebRequestTimeout: client request timeout reached. However state is unknown", DateTime.Now.ToString(CultureInfo.InvariantCulture)), pubnubConfig.LogVerbosity);
+                    LoggingMethod.WriteToLog(pubnubLog, string.Format(CultureInfo.InvariantCulture, "DateTime: {0}, OnPubnubWebRequestTimeout: client request timeout reached. However state is unknown", DateTime.Now.ToString(CultureInfo.InvariantCulture)), pubnubConfig.LogVerbosity);
                 }
             }
         }
@@ -1320,7 +1320,7 @@ namespace PubnubApi
                 }
                 catch {  /* ignore */ }
 
-                LoggingMethod.WriteToLog(pubnubLog, string.Format("DateTime: {0}, **WP7 OnPubnubWebRequestTimeout**", DateTime.Now.ToString(CultureInfo.InvariantCulture)), pubnubConfig.LogVerbosity);
+                LoggingMethod.WriteToLog(pubnubLog, string.Format(CultureInfo.InvariantCulture, "DateTime: {0}, **WP7 OnPubnubWebRequestTimeout**", DateTime.Now.ToString(CultureInfo.InvariantCulture)), pubnubConfig.LogVerbosity);
 
                 if (currentState.ResponseType != PNOperationType.PNSubscribeOperation 
                     && currentState.ResponseType != PNOperationType.Presence

--- a/src/Api/PubnubApi/PubnubHttp.cs
+++ b/src/Api/PubnubApi/PubnubHttp.cs
@@ -150,7 +150,7 @@ namespace PubnubApi
 
         async Task<string> IPubnubHttp.SendRequestAndGetJsonResponseWithPATCH<T>(Uri requestUri, RequestState<T> pubnubRequestState, HttpWebRequest request, byte[] patchData, string contentType)
         {
-            LoggingMethod.WriteToLog(pubnubLog, string.Format(CultureInfo.InvariantCulture, "DateTime: {0}, patchData = {1}", DateTime.Now.ToString(CultureInfo.InvariantCulture), Encoding.UTF8.GetString(patchData)), pubnubConfig.LogVerbosity);
+            LoggingMethod.WriteToLog(pubnubLog, string.Format(CultureInfo.InvariantCulture, "DateTime: {0}, patchData = {1}", DateTime.Now.ToString(CultureInfo.InvariantCulture), Encoding.UTF8.GetString(patchData, 0, patchData.Length)), pubnubConfig.LogVerbosity);
             if (pubnubConfig.UseClassicHttpWebRequest)
             {
                 return await SendRequestAndGetJsonResponseClassicHttpWithPATCH(pubnubRequestState, request, patchData).ConfigureAwait(false);

--- a/src/Api/PubnubApi/PubnubHttpClientHandler.cs
+++ b/src/Api/PubnubApi/PubnubHttpClientHandler.cs
@@ -28,7 +28,7 @@ namespace PubnubApi
         protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
         {
             cancellationToken.ThrowIfCancellationRequested();
-            LoggingMethod.WriteToLog(pubnubLog, string.Format("DateTime {0} PubnubHttpClientHandler {1} SendAsync ", DateTime.Now.ToString(CultureInfo.InvariantCulture), pubnubHandlerName), pubnubConfig.LogVerbosity);
+            LoggingMethod.WriteToLog(pubnubLog, string.Format(CultureInfo.InvariantCulture, "DateTime {0} PubnubHttpClientHandler {1} SendAsync ", DateTime.Now.ToString(CultureInfo.InvariantCulture), pubnubHandlerName), pubnubConfig.LogVerbosity);
             return await base.SendAsync(request, cancellationToken).ConfigureAwait(false);
         }
     }

--- a/src/Api/PubnubApi/Security/MD5.cs
+++ b/src/Api/PubnubApi/Security/MD5.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Globalization;
 using System.IO;
 using System.Text;
 
@@ -46,7 +47,7 @@ namespace PubnubApi
                 StringBuilder sb = new StringBuilder();
                 foreach (byte b in hash)
                 {
-                    sb.Append(b.ToString("x2"));
+                    sb.Append(b.ToString("x2", CultureInfo.InvariantCulture));
                 }
                 return sb.ToString();
             }
@@ -501,19 +502,19 @@ namespace PubnubApi
 		{
 			if (inputBuffer == null)
 			{
-				throw new ArgumentNullException("inputBuffer");
+				throw new ArgumentNullException(nameof(inputBuffer));
 			}
 			if (inputOffset < 0)
 			{
-				throw new ArgumentOutOfRangeException("inputOffset");
+				throw new ArgumentOutOfRangeException(nameof(inputOffset));
 			}
 			if ((inputCount < 0) || (inputCount > inputBuffer.Length))
 			{
-				throw new ArgumentException("inputCount");
+				throw new ArgumentException($"{nameof(inputCount)} invalid.");
 			}
 			if ((inputBuffer.Length - inputCount) < inputOffset)
 			{
-				throw new ArgumentOutOfRangeException("inputOffset");
+				throw new ArgumentOutOfRangeException(nameof(inputOffset));
 			}
 			if (this.State == 0)
 			{
@@ -536,19 +537,19 @@ namespace PubnubApi
 		{
 			if (inputBuffer == null)
 			{
-				throw new ArgumentNullException("inputBuffer");
+				throw new ArgumentNullException(nameof(inputBuffer));
 			}
 			if (inputOffset < 0)
 			{
-				throw new ArgumentOutOfRangeException("inputOffset");
+				throw new ArgumentOutOfRangeException(nameof(inputOffset));
 			}
 			if ((inputCount < 0) || (inputCount > inputBuffer.Length))
 			{
-				throw new ArgumentException("inputCount");
+				throw new ArgumentException($"{nameof(inputCount)} invalid.");
 			}
 			if ((inputBuffer.Length - inputCount) < inputOffset)
 			{
-				throw new ArgumentOutOfRangeException("inputOffset");
+				throw new ArgumentOutOfRangeException(nameof(inputOffset));
 			}
 			if (this.State == 0)
 			{

--- a/src/Api/PubnubApi/Security/PubnubCrypto.cs
+++ b/src/Api/PubnubApi/Security/PubnubCrypto.cs
@@ -12,16 +12,16 @@ namespace PubnubApi
         private readonly IPubnubLog pubnubLog;
         private readonly IPubnubUnitTest pnUnit;
 
-        public PubnubCrypto(string cipher_key, PNConfiguration pubnubConfig, IPubnubLog log, IPubnubUnitTest pubnubUnit)
-            : base(cipher_key, pubnubConfig)
+        public PubnubCrypto(string cipherKey, PNConfiguration pubnubConfig, IPubnubLog log, IPubnubUnitTest pubnubUnit)
+            : base(cipherKey, pubnubConfig)
         {
             this.config = pubnubConfig;
             this.pubnubLog = log;
             this.pnUnit = pubnubUnit;
         }
 
-        public PubnubCrypto(string cipher_key)
-            : base(cipher_key)
+        public PubnubCrypto(string cipherKey)
+            : base(cipherKey)
         {
         }
 
@@ -116,7 +116,7 @@ namespace PubnubApi
             }
             if (config != null)
             {
-                LoggingMethod.WriteToLog(pubnubLog, string.Format("DateTime {0} IV = {1}", DateTime.Now.ToString(CultureInfo.InvariantCulture), GetDisplayableBytes(ivBytes)), config.LogVerbosity);
+                LoggingMethod.WriteToLog(pubnubLog, string.Format(CultureInfo.InvariantCulture, "DateTime {0} IV = {1}", DateTime.Now.ToString(CultureInfo.InvariantCulture), GetDisplayableBytes(ivBytes)), config.LogVerbosity);
             }
 
             Aes aesAlg = Aes.Create();
@@ -167,7 +167,7 @@ namespace PubnubApi
                 {
                     if (config != null)
                     {
-                        LoggingMethod.WriteToLog(pubnubLog, string.Format("DateTime {0} Decrypt Error. {1}", DateTime.Now.ToString(CultureInfo.InvariantCulture), ex), config.LogVerbosity);
+                        LoggingMethod.WriteToLog(pubnubLog, string.Format(CultureInfo.InvariantCulture, "DateTime {0} Decrypt Error. {1}", DateTime.Now.ToString(CultureInfo.InvariantCulture), ex), config.LogVerbosity);
                     }
                     throw;
                 }

--- a/src/Api/PubnubApi/Security/PubnubCryptoBase.cs
+++ b/src/Api/PubnubApi/Security/PubnubCryptoBase.cs
@@ -10,14 +10,14 @@ namespace PubnubApi
     {
         private readonly string cipherKey;
         private readonly PNConfiguration config;
-        protected PubnubCryptoBase(string cipher_key, PNConfiguration pubnubConfig)
+        protected PubnubCryptoBase(string cipherKey, PNConfiguration pubnubConfig)
         {
-            this.cipherKey = cipher_key;
+            this.cipherKey = cipherKey;
             this.config = pubnubConfig;
         }
-        protected PubnubCryptoBase(string cipher_key)
+        protected PubnubCryptoBase(string cipherKey)
         {
-            this.cipherKey = cipher_key;
+            this.cipherKey = cipherKey;
             this.config = null;
         }
 
@@ -62,21 +62,21 @@ namespace PubnubApi
         // encrypt string
         public string Encrypt(string plainText)
         {
-            if (plainText == null || plainText.Length <= 0) { throw new ArgumentNullException("plainText"); }
+            if (plainText == null || plainText.Length <= 0) { throw new ArgumentNullException(nameof(plainText)); }
             bool dynamicIV = (config != null && config.UseRandomInitializationVector);
             return EncryptOrDecrypt(true, plainText, dynamicIV);
         }
 
         public byte[] Encrypt(byte[] plainBytes)
         {
-            if (plainBytes == null || plainBytes.Length <= 0) { throw new ArgumentNullException("plainBytes"); }
+            if (plainBytes == null || plainBytes.Length <= 0) { throw new ArgumentNullException(nameof(plainBytes)); }
             bool dynamicIV = (config != null && config.UseRandomInitializationVector);
             return EncryptOrDecrypt(true, plainBytes, dynamicIV);
         }
 
         public byte[] Encrypt(byte[] plainBytes, bool file)
         {
-            if (plainBytes == null || plainBytes.Length <= 0) { throw new ArgumentNullException("plainBytes"); }
+            if (plainBytes == null || plainBytes.Length <= 0) { throw new ArgumentNullException(nameof(plainBytes)); }
             bool dynamicIV = file || (config != null && config.UseRandomInitializationVector);
             return EncryptOrDecrypt(true, plainBytes, dynamicIV);
         }
@@ -84,21 +84,21 @@ namespace PubnubApi
         // decrypt string
         public string Decrypt(string cipherText)
         {
-            if (cipherText == null) { throw new ArgumentNullException("cipherText"); }
+            if (cipherText == null) { throw new ArgumentNullException(nameof(cipherText)); }
             bool dynamicIV = (config != null && config.UseRandomInitializationVector);
             return EncryptOrDecrypt(false, cipherText, dynamicIV);
         }
 
         public byte[] Decrypt(byte[] cipherBytes)
         {
-            if (cipherBytes == null) { throw new ArgumentNullException("cipherBytes"); }
+            if (cipherBytes == null) { throw new ArgumentNullException(nameof(cipherBytes)); }
             bool dynamicIV = (config != null && config.UseRandomInitializationVector);
             return EncryptOrDecrypt(false, cipherBytes, dynamicIV);
         }
 
         public byte[] Decrypt(byte[] cipherBytes, bool file)
         {
-            if (cipherBytes == null) { throw new ArgumentNullException("cipherBytes"); }
+            if (cipherBytes == null) { throw new ArgumentNullException(nameof(cipherBytes)); }
             bool dynamicIV = file || (config != null && config.UseRandomInitializationVector);
             return EncryptOrDecrypt(false, cipherBytes, dynamicIV);
         }
@@ -114,7 +114,7 @@ namespace PubnubApi
                 value,
                 @"\\u(?<Value>[a-zA-Z0-9]{4})",
                 m => {
-                    return ((char)int.Parse(m.Groups["Value"].Value, NumberStyles.HexNumber)).ToString();
+                    return ((char)int.Parse(m.Groups["Value"].Value, NumberStyles.HexNumber, CultureInfo.InvariantCulture)).ToString();
                 }
             );
         }
@@ -136,7 +136,7 @@ namespace PubnubApi
                 if (c > 127)
                 {
                     // This character is too big for ASCII
-                    string encodedValue = "\\u" + ((int)c).ToString("x4");
+                    string encodedValue = "\\u" + ((int)c).ToString("x4", CultureInfo.InvariantCulture);
                     sb.Append(encodedValue);
                 }
                 else

--- a/src/Api/PubnubApiPCL/PubnubApiPCL.csproj
+++ b/src/Api/PubnubApiPCL/PubnubApiPCL.csproj
@@ -14,7 +14,7 @@
 
   <PropertyGroup>
     <PackageId>PubnubPCL</PackageId>
-    <PackageVersion>6.12.0.0</PackageVersion>
+    <PackageVersion>6.13.0.0</PackageVersion>
     <Title>PubNub C# .NET - Web Data Push API</Title>
     <Authors>Pandu Masabathula</Authors>
     <Owners>PubNub</Owners>
@@ -22,7 +22,9 @@
     <PackageIconUrl>http://pubnub.s3.amazonaws.com/2011/powered-by-pubnub/pubnub-icon-600x600.png</PackageIconUrl>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
     <RepositoryUrl>https://github.com/pubnub/c-sharp/</RepositoryUrl>
-    <PackageReleaseNotes>Encode comma char for push related multi channels.</PackageReleaseNotes>
+    <PackageReleaseNotes>Added null check for PublishFileMessage PNStatus in SendFileOperation.
+Removed invalid Content-Type in ObjectsV2 request headers targeting .Net Frameworks.
+Added CultureInfo.InvariantCulture to string formatting.</PackageReleaseNotes>
     <PackageTags>Web Data Push Real-time Notifications ESB Message Broadcasting Distributed Computing</PackageTags>
     <!--<Summary>PubNub is a Massively Scalable Web Push Service for Web and Mobile Games.  This is a cloud-based service for broadcasting messages to thousands of web and mobile clients simultaneously</Summary>-->
     <Description>PubNub is a Massively Scalable Web Push Service for Web and Mobile Games.  This is a cloud-based service for broadcasting messages to thousands of web and mobile clients simultaneously</Description>

--- a/src/Api/PubnubApiUWP/PubnubApiUWP.csproj
+++ b/src/Api/PubnubApiUWP/PubnubApiUWP.csproj
@@ -15,7 +15,7 @@
 
   <PropertyGroup>
     <PackageId>PubnubUWP</PackageId>
-    <PackageVersion>6.12.0.0</PackageVersion>
+    <PackageVersion>6.13.0.0</PackageVersion>
     <Title>PubNub C# .NET - Web Data Push API</Title>
     <Authors>Pandu Masabathula</Authors>
     <Owners>PubNub</Owners>
@@ -23,7 +23,9 @@
     <PackageIconUrl>http://pubnub.s3.amazonaws.com/2011/powered-by-pubnub/pubnub-icon-600x600.png</PackageIconUrl>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
     <RepositoryUrl>https://github.com/pubnub/c-sharp/</RepositoryUrl>
-    <PackageReleaseNotes>Encode comma char for push related multi channels.</PackageReleaseNotes>
+    <PackageReleaseNotes>Added null check for PublishFileMessage PNStatus in SendFileOperation.
+Removed invalid Content-Type in ObjectsV2 request headers targeting .Net Frameworks.
+Added CultureInfo.InvariantCulture to string formatting.</PackageReleaseNotes>
     <PackageTags>Web Data Push Real-time Notifications ESB Message Broadcasting Distributed Computing</PackageTags>
     <!--<Summary>PubNub is a Massively Scalable Web Push Service for Web and Mobile Games.  This is a cloud-based service for broadcasting messages to thousands of web and mobile clients simultaneously</Summary>-->
     <Description>PubNub is a Massively Scalable Web Push Service for Web and Mobile Games.  This is a cloud-based service for broadcasting messages to thousands of web and mobile clients simultaneously</Description>

--- a/src/UnitTests/PubnubApi.Tests/WhenGrantIsRequested.cs
+++ b/src/UnitTests/PubnubApi.Tests/WhenGrantIsRequested.cs
@@ -990,6 +990,18 @@ namespace PubNubMessaging.Tests
             server.RunOnHttps(config.Secure);
 
 #if NET40
+            PNResult<PNAccessManagerTokenResult> grantResponse = Task.Factory.StartNew(async () => await pubnub.GrantToken()
+                    .Resources(new PNTokenResources()
+                    {
+                        Spaces = new Dictionary<string, PNTokenAuthValues>() {
+                                            { "spc1", new PNTokenAuthValues() { Read = true, Write = true, Manage= true, Create = true, Delete=true, Get = true, Update = true, Join = true } } },
+                        Users = new Dictionary<string, PNTokenAuthValues>() {
+                                            { "usr1", new PNTokenAuthValues() { Read = true, Write = true, Manage= true, Create = true, Delete=true, Get = true, Update = true, Join = true } } },
+                    }
+                    )
+                .TTL(10)
+                .ExecuteAsync()).Result.Result;
+
 #else
             PNResult<PNAccessManagerTokenResult> grantResponse = await pubnub.GrantToken()
                     .Resources(new PNTokenResources()
@@ -1002,11 +1014,11 @@ namespace PubNubMessaging.Tests
                     )
                 .TTL(10)
                 .ExecuteAsync();
+#endif
             if (grantResponse.Result != null && !grantResponse.Status.Error)
             {
                 receivedGrantMessage = true;
             }
-#endif
             Assert.IsTrue(receivedGrantMessage, "WhenGrantIsRequested -> ThenWithAsyncGrantTokenShouldReturnSuccess failed.");
 
         }


### PR DESCRIPTION
fix: Added null check for PublishFileMessage PNStatus in SendFileOperation.

Added null check for PublishFileMessage PNStatus in SendFileOperation.

fix: Removed invalid Content-Type in ObjectsV2 request headers targeting .Net Frameworks.

Removed invalid Content-Type in ObjectsV2 request headers targeting .Net Frameworks.

refactor: Added CultureInfo.InvariantCulture to string formatting.

Added CultureInfo.InvariantCulture to string formatting.