### PR TITLE
CLEN-1936: Fix status category in no network condition

### DIFF
--- a/src/Api/PubnubApi/EndPoint/OtherOperation.cs
+++ b/src/Api/PubnubApi/EndPoint/OtherOperation.cs
@@ -97,7 +97,7 @@ namespace PubnubApi.EndPoint
         public static long TranslateDateTimeToPubnubUnixNanoSeconds(DateTime dotNetUTCDateTime)
         {
             TimeSpan timeSpan = dotNetUTCDateTime - new DateTime(1970, 1, 1, 0, 0, 0, DateTimeKind.Utc);
-            long timeStamp = Convert.ToInt64(timeSpan.TotalSeconds) * 10000000;
+            long timeStamp = Convert.ToInt64(timeSpan.TotalSeconds * 10000000);
             return timeStamp;
         }
 

--- a/src/Api/PubnubApi/EndPoint/PubSub/SubscribeManager.cs
+++ b/src/Api/PubnubApi/EndPoint/PubSub/SubscribeManager.cs
@@ -1213,7 +1213,7 @@ namespace PubnubApi.EndPoint
 
                                 if (netState.Channels != null && netState.Channels.Length > 0)
                                 {
-                                    PNStatus status = new StatusBuilder(config.ContainsKey(PubnubInstance.InstanceId) ? config[PubnubInstance.InstanceId] : null, jsonLibrary).CreateStatusResponse<T>(netState.ResponseType, PNStatusCategory.PNReconnectedCategory, null, (int)System.Net.HttpStatusCode.NotFound, new PNException("Internet connection problem. Retrying connection"));
+                                    PNStatus status = new StatusBuilder(config.ContainsKey(PubnubInstance.InstanceId) ? config[PubnubInstance.InstanceId] : null, jsonLibrary).CreateStatusResponse<T>(netState.ResponseType, PNStatusCategory.PNNetworkIssuesCategory, null, (int)System.Net.HttpStatusCode.NotFound, new PNException("Internet connection problem. Retrying connection"));
                                     if (netState.Channels != null && netState.Channels.Length > 0)
                                     {
                                         status.AffectedChannels.AddRange(netState.Channels.ToList());

--- a/src/UnitTests/PubnubApi.Tests/WhenGetRequestServerTime.cs
+++ b/src/UnitTests/PubnubApi.Tests/WhenGetRequestServerTime.cs
@@ -285,17 +285,27 @@ namespace PubNubMessaging.Tests
         public static void TranslateDateTimeToUnixTime()
         {
             //Test for 26th June 2012 GMT
-            DateTime dt = new DateTime(2012, 6, 26, 0, 0, 0, DateTimeKind.Utc);
+            DateTime dt = new DateTime(2012, 6, 26, 21, 37, 13, 37, DateTimeKind.Utc);
             long nanoSecondTime = Pubnub.TranslateDateTimeToPubnubUnixNanoSeconds(dt);
-            Assert.True(13406688000000000 == nanoSecondTime);
+            Assert.True(13407466330370000 == nanoSecondTime);
+        }
+        
+        [Test]
+        public static void TranslateDateTimeToUnixTimeAndBack()
+        {
+            //Test for 26th June 2012 GMT
+            DateTime expectedDate = new DateTime(2012, 6, 26, 21, 37, 13, 37, DateTimeKind.Utc);
+            long nanoSecondTime = Pubnub.TranslateDateTimeToPubnubUnixNanoSeconds(expectedDate);
+            DateTime dateAgain = Pubnub.TranslatePubnubUnixNanoSecondsToDateTime(nanoSecondTime);
+            Assert.True(expectedDate.Equals(dateAgain));
         }
 
         [Test]
         public static void TranslateUnixTimeToDateTime()
         {
             //Test for 26th June 2012 GMT
-            DateTime expectedDate = new DateTime(2012, 6, 26, 0, 0, 0, DateTimeKind.Utc);
-            DateTime actualDate = Pubnub.TranslatePubnubUnixNanoSecondsToDateTime(13406688000000000);
+            DateTime expectedDate = new DateTime(2012, 6, 26, 21, 37, 13, 37, DateTimeKind.Utc);
+            DateTime actualDate = Pubnub.TranslatePubnubUnixNanoSecondsToDateTime(13407466330370000);
             Assert.True(expectedDate == actualDate);
         }
 


### PR DESCRIPTION
fix: Proper status category in network issue situation.

Resolved the issue where an incorrect network status was emitted when no internet connection was detected.