### PR TITLE
Fix/here_now

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,4 +1,4 @@
-*         @budgetpreneur @MikeDobrzan @mohitpubnub
-.github   @parfeon @budgetpreneur @MikeDobrzan @mohitpubnub
-README.md @techwritermat
+*         @parfeon @Xavrax @mohitpubnub
+.github   @parfeon @Xavrax @mohitpubnub
+README.md @techwritermat @kazydek
 

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,4 +1,2 @@
-*         @parfeon @Xavrax @mohitpubnub
-.github   @parfeon @Xavrax @mohitpubnub
+*         @mohitpubnub @Xavrax @parfeon
 README.md @techwritermat @kazydek
-

--- a/.pubnub.yml
+++ b/.pubnub.yml
@@ -3,18 +3,11 @@ version: "6.19.0"
 schema: 1
 scm: github.com/pubnub/c-sharp
 changelog:
-  - date: 2023-10-16
+  - date: 2023-10-24
     version: v6.19.0
     changes:
-      - type: feature
-        text: "Add crypto module that allows configure SDK to encrypt and decrypt messages."
       - type: bug
-        text: "Improved security of crypto implementation by adding enhanced AES-CBC cryptor."
-      - type: bug
-        text: "Fixes Newtonsoft Json vulnerability with MaxDepth and upgrade to version  for non-PCL."
-      - type: improvement
-        text: "Add SubscribeKey validation for subscribe feature."
-  - date: 2023-09-04
+        text: "Fixes issue of getting error when hereNow is called with channelGroups param only."  - date: 2023-09-04
     version: v6.18.0
     changes:
       - type: bug
@@ -795,7 +788,7 @@ sdks:
             distribution-type: source
             distribution-repository: GitHub
             package-name: Pubnub
-            location: https://github.com/pubnub/c-sharp/releases/tag/v6.19.0.0
+            location: https://github.com/pubnub/c-sharp/releases/tag/v6.19.0.1
             requires:
               -
                 name: ".Net"
@@ -1078,7 +1071,7 @@ sdks:
             distribution-type: source
             distribution-repository: GitHub
             package-name: PubNubPCL
-            location: https://github.com/pubnub/c-sharp/releases/tag/v6.19.0.0
+            location: https://github.com/pubnub/c-sharp/releases/tag/v6.19.0.1
             requires:
               -
                 name: ".Net Core"
@@ -1437,7 +1430,7 @@ sdks:
             distribution-type: source
             distribution-repository: GitHub
             package-name: PubnubUWP
-            location: https://github.com/pubnub/c-sharp/releases/tag/v6.19.0.0
+            location: https://github.com/pubnub/c-sharp/releases/tag/v6.19.0.1
             requires:
               -
                 name: "Universal Windows Platform Development"

--- a/.pubnub.yml
+++ b/.pubnub.yml
@@ -3,11 +3,18 @@ version: "6.19.0"
 schema: 1
 scm: github.com/pubnub/c-sharp
 changelog:
-  - date: 2023-10-24
+  - date: 2023-10-16
     version: v6.19.0
     changes:
+      - type: feature
+        text: "Add crypto module that allows configure SDK to encrypt and decrypt messages."
       - type: bug
-        text: "Fixes issue of getting error when hereNow is called with channelGroups param only."  - date: 2023-09-04
+        text: "Improved security of crypto implementation by adding enhanced AES-CBC cryptor."
+      - type: bug
+        text: "Fixes Newtonsoft Json vulnerability with MaxDepth and upgrade to version  for non-PCL."
+      - type: improvement
+        text: "Add SubscribeKey validation for subscribe feature."
+  - date: 2023-09-04
     version: v6.18.0
     changes:
       - type: bug
@@ -788,7 +795,7 @@ sdks:
             distribution-type: source
             distribution-repository: GitHub
             package-name: Pubnub
-            location: https://github.com/pubnub/c-sharp/releases/tag/v6.19.0.1
+            location: https://github.com/pubnub/c-sharp/releases/tag/v6.19.0.0
             requires:
               -
                 name: ".Net"
