### PR TITLE
SetChannelMetadata name - removed default empty

### DIFF
--- a/.pubnub.yml
+++ b/.pubnub.yml
@@ -1,8 +1,13 @@
 name: c-sharp
-version: "6.17.0"
+version: "6.18.0"
 schema: 1
 scm: github.com/pubnub/c-sharp
 changelog:
+  - date: 2023-09-04
+    version: v6.18.0
+    changes:
+      - type: bug
+        text: "Allow name param as optional in SetChannelMetadata. Removed default empty value."
   - date: 2023-07-10
     version: v6.17.0
     changes:
@@ -725,7 +730,7 @@ features:
     - QUERY-PARAM
 supported-platforms:
   -
-    version: Pubnub 'C#' 6.17.0
+    version: Pubnub 'C#' 6.18.0
     platforms:
       - Windows 10 and up
       - Windows Server 2008 and up
@@ -735,7 +740,7 @@ supported-platforms:
       - .Net Framework 4.5
       - .Net Framework 4.6.1+
   -
-    version: PubnubPCL 'C#' 6.17.0
+    version: PubnubPCL 'C#' 6.18.0
     platforms:
       - Xamarin.Android
       - Xamarin.iOS
@@ -755,7 +760,7 @@ supported-platforms:
       - .Net Core
       - .Net 6.0
   -
-    version: PubnubUWP 'C#' 6.17.0
+    version: PubnubUWP 'C#' 6.18.0
     platforms:
       - Windows Phone 10
       - Universal Windows Apps
@@ -779,7 +784,7 @@ sdks:
             distribution-type: source
             distribution-repository: GitHub
             package-name: Pubnub
-            location: https://github.com/pubnub/c-sharp/releases/tag/v6.17.0.0
+            location: https://github.com/pubnub/c-sharp/releases/tag/v6.18.0.0
             requires:
               -
                 name: ".Net"
@@ -1062,7 +1067,7 @@ sdks:
             distribution-type: source
             distribution-repository: GitHub
             package-name: PubNubPCL
-            location: https://github.com/pubnub/c-sharp/releases/tag/v6.17.0.0
+            location: https://github.com/pubnub/c-sharp/releases/tag/v6.18.0.0
             requires:
               -
                 name: ".Net Core"
@@ -1421,7 +1426,7 @@ sdks:
             distribution-type: source
             distribution-repository: GitHub
             package-name: PubnubUWP
-            location: https://github.com/pubnub/c-sharp/releases/tag/v6.17.0.0
+            location: https://github.com/pubnub/c-sharp/releases/tag/v6.18.0.0
             requires:
               -
                 name: "Universal Windows Platform Development"

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+v6.18.0 - September 04 2023
+-----------------------------
+- Fixed: allow name param as optional in SetChannelMetadata. Removed default empty value.
+
 v6.17.0 - July 10 2023
 -----------------------------
 - Modified: validate json string before deserialization.

--- a/src/Api/PubnubApi/EndPoint/Objects/SetChannelMetadataOperation.cs
+++ b/src/Api/PubnubApi/EndPoint/Objects/SetChannelMetadataOperation.cs
@@ -21,7 +21,7 @@ namespace PubnubApi.EndPoint
         private readonly EndPoint.TelemetryManager pubnubTelemetryMgr;
 
         private string chMetaId = "";
-        private string chMetaName = "";
+        private string chMetaName;
         private string chMetaDesc;
         private Dictionary<string, object> chMetaCustom;
         private bool includeCustom;

--- a/src/Api/PubnubApi/Properties/AssemblyInfo.cs
+++ b/src/Api/PubnubApi/Properties/AssemblyInfo.cs
@@ -11,8 +11,8 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyProduct("Pubnub C# SDK")]
 [assembly: AssemblyCopyright("Copyright ©  2021")]
 [assembly: AssemblyTrademark("")]
-[assembly: AssemblyVersion("6.17.0.0")]
-[assembly: AssemblyFileVersion("6.17.0.0")]
+[assembly: AssemblyVersion("6.18.0.0")]
+[assembly: AssemblyFileVersion("6.18.0.0")]
 // Setting ComVisible to false makes the types in this assembly not visible
 // to COM components.  If you need to access a type in this assembly from
 // COM, set the ComVisible attribute to true on that type.

--- a/src/Api/PubnubApi/PubnubApi.csproj
+++ b/src/Api/PubnubApi/PubnubApi.csproj
@@ -13,7 +13,7 @@
 
   <PropertyGroup>
     <PackageId>Pubnub</PackageId>
