### PR TITLE
fix/JSON Serialisation when message decryption failed

### DIFF
--- a/.pubnub.yml
+++ b/.pubnub.yml
@@ -1,8 +1,13 @@
 name: c-sharp
-version: "6.19.4"
+version: "6.19.5"
 schema: 1
 scm: github.com/pubnub/c-sharp
 changelog:
+  - date: 2024-01-17
+    version: v6.19.5
+    changes:
+      - type: bug
+        text: "Fixes issue of getting exception for custom objects in subscription and history when crypto module is configured."
   - date: 2023-11-28
     version: v6.19.4
     changes:
@@ -761,7 +766,7 @@ features:
     - QUERY-PARAM
 supported-platforms:
   -
-    version: Pubnub 'C#' 6.19.4
+    version: Pubnub 'C#' 6.19.5
     platforms:
       - Windows 10 and up
       - Windows Server 2008 and up
@@ -771,7 +776,7 @@ supported-platforms:
       - .Net Framework 4.5
       - .Net Framework 4.6.1+
   -
-    version: PubnubPCL 'C#' 6.19.4
+    version: PubnubPCL 'C#' 6.19.5
     platforms:
       - Xamarin.Android
       - Xamarin.iOS
@@ -791,7 +796,7 @@ supported-platforms:
       - .Net Core
       - .Net 6.0
   -
-    version: PubnubUWP 'C#' 6.19.4
+    version: PubnubUWP 'C#' 6.19.5
     platforms:
       - Windows Phone 10
       - Universal Windows Apps
@@ -815,7 +820,7 @@ sdks:
             distribution-type: source
             distribution-repository: GitHub
             package-name: Pubnub
-            location: https://github.com/pubnub/c-sharp/releases/tag/v6.19.4.0
+            location: https://github.com/pubnub/c-sharp/releases/tag/v6.19.5.0
             requires:
               -
                 name: ".Net"
@@ -1098,7 +1103,7 @@ sdks:
             distribution-type: source
             distribution-repository: GitHub
             package-name: PubNubPCL
-            location: https://github.com/pubnub/c-sharp/releases/tag/v6.19.4.0
+            location: https://github.com/pubnub/c-sharp/releases/tag/v6.19.5.0
             requires:
               -
                 name: ".Net Core"
@@ -1457,7 +1462,7 @@ sdks:
             distribution-type: source
             distribution-repository: GitHub
             package-name: PubnubUWP
-            location: https://github.com/pubnub/c-sharp/releases/tag/v6.19.4.0
+            location: https://github.com/pubnub/c-sharp/releases/tag/v6.19.5.0
             requires:
               -
                 name: "Universal Windows Platform Development"

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+v6.19.5 - January 17 2024
+-----------------------------
+- Fixed: fixes issue of getting exception for custom objects in subscription and history when crypto module is configured.
+
 v6.19.4 - November 28 2023
 -----------------------------
 - Fixed: handle unencrypted message while getting messages with crypto.

--- a/src/Api/PubnubApi/Properties/AssemblyInfo.cs
+++ b/src/Api/PubnubApi/Properties/AssemblyInfo.cs
@@ -11,8 +11,8 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyProduct("Pubnub C# SDK")]
 [assembly: AssemblyCopyright("Copyright ©  2021")]
 [assembly: AssemblyTrademark("")]
-[assembly: AssemblyVersion("6.19.4.0")]
-[assembly: AssemblyFileVersion("6.19.4.0")]
+[assembly: AssemblyVersion("6.19.5.0")]
+[assembly: AssemblyFileVersion("6.19.5.0")]
 // Setting ComVisible to false makes the types in this assembly not visible
 // to COM components.  If you need to access a type in this assembly from
 // COM, set the ComVisible attribute to true on that type.

--- a/src/Api/PubnubApi/PubnubApi.csproj
+++ b/src/Api/PubnubApi/PubnubApi.csproj
@@ -14,7 +14,7 @@
 
   <PropertyGroup>
     <PackageId>Pubnub</PackageId>