@@ -1071,7 +1078,7 @@ sdks:
             distribution-type: source
             distribution-repository: GitHub
             package-name: PubNubPCL
-            location: https://github.com/pubnub/c-sharp/releases/tag/v6.19.0.1
+            location: https://github.com/pubnub/c-sharp/releases/tag/v6.19.0.0
             requires:
               -
                 name: ".Net Core"
@@ -1430,7 +1437,7 @@ sdks:
             distribution-type: source
             distribution-repository: GitHub
             package-name: PubnubUWP
-            location: https://github.com/pubnub/c-sharp/releases/tag/v6.19.0.1
+            location: https://github.com/pubnub/c-sharp/releases/tag/v6.19.0.0
             requires:
               -
                 name: "Universal Windows Platform Development"

--- a/.pubnub.yml
+++ b/.pubnub.yml
@@ -1,8 +1,13 @@
 name: c-sharp
-version: "6.19.0"
+version: "6.19.1"
 schema: 1
 scm: github.com/pubnub/c-sharp
 changelog:
+  - date: 2023-10-24
+    version: v6.19.1
+    changes:
+      - type: bug
+        text: "Fixes issue of getting error when hereNow is called with channelGroups param only."
   - date: 2023-10-16
     version: v6.19.0
     changes:
@@ -741,7 +746,7 @@ features:
     - QUERY-PARAM
 supported-platforms:
   -
-    version: Pubnub 'C#' 6.19.0
+    version: Pubnub 'C#' 6.19.1
     platforms:
       - Windows 10 and up
       - Windows Server 2008 and up
@@ -751,7 +756,7 @@ supported-platforms:
       - .Net Framework 4.5
       - .Net Framework 4.6.1+
   -
-    version: PubnubPCL 'C#' 6.19.0
+    version: PubnubPCL 'C#' 6.19.1
     platforms:
       - Xamarin.Android
       - Xamarin.iOS
@@ -771,7 +776,7 @@ supported-platforms:
       - .Net Core
       - .Net 6.0
   -
-    version: PubnubUWP 'C#' 6.19.0
+    version: PubnubUWP 'C#' 6.19.1
     platforms:
       - Windows Phone 10
       - Universal Windows Apps
@@ -795,7 +800,7 @@ sdks:
             distribution-type: source
             distribution-repository: GitHub
             package-name: Pubnub
-            location: https://github.com/pubnub/c-sharp/releases/tag/v6.19.0.0
+            location: https://github.com/pubnub/c-sharp/releases/tag/v6.19.1.0
             requires:
               -
                 name: ".Net"
@@ -1078,7 +1083,7 @@ sdks:
             distribution-type: source
             distribution-repository: GitHub
             package-name: PubNubPCL
-            location: https://github.com/pubnub/c-sharp/releases/tag/v6.19.0.0
+            location: https://github.com/pubnub/c-sharp/releases/tag/v6.19.1.0
             requires:
               -
                 name: ".Net Core"
@@ -1437,7 +1442,7 @@ sdks:
             distribution-type: source
             distribution-repository: GitHub
             package-name: PubnubUWP
-            location: https://github.com/pubnub/c-sharp/releases/tag/v6.19.0.0
+            location: https://github.com/pubnub/c-sharp/releases/tag/v6.19.1.0
             requires:
               -
                 name: "Universal Windows Platform Development"

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,11 +1,8 @@
-v6.19.0 - October 16 2023
+v6.19.0 - October 24 2023
 -----------------------------
-- Added: add crypto module that allows configure SDK to encrypt and decrypt messages.
+- Fixed: fixes issue of getting error when hereNow is called with channelGroups param only.
 
-- Fixed: improved security of crypto implementation by adding enhanced AES-CBC cryptor.
-- Fixed: fixes Newtonsoft Json vulnerability with MaxDepth and upgrade to version  for non-PCL.
 
-- Modified: add SubscribeKey validation for subscribe feature.
 
 v6.18.0 - September 04 2023
 -----------------------------

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+v6.19.1 - October 24 2023
+-----------------------------
+- Fixed: fixes issue of getting error when hereNow is called with channelGroups param only.
+
 v6.19.0 - October 16 2023
 -----------------------------
 - Added: add crypto module that allows configure SDK to encrypt and decrypt messages.

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,8 +1,11 @@
-v6.19.0 - October 24 2023
+v6.19.0 - October 16 2023
 -----------------------------
