### PR TITLE
fix: DateTime/Timetoken conversion precision loss

### DIFF
--- a/.pubnub.yml
+++ b/.pubnub.yml
@@ -1,8 +1,13 @@
 name: c-sharp
-version: "6.19.5"
+version: "6.19.6"
 schema: 1
 scm: github.com/pubnub/c-sharp
 changelog:
+  - date: 2024-03-28
+    version: v6.19.6
+    changes:
+      - type: bug
+        text: "Fixes issue of inaccurate DateTime to TimeToken conversion in TranslateDateTimeToPubnubUnixNanoSeconds."
   - date: 2024-01-17
     version: v6.19.5
     changes:
@@ -766,7 +771,7 @@ features:
     - QUERY-PARAM
 supported-platforms:
   -
-    version: Pubnub 'C#' 6.19.5
+    version: Pubnub 'C#' 6.19.6
     platforms:
       - Windows 10 and up
       - Windows Server 2008 and up
@@ -776,7 +781,7 @@ supported-platforms:
       - .Net Framework 4.5
       - .Net Framework 4.6.1+
   -
-    version: PubnubPCL 'C#' 6.19.5
+    version: PubnubPCL 'C#' 6.19.6
     platforms:
       - Xamarin.Android
       - Xamarin.iOS
@@ -796,7 +801,7 @@ supported-platforms:
       - .Net Core
       - .Net 6.0
   -
-    version: PubnubUWP 'C#' 6.19.5
+    version: PubnubUWP 'C#' 6.19.6
     platforms:
       - Windows Phone 10
       - Universal Windows Apps
@@ -820,7 +825,7 @@ sdks:
             distribution-type: source
             distribution-repository: GitHub
             package-name: Pubnub
-            location: https://github.com/pubnub/c-sharp/releases/tag/v6.19.5.0
+            location: https://github.com/pubnub/c-sharp/releases/tag/v6.19.6.0
             requires:
               -
                 name: ".Net"
@@ -1103,7 +1108,7 @@ sdks:
             distribution-type: source
             distribution-repository: GitHub
             package-name: PubNubPCL
-            location: https://github.com/pubnub/c-sharp/releases/tag/v6.19.5.0
+            location: https://github.com/pubnub/c-sharp/releases/tag/v6.19.6.0
             requires:
               -
                 name: ".Net Core"
@@ -1462,7 +1467,7 @@ sdks:
             distribution-type: source
             distribution-repository: GitHub
             package-name: PubnubUWP
-            location: https://github.com/pubnub/c-sharp/releases/tag/v6.19.5.0
+            location: https://github.com/pubnub/c-sharp/releases/tag/v6.19.6.0
             requires:
               -
                 name: "Universal Windows Platform Development"

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+v6.19.6 - March 28 2024
+-----------------------------
+- Fixed: fixes issue of inaccurate DateTime to TimeToken conversion in TranslateDateTimeToPubnubUnixNanoSeconds.
+
 v6.19.5 - January 17 2024
 -----------------------------
 - Fixed: fixes issue of getting exception for custom objects in subscription and history when crypto module is configured.

--- a/src/Api/PubnubApi/EndPoint/OtherOperation.cs
+++ b/src/Api/PubnubApi/EndPoint/OtherOperation.cs
@@ -97,7 +97,7 @@ namespace PubnubApi.EndPoint
         public static long TranslateDateTimeToPubnubUnixNanoSeconds(DateTime dotNetUTCDateTime)
         {
             TimeSpan timeSpan = dotNetUTCDateTime - new DateTime(1970, 1, 1, 0, 0, 0, DateTimeKind.Utc);
-            long timeStamp = Convert.ToInt64(timeSpan.TotalSeconds) * 10000000;
+            long timeStamp = Convert.ToInt64(timeSpan.TotalSeconds * 10000000);
             return timeStamp;
         }
 

--- a/src/Api/PubnubApi/Properties/AssemblyInfo.cs
+++ b/src/Api/PubnubApi/Properties/AssemblyInfo.cs
@@ -11,8 +11,8 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyProduct("Pubnub C# SDK")]
 [assembly: AssemblyCopyright("Copyright ©  2021")]
 [assembly: AssemblyTrademark("")]