-    <PackageVersion>6.19.4.0</PackageVersion>
+    <PackageVersion>6.19.5.0</PackageVersion>
     <Title>PubNub C# .NET - Web Data Push API</Title>
     <Authors>Pandu Masabathula</Authors>
     <Owners>PubNub</Owners>
@@ -22,7 +22,7 @@
     <PackageIconUrl>http://pubnub.s3.amazonaws.com/2011/powered-by-pubnub/pubnub-icon-600x600.png</PackageIconUrl>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
     <RepositoryUrl>https://github.com/pubnub/c-sharp/</RepositoryUrl>
-    <PackageReleaseNotes>Handle unencrypted message while getting messages with crypto.</PackageReleaseNotes>
+    <PackageReleaseNotes>Fixes issue of getting exception for custom objects in subscription and history when crypto module is configured.</PackageReleaseNotes>
     <PackageTags>Web Data Push Real-time Notifications ESB Message Broadcasting Distributed Computing</PackageTags>
     <!--<Summary>PubNub is a Massively Scalable Web Push Service for Web and Mobile Games.  This is a cloud-based service for broadcasting messages to thousands of web and mobile clients simultaneously</Summary>-->
     <Description>PubNub is a Massively Scalable Web Push Service for Web and Mobile Games.  This is a cloud-based service for broadcasting messages to thousands of web and mobile clients simultaneously</Description>

--- a/src/Api/PubnubApi/PubnubCoreBase.cs
+++ b/src/Api/PubnubApi/PubnubCoreBase.cs
@@ -736,8 +736,7 @@ namespace PubnubApi
                                                         currentConfig.LogVerbosity
                                                 );
                                             }
-                                            object decodeMessage = jsonLib.DeserializeToObject((decryptMessage == "**DECRYPT ERROR**") ? payload.ToString() : decryptMessage);
-
+                                            object decodeMessage = jsonLib.DeserializeToObject((decryptMessage == "**DECRYPT ERROR**") ? jsonLib.SerializeToJsonString(payload) : decryptMessage);
                                             payloadContainer.Add(decodeMessage);
                                         }
                                         else

--- a/src/Api/PubnubApi/Security/SecureMessage.cs
+++ b/src/Api/PubnubApi/Security/SecureMessage.cs
@@ -68,12 +68,10 @@ namespace PubnubApi
                             {
                                 status.AffectedChannelGroups.AddRange(channelGroups);
                             }
-
-                            errorCallback.OnResponse(default(T), status);
+                            pubnubLog.WriteToLog("Failed to decrypt message!\nMessage might be not encrypted, returning as is...");
                         }
-                        pubnubLog.WriteToLog("Failed to decrypt message!\nMessage might be not encrypted, returning as is...");
-                        object decodeMessage = jsonLib.DeserializeToObject((decryptMessage == "**DECRYPT ERROR**") ? element.ToString() : decryptMessage);
-                        receivedMsg.Add(decodeMessage);
+                        object decodedMessage = jsonLib.DeserializeToObject((decryptMessage == "**DECRYPT ERROR**") ? jsonLib.SerializeToJsonString(element) : decryptMessage);
+                        receivedMsg.Add(decodedMessage);
                     }
                     returnMessage.Add(receivedMsg);
                 }
@@ -151,13 +149,11 @@ namespace PubnubApi
                                             {
                                                 status.AffectedChannelGroups.AddRange(channelGroups);
                                             }
-
-                                            errorCallback.OnResponse(default(T), status);
+                                            pubnubLog.WriteToLog("Failed to decrypt message!\nMessage might be not encrypted, returning as is...");
                                             #endregion
                                         }