-- Fixed: fixes issue of getting error when hereNow is called with channelGroups param only.
+- Added: add crypto module that allows configure SDK to encrypt and decrypt messages.
 
+- Fixed: improved security of crypto implementation by adding enhanced AES-CBC cryptor.
+- Fixed: fixes Newtonsoft Json vulnerability with MaxDepth and upgrade to version  for non-PCL.
 
+- Modified: add SubscribeKey validation for subscribe feature.
 
 v6.18.0 - September 04 2023
 -----------------------------

--- a/src/Api/PubnubApi/Builder/UrlRequestBuilder.cs
+++ b/src/Api/PubnubApi/Builder/UrlRequestBuilder.cs
@@ -278,6 +278,9 @@ namespace PubnubApi
         Uri IUrlRequestBuilder.BuildHereNowRequest(string requestMethod, string requestBody, string[] channels, string[] channelGroups, bool showUUIDList, bool includeUserState, Dictionary<string, object> externalQueryParam)
         {
             PNOperationType currentType = PNOperationType.PNHereNowOperation;
+            if ((channels == null || channels.Length == 0) && (channelGroups == null || channelGroups.Length == 0)) {
+                throw new ArgumentException("Please provide Channels or ChannelGroups.");
+            }
             string channel = (channels != null && channels.Length > 0) ? string.Join(",", channels.OrderBy(x => x).ToArray()) : ",";
 
             List<string> url = new List<string>();

--- a/src/Api/PubnubApi/Builder/UrlRequestBuilder.cs
+++ b/src/Api/PubnubApi/Builder/UrlRequestBuilder.cs
@@ -278,18 +278,15 @@ namespace PubnubApi
         Uri IUrlRequestBuilder.BuildHereNowRequest(string requestMethod, string requestBody, string[] channels, string[] channelGroups, bool showUUIDList, bool includeUserState, Dictionary<string, object> externalQueryParam)
         {
             PNOperationType currentType = PNOperationType.PNHereNowOperation;
-            string channel = (channels != null && channels.Length > 0) ? string.Join(",", channels.OrderBy(x => x).ToArray()) : "";
+            string channel = (channels != null && channels.Length > 0) ? string.Join(",", channels.OrderBy(x => x).ToArray()) : ",";
 
             List<string> url = new List<string>();
             url.Add("v2");
             url.Add("presence");
             url.Add("sub_key");
             url.Add(pubnubConfig.ContainsKey(pubnubInstanceId) ? pubnubConfig[pubnubInstanceId].SubscribeKey : "");
-            if (!string.IsNullOrEmpty(channel))
-            {
-                url.Add("channel");
-                url.Add(channel);
-            }
+            url.Add("channel");
+            url.Add(channel);
 
             int disableUUID = showUUIDList ? 0 : 1;
             int userState = includeUserState ? 1 : 0;

--- a/src/Api/PubnubApi/Properties/AssemblyInfo.cs
+++ b/src/Api/PubnubApi/Properties/AssemblyInfo.cs
@@ -11,8 +11,8 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyProduct("Pubnub C# SDK")]
 [assembly: AssemblyCopyright("Copyright ©  2021")]
 [assembly: AssemblyTrademark("")]
-[assembly: AssemblyVersion("6.19.0.0")]
-[assembly: AssemblyFileVersion("6.19.0.0")]
+[assembly: AssemblyVersion("6.19.1.0")]
+[assembly: AssemblyFileVersion("6.19.1.0")]
 // Setting ComVisible to false makes the types in this assembly not visible
 // to COM components.  If you need to access a type in this assembly from
 // COM, set the ComVisible attribute to true on that type.

--- a/src/Api/PubnubApi/Properties/AssemblyInfo.cs
+++ b/src/Api/PubnubApi/Properties/AssemblyInfo.cs
@@ -11,8 +11,8 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyProduct("Pubnub C# SDK")]
 [assembly: AssemblyCopyright("Copyright ©  2021")]
 [assembly: AssemblyTrademark("")]
