### PR TITLE
fix:duplicate message when event engine is disabled

### DIFF
--- a/.pubnub.yml
+++ b/.pubnub.yml
@@ -1,8 +1,13 @@
 name: c-sharp
-version: "7.1.1"
+version: "7.1.2"
 schema: 1
 scm: github.com/pubnub/c-sharp
 changelog:
+  - date: 2025-01-21
+    version: v7.1.2
+    changes:
+      - type: bug
+        text: "Fixes issue of receiving duplicate messages when event engine is disabled."
   - date: 2025-01-16
     version: v7.1.1
     changes:
@@ -818,7 +823,7 @@ features:
     - QUERY-PARAM
 supported-platforms:
   -
-    version: Pubnub 'C#' 7.1.1
+    version: Pubnub 'C#' 7.1.2
     platforms:
       - Windows 10 and up
       - Windows Server 2008 and up
@@ -829,7 +834,7 @@ supported-platforms:
       - .Net Framework 4.6.1+
       - .Net Framework 6.0
   -
-    version: PubnubPCL 'C#' 7.1.1
+    version: PubnubPCL 'C#' 7.1.2
     platforms:
       - Xamarin.Android
       - Xamarin.iOS
@@ -849,7 +854,7 @@ supported-platforms:
       - .Net Core
       - .Net 6.0
   -
-    version: PubnubUWP 'C#' 7.1.1
+    version: PubnubUWP 'C#' 7.1.2
     platforms:
       - Windows Phone 10
       - Universal Windows Apps
@@ -873,7 +878,7 @@ sdks:
             distribution-type: source
             distribution-repository: GitHub
             package-name: Pubnub
-            location: https://github.com/pubnub/c-sharp/releases/tag/v7.1.1.0
+            location: https://github.com/pubnub/c-sharp/releases/tag/v7.1.2.0
             requires:
               -
                 name: ".Net"
@@ -1156,7 +1161,7 @@ sdks:
             distribution-type: source
             distribution-repository: GitHub
             package-name: PubNubPCL
-            location: https://github.com/pubnub/c-sharp/releases/tag/v7.1.1.0
+            location: https://github.com/pubnub/c-sharp/releases/tag/v7.1.2.0
             requires:
               -
                 name: ".Net Core"
@@ -1515,7 +1520,7 @@ sdks:
             distribution-type: source
             distribution-repository: GitHub
             package-name: PubnubUWP
-            location: https://github.com/pubnub/c-sharp/releases/tag/v7.1.1.0
+            location: https://github.com/pubnub/c-sharp/releases/tag/v7.1.2.0
             requires:
               -
                 name: "Universal Windows Platform Development"

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+v7.1.2 - January 21 2025
+-----------------------------
+- Fixed: fixes issue of receiving duplicate messages when event engine is disabled.
+
 v7.1.1 - January 16 2025
 -----------------------------
 - Modified: refactored event result data parsing logic within the subscribe feature for enhanced performance and maintainability.

--- a/src/Api/PubnubApi/EndPoint/PubSub/PublishOperation.cs
+++ b/src/Api/PubnubApi/EndPoint/PubSub/PublishOperation.cs
@@ -338,7 +338,7 @@ namespace PubnubApi.EndPoint
 			}
 
 			if (storeInHistory && ttl >= 0) {
-				requestQueryStringParams.Add("tt1", ttl.ToString(CultureInfo.InvariantCulture));
+				requestQueryStringParams.Add("ttl", ttl.ToString(CultureInfo.InvariantCulture));
 			}
 
 			if (!storeInHistory) {

--- a/src/Api/PubnubApi/EndPoint/PubSub/SubscribeManager.cs
+++ b/src/Api/PubnubApi/EndPoint/PubSub/SubscribeManager.cs
@@ -224,7 +224,6 @@ namespace PubnubApi.EndPoint
 							SubscribeHeartbeatCheckTimer.Change(Timeout.Infinite, Timeout.Infinite);
 						} catch {  /* ignore */ }
 					}