-    <PackageVersion>6.17.0.0</PackageVersion>
+    <PackageVersion>6.18.0.0</PackageVersion>
     <Title>PubNub C# .NET - Web Data Push API</Title>
     <Authors>Pandu Masabathula</Authors>
     <Owners>PubNub</Owners>
@@ -21,7 +21,7 @@
     <PackageIconUrl>http://pubnub.s3.amazonaws.com/2011/powered-by-pubnub/pubnub-icon-600x600.png</PackageIconUrl>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
     <RepositoryUrl>https://github.com/pubnub/c-sharp/</RepositoryUrl>
-    <PackageReleaseNotes>Validate json string before deserialization.</PackageReleaseNotes>
+    <PackageReleaseNotes>Allow name param as optional in SetChannelMetadata. Removed default empty value.</PackageReleaseNotes>
     <PackageTags>Web Data Push Real-time Notifications ESB Message Broadcasting Distributed Computing</PackageTags>
     <!--<Summary>PubNub is a Massively Scalable Web Push Service for Web and Mobile Games.  This is a cloud-based service for broadcasting messages to thousands of web and mobile clients simultaneously</Summary>-->
     <Description>PubNub is a Massively Scalable Web Push Service for Web and Mobile Games.  This is a cloud-based service for broadcasting messages to thousands of web and mobile clients simultaneously</Description>

--- a/src/Api/PubnubApiPCL/PubnubApiPCL.csproj
+++ b/src/Api/PubnubApiPCL/PubnubApiPCL.csproj
@@ -14,7 +14,7 @@
 
   <PropertyGroup>
     <PackageId>PubnubPCL</PackageId>
-    <PackageVersion>6.17.0.0</PackageVersion>
+    <PackageVersion>6.18.0.0</PackageVersion>
     <Title>PubNub C# .NET - Web Data Push API</Title>
     <Authors>Pandu Masabathula</Authors>
     <Owners>PubNub</Owners>
@@ -22,7 +22,7 @@
     <PackageIconUrl>http://pubnub.s3.amazonaws.com/2011/powered-by-pubnub/pubnub-icon-600x600.png</PackageIconUrl>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
     <RepositoryUrl>https://github.com/pubnub/c-sharp/</RepositoryUrl>
-    <PackageReleaseNotes>Validate json string before deserialization.</PackageReleaseNotes>
+    <PackageReleaseNotes>Allow name param as optional in SetChannelMetadata. Removed default empty value.</PackageReleaseNotes>
     <PackageTags>Web Data Push Real-time Notifications ESB Message Broadcasting Distributed Computing</PackageTags>
     <!--<Summary>PubNub is a Massively Scalable Web Push Service for Web and Mobile Games.  This is a cloud-based service for broadcasting messages to thousands of web and mobile clients simultaneously</Summary>-->
     <Description>PubNub is a Massively Scalable Web Push Service for Web and Mobile Games.  This is a cloud-based service for broadcasting messages to thousands of web and mobile clients simultaneously</Description>

--- a/src/Api/PubnubApiUWP/PubnubApiUWP.csproj
+++ b/src/Api/PubnubApiUWP/PubnubApiUWP.csproj
@@ -15,7 +15,7 @@
 
   <PropertyGroup>
     <PackageId>PubnubUWP</PackageId>
-    <PackageVersion>6.17.0.0</PackageVersion>
+    <PackageVersion>6.18.0.0</PackageVersion>
     <Title>PubNub C# .NET - Web Data Push API</Title>
     <Authors>Pandu Masabathula</Authors>
     <Owners>PubNub</Owners>
@@ -23,7 +23,7 @@
     <PackageIconUrl>http://pubnub.s3.amazonaws.com/2011/powered-by-pubnub/pubnub-icon-600x600.png</PackageIconUrl>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
     <RepositoryUrl>https://github.com/pubnub/c-sharp/</RepositoryUrl>
-    <PackageReleaseNotes>Validate json string before deserialization.</PackageReleaseNotes>
+    <PackageReleaseNotes>Allow name param as optional in SetChannelMetadata. Removed default empty value.</PackageReleaseNotes>
     <PackageTags>Web Data Push Real-time Notifications ESB Message Broadcasting Distributed Computing</PackageTags>
     <!--<Summary>PubNub is a Massively Scalable Web Push Service for Web and Mobile Games.  This is a cloud-based service for broadcasting messages to thousands of web and mobile clients simultaneously</Summary>-->
     <Description>PubNub is a Massively Scalable Web Push Service for Web and Mobile Games.  This is a cloud-based service for broadcasting messages to thousands of web and mobile clients simultaneously</Description>


### PR DESCRIPTION

fix: Allow name param as optional in SetChannelMetadata. Removed default empty value.

Allow name param as optional in SetChannelMetadata. Removed default empty value.