-[assembly: AssemblyVersion("6.19.0.0")]
-[assembly: AssemblyFileVersion("6.19.0.0")]
+[assembly: AssemblyVersion("6.19.0.1")]
+[assembly: AssemblyFileVersion("6.19.0.1")]
 // Setting ComVisible to false makes the types in this assembly not visible
 // to COM components.  If you need to access a type in this assembly from
 // COM, set the ComVisible attribute to true on that type.

--- a/src/Api/PubnubApi/Properties/AssemblyInfo.cs
+++ b/src/Api/PubnubApi/Properties/AssemblyInfo.cs
@@ -11,8 +11,8 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyProduct("Pubnub C# SDK")]
 [assembly: AssemblyCopyright("Copyright ©  2021")]
 [assembly: AssemblyTrademark("")]
-[assembly: AssemblyVersion("6.19.0.1")]
-[assembly: AssemblyFileVersion("6.19.0.1")]
+[assembly: AssemblyVersion("6.19.0.0")]
+[assembly: AssemblyFileVersion("6.19.0.0")]
 // Setting ComVisible to false makes the types in this assembly not visible
 // to COM components.  If you need to access a type in this assembly from
 // COM, set the ComVisible attribute to true on that type.

--- a/src/Api/PubnubApi/PubnubApi.csproj
+++ b/src/Api/PubnubApi/PubnubApi.csproj
@@ -14,7 +14,7 @@
 
   <PropertyGroup>
     <PackageId>Pubnub</PackageId>
-    <PackageVersion>6.19.0.0</PackageVersion>
+    <PackageVersion>6.19.1.0</PackageVersion>
     <Title>PubNub C# .NET - Web Data Push API</Title>
     <Authors>Pandu Masabathula</Authors>
     <Owners>PubNub</Owners>
@@ -22,10 +22,7 @@
     <PackageIconUrl>http://pubnub.s3.amazonaws.com/2011/powered-by-pubnub/pubnub-icon-600x600.png</PackageIconUrl>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
     <RepositoryUrl>https://github.com/pubnub/c-sharp/</RepositoryUrl>
-    <PackageReleaseNotes>Add crypto module that allows configure SDK to encrypt and decrypt messages.
-Improved security of crypto implementation by adding enhanced AES-CBC cryptor.
-Fixes Newtonsoft Json vulnerability with MaxDepth and upgrade to version  for non-PCL.
-Add SubscribeKey validation for subscribe feature.</PackageReleaseNotes>
+    <PackageReleaseNotes>Fixes issue of getting error when hereNow is called with channelGroups param only.</PackageReleaseNotes>
     <PackageTags>Web Data Push Real-time Notifications ESB Message Broadcasting Distributed Computing</PackageTags>
     <!--<Summary>PubNub is a Massively Scalable Web Push Service for Web and Mobile Games.  This is a cloud-based service for broadcasting messages to thousands of web and mobile clients simultaneously</Summary>-->
     <Description>PubNub is a Massively Scalable Web Push Service for Web and Mobile Games.  This is a cloud-based service for broadcasting messages to thousands of web and mobile clients simultaneously</Description>

--- a/src/Api/PubnubApi/PubnubApi.csproj
+++ b/src/Api/PubnubApi/PubnubApi.csproj
@@ -14,7 +14,7 @@
 
   <PropertyGroup>
     <PackageId>Pubnub</PackageId>
-    <PackageVersion>6.19.0.0</PackageVersion>
+    <PackageVersion>6.19.0.1</PackageVersion>
     <Title>PubNub C# .NET - Web Data Push API</Title>
     <Authors>Pandu Masabathula</Authors>
     <Owners>PubNub</Owners>
@@ -22,10 +22,7 @@
     <PackageIconUrl>http://pubnub.s3.amazonaws.com/2011/powered-by-pubnub/pubnub-icon-600x600.png</PackageIconUrl>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
     <RepositoryUrl>https://github.com/pubnub/c-sharp/</RepositoryUrl>