-[assembly: AssemblyVersion("6.19.5.0")]
-[assembly: AssemblyFileVersion("6.19.5.0")]
+[assembly: AssemblyVersion("6.19.6.0")]
+[assembly: AssemblyFileVersion("6.19.6.0")]
 // Setting ComVisible to false makes the types in this assembly not visible
 // to COM components.  If you need to access a type in this assembly from
 // COM, set the ComVisible attribute to true on that type.

--- a/src/Api/PubnubApi/PubnubApi.csproj
+++ b/src/Api/PubnubApi/PubnubApi.csproj
@@ -14,7 +14,7 @@
 
   <PropertyGroup>
     <PackageId>Pubnub</PackageId>
-    <PackageVersion>6.19.5.0</PackageVersion>
+    <PackageVersion>6.19.6.0</PackageVersion>
     <Title>PubNub C# .NET - Web Data Push API</Title>
     <Authors>Pandu Masabathula</Authors>
     <Owners>PubNub</Owners>
@@ -22,7 +22,7 @@
     <PackageIconUrl>http://pubnub.s3.amazonaws.com/2011/powered-by-pubnub/pubnub-icon-600x600.png</PackageIconUrl>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
     <RepositoryUrl>https://github.com/pubnub/c-sharp/</RepositoryUrl>
-    <PackageReleaseNotes>Fixes issue of getting exception for custom objects in subscription and history when crypto module is configured.</PackageReleaseNotes>
+    <PackageReleaseNotes>Fixes issue of inaccurate DateTime to TimeToken conversion in TranslateDateTimeToPubnubUnixNanoSeconds.</PackageReleaseNotes>
     <PackageTags>Web Data Push Real-time Notifications ESB Message Broadcasting Distributed Computing</PackageTags>
     <!--<Summary>PubNub is a Massively Scalable Web Push Service for Web and Mobile Games.  This is a cloud-based service for broadcasting messages to thousands of web and mobile clients simultaneously</Summary>-->
     <Description>PubNub is a Massively Scalable Web Push Service for Web and Mobile Games.  This is a cloud-based service for broadcasting messages to thousands of web and mobile clients simultaneously</Description>

--- a/src/Api/PubnubApiPCL/PubnubApiPCL.csproj
+++ b/src/Api/PubnubApiPCL/PubnubApiPCL.csproj
@@ -15,7 +15,7 @@
 
   <PropertyGroup>
     <PackageId>PubnubPCL</PackageId>
-    <PackageVersion>6.19.5.0</PackageVersion>
+    <PackageVersion>6.19.6.0</PackageVersion>
     <Title>PubNub C# .NET - Web Data Push API</Title>
     <Authors>Pandu Masabathula</Authors>
     <Owners>PubNub</Owners>
@@ -23,7 +23,7 @@
     <PackageIconUrl>http://pubnub.s3.amazonaws.com/2011/powered-by-pubnub/pubnub-icon-600x600.png</PackageIconUrl>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
     <RepositoryUrl>https://github.com/pubnub/c-sharp/</RepositoryUrl>
-    <PackageReleaseNotes>Fixes issue of getting exception for custom objects in subscription and history when crypto module is configured.</PackageReleaseNotes>
+    <PackageReleaseNotes>Fixes issue of inaccurate DateTime to TimeToken conversion in TranslateDateTimeToPubnubUnixNanoSeconds.</PackageReleaseNotes>
     <PackageTags>Web Data Push Real-time Notifications ESB Message Broadcasting Distributed Computing</PackageTags>
     <!--<Summary>PubNub is a Massively Scalable Web Push Service for Web and Mobile Games.  This is a cloud-based service for broadcasting messages to thousands of web and mobile clients simultaneously</Summary>-->
     <Description>PubNub is a Massively Scalable Web Push Service for Web and Mobile Games.  This is a cloud-based service for broadcasting messages to thousands of web and mobile clients simultaneously</Description>

--- a/src/Api/PubnubApiUWP/PubnubApiUWP.csproj
+++ b/src/Api/PubnubApiUWP/PubnubApiUWP.csproj
@@ -16,7 +16,7 @@
 
   <PropertyGroup>
     <PackageId>PubnubUWP</PackageId>
-    <PackageVersion>6.19.5.0</PackageVersion>
+    <PackageVersion>6.19.6.0</PackageVersion>
     <Title>PubNub C# .NET - Web Data Push API</Title>
     <Authors>Pandu Masabathula</Authors>
     <Owners>PubNub</Owners>