-					SubscribeHeartbeatCheckTimer = new Timer(StartSubscribeHeartbeatCheckCallback<T>, null, config[PubnubInstance.InstanceId].SubscribeTimeout * 500, config[PubnubInstance.InstanceId].SubscribeTimeout * 500);
 				}
 			} catch (Exception ex) {
 				LoggingMethod.WriteToLog(pubnubLog, $"subscribe initialisation opeartion encountered error {ex.Message}", config.ContainsKey(PubnubInstance.InstanceId) ? config[PubnubInstance.InstanceId].LogVerbosity : PNLogVerbosity.NONE);

--- a/src/Api/PubnubApi/Properties/AssemblyInfo.cs
+++ b/src/Api/PubnubApi/Properties/AssemblyInfo.cs
@@ -11,8 +11,8 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyProduct("Pubnub C# SDK")]
 [assembly: AssemblyCopyright("Copyright ©  2021")]
 [assembly: AssemblyTrademark("")]
-[assembly: AssemblyVersion("7.1.1.0")]
-[assembly: AssemblyFileVersion("7.1.1.0")]
+[assembly: AssemblyVersion("7.1.2.0")]
+[assembly: AssemblyFileVersion("7.1.2.0")]
 // Setting ComVisible to false makes the types in this assembly not visible
 // to COM components.  If you need to access a type in this assembly from
 // COM, set the ComVisible attribute to true on that type.

--- a/src/Api/PubnubApi/PubnubApi.csproj
+++ b/src/Api/PubnubApi/PubnubApi.csproj
@@ -14,7 +14,7 @@
 
   <PropertyGroup>
     <PackageId>Pubnub</PackageId>
-    <PackageVersion>7.1.1.0</PackageVersion>
+    <PackageVersion>7.1.2.0</PackageVersion>
     <Title>PubNub C# .NET - Web Data Push API</Title>
     <Authors>Pandu Masabathula</Authors>
     <Owners>PubNub</Owners>
@@ -22,7 +22,7 @@
     <PackageIconUrl>http://pubnub.s3.amazonaws.com/2011/powered-by-pubnub/pubnub-icon-600x600.png</PackageIconUrl>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
     <RepositoryUrl>https://github.com/pubnub/c-sharp/</RepositoryUrl>
-    <PackageReleaseNotes>Refactored event result data parsing logic within the subscribe feature for enhanced performance and maintainability.</PackageReleaseNotes>
+    <PackageReleaseNotes>Fixes issue of receiving duplicate messages when event engine is disabled.</PackageReleaseNotes>
     <PackageTags>Web Data Push Real-time Notifications ESB Message Broadcasting Distributed Computing</PackageTags>
     <!--<Summary>PubNub is a Massively Scalable Web Push Service for Web and Mobile Games.  This is a cloud-based service for broadcasting messages to thousands of web and mobile clients simultaneously</Summary>-->
     <Description>PubNub is a Massively Scalable Web Push Service for Web and Mobile Games.  This is a cloud-based service for broadcasting messages to thousands of web and mobile clients simultaneously</Description>

--- a/src/Api/PubnubApiPCL/PubnubApiPCL.csproj
+++ b/src/Api/PubnubApiPCL/PubnubApiPCL.csproj
@@ -15,7 +15,7 @@
 
   <PropertyGroup>
     <PackageId>PubnubPCL</PackageId>
-    <PackageVersion>7.1.1.0</PackageVersion>
+    <PackageVersion>7.1.2.0</PackageVersion>
     <Title>PubNub C# .NET - Web Data Push API</Title>
     <Authors>Pandu Masabathula</Authors>
     <Owners>PubNub</Owners>
@@ -23,7 +23,7 @@
     <PackageIconUrl>http://pubnub.s3.amazonaws.com/2011/powered-by-pubnub/pubnub-icon-600x600.png</PackageIconUrl>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
     <RepositoryUrl>https://github.com/pubnub/c-sharp/</RepositoryUrl>