-    <PackageReleaseNotes>Add crypto module that allows configure SDK to encrypt and decrypt messages.
-Improved security of crypto implementation by adding enhanced AES-CBC cryptor.
-Fixes Newtonsoft Json vulnerability with MaxDepth and upgrade to version  for non-PCL.
-Add SubscribeKey validation for subscribe feature.</PackageReleaseNotes>
+    <PackageReleaseNotes>Fixes issue of getting error when hereNow is called with channelGroups param only.</PackageReleaseNotes>
     <PackageTags>Web Data Push Real-time Notifications ESB Message Broadcasting Distributed Computing</PackageTags>
     <!--<Summary>PubNub is a Massively Scalable Web Push Service for Web and Mobile Games.  This is a cloud-based service for broadcasting messages to thousands of web and mobile clients simultaneously</Summary>-->
     <Description>PubNub is a Massively Scalable Web Push Service for Web and Mobile Games.  This is a cloud-based service for broadcasting messages to thousands of web and mobile clients simultaneously</Description>

--- a/src/Api/PubnubApi/PubnubApi.csproj
+++ b/src/Api/PubnubApi/PubnubApi.csproj
@@ -14,7 +14,7 @@
 
   <PropertyGroup>
     <PackageId>Pubnub</PackageId>
-    <PackageVersion>6.19.0.1</PackageVersion>
+    <PackageVersion>6.19.0.0</PackageVersion>
     <Title>PubNub C# .NET - Web Data Push API</Title>
     <Authors>Pandu Masabathula</Authors>
     <Owners>PubNub</Owners>
@@ -22,7 +22,10 @@
     <PackageIconUrl>http://pubnub.s3.amazonaws.com/2011/powered-by-pubnub/pubnub-icon-600x600.png</PackageIconUrl>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
     <RepositoryUrl>https://github.com/pubnub/c-sharp/</RepositoryUrl>
-    <PackageReleaseNotes>Fixes issue of getting error when hereNow is called with channelGroups param only.</PackageReleaseNotes>
+    <PackageReleaseNotes>Add crypto module that allows configure SDK to encrypt and decrypt messages.
+Improved security of crypto implementation by adding enhanced AES-CBC cryptor.
+Fixes Newtonsoft Json vulnerability with MaxDepth and upgrade to version  for non-PCL.
+Add SubscribeKey validation for subscribe feature.</PackageReleaseNotes>
     <PackageTags>Web Data Push Real-time Notifications ESB Message Broadcasting Distributed Computing</PackageTags>
     <!--<Summary>PubNub is a Massively Scalable Web Push Service for Web and Mobile Games.  This is a cloud-based service for broadcasting messages to thousands of web and mobile clients simultaneously</Summary>-->
     <Description>PubNub is a Massively Scalable Web Push Service for Web and Mobile Games.  This is a cloud-based service for broadcasting messages to thousands of web and mobile clients simultaneously</Description>

--- a/src/Api/PubnubApiPCL/PubnubApiPCL.csproj
+++ b/src/Api/PubnubApiPCL/PubnubApiPCL.csproj
@@ -15,7 +15,7 @@
 
   <PropertyGroup>
     <PackageId>PubnubPCL</PackageId>
-    <PackageVersion>6.19.0.0</PackageVersion>
+    <PackageVersion>6.19.0.1</PackageVersion>
     <Title>PubNub C# .NET - Web Data Push API</Title>
     <Authors>Pandu Masabathula</Authors>
     <Owners>PubNub</Owners>
@@ -23,10 +23,7 @@
     <PackageIconUrl>http://pubnub.s3.amazonaws.com/2011/powered-by-pubnub/pubnub-icon-600x600.png</PackageIconUrl>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
     <RepositoryUrl>https://github.com/pubnub/c-sharp/</RepositoryUrl>