-                                        pubnubLog.WriteToLog("Failed to decrypt message!\nMessage might be not encrypted, returning as is...");
-                                        object decodeMessage = jsonLib.DeserializeToObject((decryptMessage == "**DECRYPT ERROR**") ? decryptMessage : decryptMessage);
-                                        dicDecrypt.Add(kvpValue.Key, decodeMessage);
+                                        object decodedMessage = jsonLib.DeserializeToObject((decryptMessage == "**DECRYPT ERROR**") ? jsonLib.SerializeToJsonString(kvpValue.Value) : decryptMessage);
+                                        dicDecrypt.Add(kvpValue.Key, decodedMessage);
                                     }
                                     else
                                     {

--- a/src/Api/PubnubApiPCL/PubnubApiPCL.csproj
+++ b/src/Api/PubnubApiPCL/PubnubApiPCL.csproj
@@ -15,7 +15,7 @@
 
   <PropertyGroup>
     <PackageId>PubnubPCL</PackageId>
-    <PackageVersion>6.19.4.0</PackageVersion>
+    <PackageVersion>6.19.5.0</PackageVersion>
     <Title>PubNub C# .NET - Web Data Push API</Title>
     <Authors>Pandu Masabathula</Authors>
     <Owners>PubNub</Owners>
@@ -23,7 +23,7 @@
     <PackageIconUrl>http://pubnub.s3.amazonaws.com/2011/powered-by-pubnub/pubnub-icon-600x600.png</PackageIconUrl>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
     <RepositoryUrl>https://github.com/pubnub/c-sharp/</RepositoryUrl>
-    <PackageReleaseNotes>Handle unencrypted message while getting messages with crypto.</PackageReleaseNotes>
+    <PackageReleaseNotes>Fixes issue of getting exception for custom objects in subscription and history when crypto module is configured.</PackageReleaseNotes>
     <PackageTags>Web Data Push Real-time Notifications ESB Message Broadcasting Distributed Computing</PackageTags>
     <!--<Summary>PubNub is a Massively Scalable Web Push Service for Web and Mobile Games.  This is a cloud-based service for broadcasting messages to thousands of web and mobile clients simultaneously</Summary>-->
     <Description>PubNub is a Massively Scalable Web Push Service for Web and Mobile Games.  This is a cloud-based service for broadcasting messages to thousands of web and mobile clients simultaneously</Description>

--- a/src/Api/PubnubApiUWP/PubnubApiUWP.csproj
+++ b/src/Api/PubnubApiUWP/PubnubApiUWP.csproj
@@ -16,7 +16,7 @@
 
   <PropertyGroup>
     <PackageId>PubnubUWP</PackageId>
-    <PackageVersion>6.19.4.0</PackageVersion>
+    <PackageVersion>6.19.5.0</PackageVersion>
     <Title>PubNub C# .NET - Web Data Push API</Title>
     <Authors>Pandu Masabathula</Authors>
     <Owners>PubNub</Owners>
@@ -24,7 +24,7 @@
     <PackageIconUrl>http://pubnub.s3.amazonaws.com/2011/powered-by-pubnub/pubnub-icon-600x600.png</PackageIconUrl>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
     <RepositoryUrl>https://github.com/pubnub/c-sharp/</RepositoryUrl>
-    <PackageReleaseNotes>Handle unencrypted message while getting messages with crypto.</PackageReleaseNotes>
+    <PackageReleaseNotes>Fixes issue of getting exception for custom objects in subscription and history when crypto module is configured.</PackageReleaseNotes>
     <PackageTags>Web Data Push Real-time Notifications ESB Message Broadcasting Distributed Computing</PackageTags>
     <!--<Summary>PubNub is a Massively Scalable Web Push Service for Web and Mobile Games.  This is a cloud-based service for broadcasting messages to thousands of web and mobile clients simultaneously</Summary>-->
     <Description>PubNub is a Massively Scalable Web Push Service for Web and Mobile Games.  This is a cloud-based service for broadcasting messages to thousands of web and mobile clients simultaneously</Description>

--- a/src/Api/PubnubApiUnity/PubnubApiUnity.csproj
+++ b/src/Api/PubnubApiUnity/PubnubApiUnity.csproj
@@ -15,7 +15,7 @@
 
   <PropertyGroup>
     <PackageId>PubnubApiUnity</PackageId>
-    <PackageVersion>6.19.4.0</PackageVersion>
+    <PackageVersion>6.19.5.0</PackageVersion>
     <Title>PubNub C# .NET - Web Data Push API</Title>
     <Authors>Pandu Masabathula</Authors>
     <Owners>PubNub</Owners>


### PR DESCRIPTION
fix: json serialisation failed for custom objects when crypto module is configured.

Fixes issue of getting exception for custom objects in subscription and history when crypto module is configured.