-    <PackageReleaseNotes>Refactored event result data parsing logic within the subscribe feature for enhanced performance and maintainability.</PackageReleaseNotes>
+    <PackageReleaseNotes>Fixes issue of receiving duplicate messages when event engine is disabled.</PackageReleaseNotes>
     <PackageTags>Web Data Push Real-time Notifications ESB Message Broadcasting Distributed Computing</PackageTags>
     <!--<Summary>PubNub is a Massively Scalable Web Push Service for Web and Mobile Games.  This is a cloud-based service for broadcasting messages to thousands of web and mobile clients simultaneously</Summary>-->
     <Description>PubNub is a Massively Scalable Web Push Service for Web and Mobile Games.  This is a cloud-based service for broadcasting messages to thousands of web and mobile clients simultaneously</Description>

--- a/src/Api/PubnubApiUWP/PubnubApiUWP.csproj
+++ b/src/Api/PubnubApiUWP/PubnubApiUWP.csproj
@@ -16,7 +16,7 @@
 
   <PropertyGroup>
     <PackageId>PubnubUWP</PackageId>
-    <PackageVersion>7.1.1.0</PackageVersion>
+    <PackageVersion>7.1.2.0</PackageVersion>
     <Title>PubNub C# .NET - Web Data Push API</Title>
     <Authors>Pandu Masabathula</Authors>
     <Owners>PubNub</Owners>
@@ -24,7 +24,7 @@
     <PackageIconUrl>http://pubnub.s3.amazonaws.com/2011/powered-by-pubnub/pubnub-icon-600x600.png</PackageIconUrl>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
     <RepositoryUrl>https://github.com/pubnub/c-sharp/</RepositoryUrl>
-    <PackageReleaseNotes>Refactored event result data parsing logic within the subscribe feature for enhanced performance and maintainability.</PackageReleaseNotes>
+    <PackageReleaseNotes>Fixes issue of receiving duplicate messages when event engine is disabled.</PackageReleaseNotes>
     <PackageTags>Web Data Push Real-time Notifications ESB Message Broadcasting Distributed Computing</PackageTags>
     <!--<Summary>PubNub is a Massively Scalable Web Push Service for Web and Mobile Games.  This is a cloud-based service for broadcasting messages to thousands of web and mobile clients simultaneously</Summary>-->
     <Description>PubNub is a Massively Scalable Web Push Service for Web and Mobile Games.  This is a cloud-based service for broadcasting messages to thousands of web and mobile clients simultaneously</Description>

--- a/src/Api/PubnubApiUnity/PubnubApiUnity.csproj
+++ b/src/Api/PubnubApiUnity/PubnubApiUnity.csproj
@@ -15,7 +15,7 @@
 
   <PropertyGroup>
     <PackageId>PubnubApiUnity</PackageId>
-    <PackageVersion>7.1.1.0</PackageVersion>
+    <PackageVersion>7.1.2.0</PackageVersion>
     <Title>PubNub C# .NET - Web Data Push API</Title>
     <Authors>Pandu Masabathula</Authors>
     <Owners>PubNub</Owners>

--- a/src/UnitTests/PubnubApi.Tests/WhenSubscribedToAChannel3.cs
+++ b/src/UnitTests/PubnubApi.Tests/WhenSubscribedToAChannel3.cs
@@ -100,6 +100,12 @@ namespace PubNubMessaging.Tests
                         {
                             channel,authValues 
                         },
+                        {
+                            channelsGrant[1],authValues 
+                        },
+                        {
+                            channelsGrant[2],authValues 
+                        },
                     }
                 }).ExecuteAsync();
             await Task.Delay(4000);


### PR DESCRIPTION
fix: remove subscribe heartbeat timer registration when event engine is disabled.

Fixes issue of receiving duplicate messages when event engine is disabled.