-    <PackageReleaseNotes>Add crypto module that allows configure SDK to encrypt and decrypt messages.
-Improved security of crypto implementation by adding enhanced AES-CBC cryptor.
-Fixes Newtonsoft Json vulnerability with MaxDepth and upgrade to version  for non-PCL.
-Add SubscribeKey validation for subscribe feature.</PackageReleaseNotes>
+    <PackageReleaseNotes>Fixes issue of getting error when hereNow is called with channelGroups param only.</PackageReleaseNotes>
     <PackageTags>Web Data Push Real-time Notifications ESB Message Broadcasting Distributed Computing</PackageTags>
     <!--<Summary>PubNub is a Massively Scalable Web Push Service for Web and Mobile Games.  This is a cloud-based service for broadcasting messages to thousands of web and mobile clients simultaneously</Summary>-->
     <Description>PubNub is a Massively Scalable Web Push Service for Web and Mobile Games.  This is a cloud-based service for broadcasting messages to thousands of web and mobile clients simultaneously</Description>

--- a/src/Api/PubnubApiPCL/PubnubApiPCL.csproj
+++ b/src/Api/PubnubApiPCL/PubnubApiPCL.csproj
@@ -15,7 +15,7 @@
 
   <PropertyGroup>
     <PackageId>PubnubPCL</PackageId>
-    <PackageVersion>6.19.0.1</PackageVersion>
+    <PackageVersion>6.19.0.0</PackageVersion>
     <Title>PubNub C# .NET - Web Data Push API</Title>
     <Authors>Pandu Masabathula</Authors>
     <Owners>PubNub</Owners>
@@ -23,7 +23,10 @@
     <PackageIconUrl>http://pubnub.s3.amazonaws.com/2011/powered-by-pubnub/pubnub-icon-600x600.png</PackageIconUrl>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
     <RepositoryUrl>https://github.com/pubnub/c-sharp/</RepositoryUrl>
-    <PackageReleaseNotes>Fixes issue of getting error when hereNow is called with channelGroups param only.</PackageReleaseNotes>
+    <PackageReleaseNotes>Add crypto module that allows configure SDK to encrypt and decrypt messages.
+Improved security of crypto implementation by adding enhanced AES-CBC cryptor.
+Fixes Newtonsoft Json vulnerability with MaxDepth and upgrade to version  for non-PCL.
+Add SubscribeKey validation for subscribe feature.</PackageReleaseNotes>
     <PackageTags>Web Data Push Real-time Notifications ESB Message Broadcasting Distributed Computing</PackageTags>
     <!--<Summary>PubNub is a Massively Scalable Web Push Service for Web and Mobile Games.  This is a cloud-based service for broadcasting messages to thousands of web and mobile clients simultaneously</Summary>-->
     <Description>PubNub is a Massively Scalable Web Push Service for Web and Mobile Games.  This is a cloud-based service for broadcasting messages to thousands of web and mobile clients simultaneously</Description>

--- a/src/Api/PubnubApiPCL/PubnubApiPCL.csproj
+++ b/src/Api/PubnubApiPCL/PubnubApiPCL.csproj
@@ -15,7 +15,7 @@
 
   <PropertyGroup>
     <PackageId>PubnubPCL</PackageId>
-    <PackageVersion>6.19.0.0</PackageVersion>
+    <PackageVersion>6.19.1.0</PackageVersion>
     <Title>PubNub C# .NET - Web Data Push API</Title>
     <Authors>Pandu Masabathula</Authors>
     <Owners>PubNub</Owners>
@@ -23,10 +23,7 @@
     <PackageIconUrl>http://pubnub.s3.amazonaws.com/2011/powered-by-pubnub/pubnub-icon-600x600.png</PackageIconUrl>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
     <RepositoryUrl>https://github.com/pubnub/c-sharp/</RepositoryUrl>
-    <PackageReleaseNotes>Add crypto module that allows configure SDK to encrypt and decrypt messages.
-Improved security of crypto implementation by adding enhanced AES-CBC cryptor.
-Fixes Newtonsoft Json vulnerability with MaxDepth and upgrade to version  for non-PCL.
-Add SubscribeKey validation for subscribe feature.</PackageReleaseNotes>
+    <PackageReleaseNotes>Fixes issue of getting error when hereNow is called with channelGroups param only.</PackageReleaseNotes>
     <PackageTags>Web Data Push Real-time Notifications ESB Message Broadcasting Distributed Computing</PackageTags>
     <!--<Summary>PubNub is a Massively Scalable Web Push Service for Web and Mobile Games.  This is a cloud-based service for broadcasting messages to thousands of web and mobile clients simultaneously</Summary>-->
     <Description>PubNub is a Massively Scalable Web Push Service for Web and Mobile Games.  This is a cloud-based service for broadcasting messages to thousands of web and mobile clients simultaneously</Description>