@@ -24,7 +24,7 @@
     <PackageIconUrl>http://pubnub.s3.amazonaws.com/2011/powered-by-pubnub/pubnub-icon-600x600.png</PackageIconUrl>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
     <RepositoryUrl>https://github.com/pubnub/c-sharp/</RepositoryUrl>
-    <PackageReleaseNotes>Fixes issue of getting exception for custom objects in subscription and history when crypto module is configured.</PackageReleaseNotes>
+    <PackageReleaseNotes>Fixes issue of inaccurate DateTime to TimeToken conversion in TranslateDateTimeToPubnubUnixNanoSeconds.</PackageReleaseNotes>
     <PackageTags>Web Data Push Real-time Notifications ESB Message Broadcasting Distributed Computing</PackageTags>
     <!--<Summary>PubNub is a Massively Scalable Web Push Service for Web and Mobile Games.  This is a cloud-based service for broadcasting messages to thousands of web and mobile clients simultaneously</Summary>-->
     <Description>PubNub is a Massively Scalable Web Push Service for Web and Mobile Games.  This is a cloud-based service for broadcasting messages to thousands of web and mobile clients simultaneously</Description>

--- a/src/Api/PubnubApiUnity/PubnubApiUnity.csproj
+++ b/src/Api/PubnubApiUnity/PubnubApiUnity.csproj
@@ -15,7 +15,7 @@
 
   <PropertyGroup>
     <PackageId>PubnubApiUnity</PackageId>
-    <PackageVersion>6.19.5.0</PackageVersion>
+    <PackageVersion>6.19.6.0</PackageVersion>
     <Title>PubNub C# .NET - Web Data Push API</Title>
     <Authors>Pandu Masabathula</Authors>
     <Owners>PubNub</Owners>

--- a/src/UnitTests/PubnubApi.Tests/WhenGetRequestServerTime.cs
+++ b/src/UnitTests/PubnubApi.Tests/WhenGetRequestServerTime.cs
@@ -285,17 +285,27 @@ namespace PubNubMessaging.Tests
         public static void TranslateDateTimeToUnixTime()
         {
             //Test for 26th June 2012 GMT
-            DateTime dt = new DateTime(2012, 6, 26, 0, 0, 0, DateTimeKind.Utc);
+            DateTime dt = new DateTime(2012, 6, 26, 21, 37, 13, 37, DateTimeKind.Utc);
             long nanoSecondTime = Pubnub.TranslateDateTimeToPubnubUnixNanoSeconds(dt);
-            Assert.True(13406688000000000 == nanoSecondTime);
+            Assert.True(13407466330370000 == nanoSecondTime);
+        }
+        
+        [Test]
+        public static void TranslateDateTimeToUnixTimeAndBack()
+        {
+            //Test for 26th June 2012 GMT
+            DateTime expectedDate = new DateTime(2012, 6, 26, 21, 37, 13, 37, DateTimeKind.Utc);
+            long nanoSecondTime = Pubnub.TranslateDateTimeToPubnubUnixNanoSeconds(expectedDate);
+            DateTime dateAgain = Pubnub.TranslatePubnubUnixNanoSecondsToDateTime(nanoSecondTime);
+            Assert.True(expectedDate.Equals(dateAgain));
         }
 
         [Test]
         public static void TranslateUnixTimeToDateTime()
         {
             //Test for 26th June 2012 GMT
-            DateTime expectedDate = new DateTime(2012, 6, 26, 0, 0, 0, DateTimeKind.Utc);
-            DateTime actualDate = Pubnub.TranslatePubnubUnixNanoSecondsToDateTime(13406688000000000);
+            DateTime expectedDate = new DateTime(2012, 6, 26, 21, 37, 13, 37, DateTimeKind.Utc);
+            DateTime actualDate = Pubnub.TranslatePubnubUnixNanoSecondsToDateTime(13407466330370000);
             Assert.True(expectedDate == actualDate);
         }
 


### PR DESCRIPTION
fix: fix loss of precision in TranslateDateTimeToPubnubUnixNanoSeconds

Fixes issue of inaccurate DateTime to TimeToken conversion in TranslateDateTimeToPubnubUnixNanoSeconds