--- a/src/Api/PubnubApiUWP/PubnubApiUWP.csproj
+++ b/src/Api/PubnubApiUWP/PubnubApiUWP.csproj
@@ -16,7 +16,7 @@
 
   <PropertyGroup>
     <PackageId>PubnubUWP</PackageId>
-    <PackageVersion>6.19.0.0</PackageVersion>
+    <PackageVersion>6.19.0.1</PackageVersion>
     <Title>PubNub C# .NET - Web Data Push API</Title>
     <Authors>Pandu Masabathula</Authors>
     <Owners>PubNub</Owners>
@@ -24,10 +24,7 @@
     <PackageIconUrl>http://pubnub.s3.amazonaws.com/2011/powered-by-pubnub/pubnub-icon-600x600.png</PackageIconUrl>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
     <RepositoryUrl>https://github.com/pubnub/c-sharp/</RepositoryUrl>
-    <PackageReleaseNotes>Add crypto module that allows configure SDK to encrypt and decrypt messages.
-Improved security of crypto implementation by adding enhanced AES-CBC cryptor.
-Fixes Newtonsoft Json vulnerability with MaxDepth and upgrade to version  for non-PCL.
-Add SubscribeKey validation for subscribe feature.</PackageReleaseNotes>
+    <PackageReleaseNotes>Fixes issue of getting error when hereNow is called with channelGroups param only.</PackageReleaseNotes>
     <PackageTags>Web Data Push Real-time Notifications ESB Message Broadcasting Distributed Computing</PackageTags>
     <!--<Summary>PubNub is a Massively Scalable Web Push Service for Web and Mobile Games.  This is a cloud-based service for broadcasting messages to thousands of web and mobile clients simultaneously</Summary>-->
     <Description>PubNub is a Massively Scalable Web Push Service for Web and Mobile Games.  This is a cloud-based service for broadcasting messages to thousands of web and mobile clients simultaneously</Description>

--- a/src/Api/PubnubApiUWP/PubnubApiUWP.csproj
+++ b/src/Api/PubnubApiUWP/PubnubApiUWP.csproj
@@ -16,7 +16,7 @@
 
   <PropertyGroup>
     <PackageId>PubnubUWP</PackageId>
-    <PackageVersion>6.19.0.1</PackageVersion>
+    <PackageVersion>6.19.0.0</PackageVersion>
     <Title>PubNub C# .NET - Web Data Push API</Title>
     <Authors>Pandu Masabathula</Authors>
     <Owners>PubNub</Owners>
@@ -24,7 +24,10 @@
     <PackageIconUrl>http://pubnub.s3.amazonaws.com/2011/powered-by-pubnub/pubnub-icon-600x600.png</PackageIconUrl>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
     <RepositoryUrl>https://github.com/pubnub/c-sharp/</RepositoryUrl>
-    <PackageReleaseNotes>Fixes issue of getting error when hereNow is called with channelGroups param only.</PackageReleaseNotes>
+    <PackageReleaseNotes>Add crypto module that allows configure SDK to encrypt and decrypt messages.
+Improved security of crypto implementation by adding enhanced AES-CBC cryptor.
+Fixes Newtonsoft Json vulnerability with MaxDepth and upgrade to version  for non-PCL.
+Add SubscribeKey validation for subscribe feature.</PackageReleaseNotes>
     <PackageTags>Web Data Push Real-time Notifications ESB Message Broadcasting Distributed Computing</PackageTags>
     <!--<Summary>PubNub is a Massively Scalable Web Push Service for Web and Mobile Games.  This is a cloud-based service for broadcasting messages to thousands of web and mobile clients simultaneously</Summary>-->
     <Description>PubNub is a Massively Scalable Web Push Service for Web and Mobile Games.  This is a cloud-based service for broadcasting messages to thousands of web and mobile clients simultaneously</Description>

--- a/src/Api/PubnubApiUWP/PubnubApiUWP.csproj
+++ b/src/Api/PubnubApiUWP/PubnubApiUWP.csproj
@@ -16,7 +16,7 @@
 
   <PropertyGroup>
     <PackageId>PubnubUWP</PackageId>
-    <PackageVersion>6.19.0.0</PackageVersion>
+    <PackageVersion>6.19.1.0</PackageVersion>
     <Title>PubNub C# .NET - Web Data Push API</Title>
     <Authors>Pandu Masabathula</Authors>
     <Owners>PubNub</Owners>
@@ -24,10 +24,7 @@
     <PackageIconUrl>http://pubnub.s3.amazonaws.com/2011/powered-by-pubnub/pubnub-icon-600x600.png</PackageIconUrl>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
     <RepositoryUrl>https://github.com/pubnub/c-sharp/</RepositoryUrl>
-    <PackageReleaseNotes>Add crypto module that allows configure SDK to encrypt and decrypt messages.
-Improved security of crypto implementation by adding enhanced AES-CBC cryptor.
-Fixes Newtonsoft Json vulnerability with MaxDepth and upgrade to version  for non-PCL.
-Add SubscribeKey validation for subscribe feature.</PackageReleaseNotes>
+    <PackageReleaseNotes>Fixes issue of getting error when hereNow is called with channelGroups param only.</PackageReleaseNotes>
     <PackageTags>Web Data Push Real-time Notifications ESB Message Broadcasting Distributed Computing</PackageTags>
     <!--<Summary>PubNub is a Massively Scalable Web Push Service for Web and Mobile Games.  This is a cloud-based service for broadcasting messages to thousands of web and mobile clients simultaneously</Summary>-->
     <Description>PubNub is a Massively Scalable Web Push Service for Web and Mobile Games.  This is a cloud-based service for broadcasting messages to thousands of web and mobile clients simultaneously</Description>

--- a/src/Api/PubnubApiUnity/PubnubApiUnity.csproj
+++ b/src/Api/PubnubApiUnity/PubnubApiUnity.csproj
@@ -15,7 +15,7 @@
 
   <PropertyGroup>
     <PackageId>PubnubApiUnity</PackageId>
-    <PackageVersion>6.19.0.0</PackageVersion>
+    <PackageVersion>6.19.0.1</PackageVersion>
     <Title>PubNub C# .NET - Web Data Push API</Title>
     <Authors>Pandu Masabathula</Authors>
     <Owners>PubNub</Owners>

--- a/src/Api/PubnubApiUnity/PubnubApiUnity.csproj
+++ b/src/Api/PubnubApiUnity/PubnubApiUnity.csproj
@@ -15,7 +15,7 @@
 
   <PropertyGroup>
     <PackageId>PubnubApiUnity</PackageId>
-    <PackageVersion>6.19.0.1</PackageVersion>
+    <PackageVersion>6.19.0.0</PackageVersion>
     <Title>PubNub C# .NET - Web Data Push API</Title>
     <Authors>Pandu Masabathula</Authors>
     <Owners>PubNub</Owners>

--- a/src/Api/PubnubApiUnity/PubnubApiUnity.csproj
+++ b/src/Api/PubnubApiUnity/PubnubApiUnity.csproj
@@ -15,7 +15,7 @@
 
   <PropertyGroup>
     <PackageId>PubnubApiUnity</PackageId>
-    <PackageVersion>6.19.0.0</PackageVersion>
+    <PackageVersion>6.19.1.0</PackageVersion>
     <Title>PubNub C# .NET - Web Data Push API</Title>
     <Authors>Pandu Masabathula</Authors>
     <Owners>PubNub</Owners>


### PR DESCRIPTION
fix: hereNow api call without channels specified generates incorrect rest url.

Fixes issue of getting error when hereNow is called with channelGroups param only.