### PR TITLE
fix: status callback on subscriptionChange

### DIFF
--- a/.pubnub.yml
+++ b/.pubnub.yml
@@ -887,7 +887,7 @@ sdks:
             requires:
               -
                 name: ".Net"
-                min-version: "3.5 or higher"
+                min-version: "6 or higher"
                 license: "MS-EULA"
                 license-url: "https://www.microsoft.com/web/webpi/eula/net_library_eula_enu.htm"
                 location: "Should be installed on computer"
@@ -1026,7 +1026,7 @@ sdks:
             requires:
               -
                 name: ".Net"
-                min-version: "3.5 or higher"
+                min-version: "6 or higher"
                 license: "MS-EULA"
                 license-url: "https://www.microsoft.com/web/webpi/eula/net_library_eula_enu.htm"
                 location: "Should be installed on computer"

--- a/.pubnub.yml
+++ b/.pubnub.yml
@@ -1,8 +1,15 @@
 name: c-sharp
-version: "7.1.3"
+version: "7.2.0"
 schema: 1
 scm: github.com/pubnub/c-sharp
 changelog:
+  - date: 2025-01-29
+    version: v7.2.0
+    changes:
+      - type: feature
+        text: "Added new optional parameter `IfMatchesEtag` for `setUUIDMetadata` and `setChannelMetadata`. When provided, the server compares the argument value with the eTag on the server and if they don't match a HTTP 412 error is returned."
+      - type: bug
+        text: "Fixes issue of not getting `PNSubscriptionChangedCategory` status when subscription change happens."
   - date: 2025-01-23
     version: v7.1.3
     changes:
@@ -828,7 +835,7 @@ features:
     - QUERY-PARAM
 supported-platforms:
   -
-    version: Pubnub 'C#' 7.1.3
+    version: Pubnub 'C#' 7.2.0
     platforms:
       - Windows 10 and up
       - Windows Server 2008 and up
@@ -839,7 +846,7 @@ supported-platforms:
       - .Net Framework 4.6.1+
       - .Net Framework 6.0
   -
-    version: PubnubPCL 'C#' 7.1.3
+    version: PubnubPCL 'C#' 7.2.0
     platforms:
       - Xamarin.Android
       - Xamarin.iOS
@@ -859,7 +866,7 @@ supported-platforms:
       - .Net Core
       - .Net 6.0
   -
-    version: PubnubUWP 'C#' 7.1.3
+    version: PubnubUWP 'C#' 7.2.0
     platforms:
       - Windows Phone 10
       - Universal Windows Apps
@@ -883,7 +890,7 @@ sdks:
             distribution-type: source
             distribution-repository: GitHub
             package-name: Pubnub
-            location: https://github.com/pubnub/c-sharp/releases/tag/v7.1.3.0
+            location: https://github.com/pubnub/c-sharp/releases/tag/v7.2.0.0
             requires:
               -
                 name: ".Net"
@@ -1166,7 +1173,7 @@ sdks:
             distribution-type: source
             distribution-repository: GitHub
             package-name: PubNubPCL
-            location: https://github.com/pubnub/c-sharp/releases/tag/v7.1.3.0
+            location: https://github.com/pubnub/c-sharp/releases/tag/v7.2.0.0
             requires:
               -
                 name: ".Net Core"
@@ -1525,7 +1532,7 @@ sdks:
             distribution-type: source
             distribution-repository: GitHub
             package-name: PubnubUWP
-            location: https://github.com/pubnub/c-sharp/releases/tag/v7.1.3.0
+            location: https://github.com/pubnub/c-sharp/releases/tag/v7.2.0.0
             requires:
               -
                 name: "Universal Windows Platform Development"

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,9 @@
+v7.2.0 - January 29 2025
+-----------------------------
+- Added: added new optional parameter `IfMatchesEtag` for `setUUIDMetadata` and `setChannelMetadata`. When provided, the server compares the argument value with the eTag on the server and if they don't match a HTTP 412 error is returned.
+
+- Fixed: fixes issue of not getting `PNSubscriptionChangedCategory` status when subscription change happens.
+
 v7.1.3 - January 23 2025
 -----------------------------
 - Modified: informative log statements throughout SDK.

--- a/src/Api/PubnubApi/EndPoint/Objects/SetChannelMetadataOperation.cs
+++ b/src/Api/PubnubApi/EndPoint/Objects/SetChannelMetadataOperation.cs
@@ -18,6 +18,7 @@ namespace PubnubApi.EndPoint
 		private Dictionary<string, object> custom;
 		private bool includeCustom;
 
+		private string ifMatchesEtag = null;
 		private PNCallback<PNSetChannelMetadataResult> savedCallback;
 		private Dictionary<string, object> queryParam;
 
@@ -66,6 +67,11 @@ namespace PubnubApi.EndPoint
 			return this;
 		}
 
+		public SetChannelMetadataOperation IfMatchesEtag(string etag)
+		{
+			this.ifMatchesEtag = etag;
+			return this;
+		}
 		public void Execute(PNCallback<PNSetChannelMetadataResult> callback)
 		{
 			if (string.IsNullOrEmpty(channelId) || string.IsNullOrEmpty(channelId.Trim())) {
@@ -226,7 +232,10 @@ namespace PubnubApi.EndPoint
 				Query = requestQueryStringParams,
 				BodyContentString = patchMessage
 			};
-
+			if (!string.IsNullOrEmpty(ifMatchesEtag))
+			{
+				requestParameter.Headers.Add("If-Match", ifMatchesEtag);
+			}
 			return requestParameter;
 		}
 	}

--- a/src/Api/PubnubApi/EndPoint/Objects/SetUuidMetadataOperation.cs
+++ b/src/Api/PubnubApi/EndPoint/Objects/SetUuidMetadataOperation.cs
@@ -22,7 +22,7 @@ namespace PubnubApi.EndPoint
 		private string uuidProfileUrl;
 		private Dictionary<string, object> uuidCustom;
 		private bool includeCustom;
-
+		private string ifMatchesEtag = null;
 
 		private PNCallback<PNSetUuidMetadataResult> savedCallback;
 		private Dictionary<string, object> queryParam;
@@ -94,6 +94,11 @@ namespace PubnubApi.EndPoint
 		public SetUuidMetadataOperation QueryParam(Dictionary<string, object> customQueryParam)
 		{
 			this.queryParam = customQueryParam;
+			return this;
+		}
+		public SetUuidMetadataOperation IfMatchesEtag(string etag)
+		{
+			this.ifMatchesEtag = etag;
 			return this;
 		}
 
@@ -248,6 +253,10 @@ namespace PubnubApi.EndPoint
 				Query = requestQueryStringParams,
 				BodyContentString = patchMessage
 			};
+			if (!string.IsNullOrEmpty(ifMatchesEtag))
+			{
+				requestParameter.Headers.Add("If-Match", ifMatchesEtag);
+			}
 			return requestParameter;
 		}
 	}

--- a/src/Api/PubnubApi/Enum/PNStatusCategory.cs
+++ b/src/Api/PubnubApi/Enum/PNStatusCategory.cs
@@ -13,6 +13,7 @@ namespace PubnubApi
         PNTimeoutCategory,
         PNNetworkIssuesCategory,
         PNConnectedCategory,
+        PNSubscriptionChangedCategory,
         PNReconnectedCategory,
         PNDisconnectedCategory,
         PNUnexpectedDisconnectCategory,

--- a/src/Api/PubnubApi/EventEngine/Subscribe/States/HandshakeFailedState.cs
+++ b/src/Api/PubnubApi/EventEngine/Subscribe/States/HandshakeFailedState.cs
@@ -17,7 +17,8 @@ namespace PubnubApi.EventEngine.Subscribe.States
                 {
                     Channels = subscriptionChanged.Channels?? Enumerable.Empty<string>(),
                     ChannelGroups = subscriptionChanged.ChannelGroups??Enumerable.Empty<string>(),
-                },
+                }.With(
+                    new EmitStatusInvocation(new PNStatus(null,PNOperationType.PNSubscribeOperation, PNStatusCategory.PNSubscriptionChangedCategory, this.Channels, this.ChannelGroups, Constants.HttpRequestSuccessStatusCode))),
 
                 Events.ReconnectEvent reconnect => new HandshakingState()
                 {

--- a/src/Api/PubnubApi/EventEngine/Subscribe/States/HandshakeReconnectingState.cs
+++ b/src/Api/PubnubApi/EventEngine/Subscribe/States/HandshakeReconnectingState.cs
@@ -28,7 +28,8 @@ namespace PubnubApi.EventEngine.Subscribe.States
 				Events.SubscriptionChangedEvent subscriptionChanged => new HandshakingState() {
                     Channels = subscriptionChanged.Channels?? Enumerable.Empty<string>(),
                     ChannelGroups = subscriptionChanged.ChannelGroups??Enumerable.Empty<string>(),
-				},
+				}.With(
+					new EmitStatusInvocation(new PNStatus(null,PNOperationType.PNSubscribeOperation, PNStatusCategory.PNSubscriptionChangedCategory, this.Channels, this.ChannelGroups, Constants.HttpRequestSuccessStatusCode))),
 
 				Events.DisconnectEvent disconnect => new HandshakeStoppedState() {
 					Channels = disconnect.Channels,

--- a/src/Api/PubnubApi/EventEngine/Subscribe/States/HandshakeStoppedState.cs
+++ b/src/Api/PubnubApi/EventEngine/Subscribe/States/HandshakeStoppedState.cs
@@ -17,7 +17,8 @@ namespace PubnubApi.EventEngine.Subscribe.States
                 {
                     Channels = subscriptionChanged.Channels?? Enumerable.Empty<string>(),
                     ChannelGroups = subscriptionChanged.ChannelGroups??Enumerable.Empty<string>(),
-                },
+                }.With(
+                    new EmitStatusInvocation(new PNStatus(null,PNOperationType.PNSubscribeOperation, PNStatusCategory.PNSubscriptionChangedCategory, this.Channels, this.ChannelGroups, Constants.HttpRequestSuccessStatusCode))),
 
                 Events.ReconnectEvent reconnect => new HandshakingState()
                 {

--- a/src/Api/PubnubApi/EventEngine/Subscribe/States/HandshakingState.cs
+++ b/src/Api/PubnubApi/EventEngine/Subscribe/States/HandshakingState.cs
@@ -23,7 +23,8 @@ namespace PubnubApi.EventEngine.Subscribe.States
                 {
                     Channels = subscriptionChanged.Channels?? Enumerable.Empty<string>(),
                     ChannelGroups = subscriptionChanged.ChannelGroups??Enumerable.Empty<string>(),
-                },
+                }.With(
+                    new EmitStatusInvocation(new PNStatus(null,PNOperationType.PNSubscribeOperation, PNStatusCategory.PNSubscriptionChangedCategory, this.Channels, this.ChannelGroups, Constants.HttpRequestSuccessStatusCode))),
 
                 Events.SubscriptionRestoredEvent subscriptionRestored => new States.HandshakingState()
                 {
@@ -53,7 +54,7 @@ namespace PubnubApi.EventEngine.Subscribe.States
                     Channels = this.Channels,
                     ChannelGroups = this.ChannelGroups,
                     Cursor = success.Cursor,
-				}.With(new EmitStatusInvocation(success.Status)),
+				}.With(new EmitStatusInvocation(new PNStatus(null, PNOperationType.PNSubscribeOperation, PNStatusCategory.PNConnectedCategory, this.Channels, this.ChannelGroups, Constants.HttpRequestSuccessStatusCode))),
 
                 _ => null
             };

--- a/src/Api/PubnubApi/EventEngine/Subscribe/States/ReceiveFailedState.cs
+++ b/src/Api/PubnubApi/EventEngine/Subscribe/States/ReceiveFailedState.cs
@@ -23,7 +23,8 @@ namespace PubnubApi.EventEngine.Subscribe.States
                     ChannelGroups = (ChannelGroups ?? Enumerable.Empty<string>()).Union(subscriptionChanged.ChannelGroups),
                     Cursor = this.Cursor,
 					
-				},
+				}.With(
+                    new EmitStatusInvocation(new PNStatus(null,PNOperationType.PNSubscribeOperation, PNStatusCategory.PNSubscriptionChangedCategory, this.Channels, this.ChannelGroups, Constants.HttpRequestSuccessStatusCode))),
 
                 Events.ReconnectEvent reconnect => new HandshakingState()
                 {

--- a/src/Api/PubnubApi/EventEngine/Subscribe/States/ReceiveReconnectingState.cs
+++ b/src/Api/PubnubApi/EventEngine/Subscribe/States/ReceiveReconnectingState.cs
@@ -34,7 +34,8 @@ namespace PubnubApi.EventEngine.Subscribe.States
                     Channels = subscriptionChanged.Channels?? Enumerable.Empty<string>(),
                     ChannelGroups = subscriptionChanged.ChannelGroups??Enumerable.Empty<string>(),
                     Cursor = this.Cursor,
-                },
+                }.With(
+                    new EmitStatusInvocation(new PNStatus(null,PNOperationType.PNSubscribeOperation, PNStatusCategory.PNSubscriptionChangedCategory, this.Channels, this.ChannelGroups, Constants.HttpRequestSuccessStatusCode))),
 
                 Events.DisconnectEvent disconnect => new ReceiveStoppedState()
                 {

--- a/src/Api/PubnubApi/EventEngine/Subscribe/States/ReceiveStoppedState.cs
+++ b/src/Api/PubnubApi/EventEngine/Subscribe/States/ReceiveStoppedState.cs
@@ -18,7 +18,8 @@ namespace PubnubApi.EventEngine.Subscribe.States
                     Channels = subscriptionChanged.Channels?? Enumerable.Empty<string>(),
                     ChannelGroups = subscriptionChanged.ChannelGroups??Enumerable.Empty<string>(),
                     Cursor = this.Cursor,
-                },
+                }.With(
+                    new EmitStatusInvocation(new PNStatus(null,PNOperationType.PNSubscribeOperation, PNStatusCategory.PNSubscriptionChangedCategory, this.Channels, this.ChannelGroups, Constants.HttpRequestSuccessStatusCode))),
                 
                 Events.ReconnectEvent reconnect => new HandshakingState()
                 {

--- a/src/Api/PubnubApi/EventEngine/Subscribe/States/ReceivingState.cs
+++ b/src/Api/PubnubApi/EventEngine/Subscribe/States/ReceivingState.cs
@@ -34,7 +34,8 @@ namespace PubnubApi.EventEngine.Subscribe.States
                     Channels = subscriptionChanged.Channels?? Enumerable.Empty<string>(),
                     ChannelGroups = subscriptionChanged.ChannelGroups??Enumerable.Empty<string>(),
                     Cursor = Cursor,
-                },
+                }.With(
+                    new EmitStatusInvocation(new PNStatus(null,PNOperationType.PNSubscribeOperation, PNStatusCategory.PNSubscriptionChangedCategory, this.Channels, this.ChannelGroups, Constants.HttpRequestSuccessStatusCode))),
 
                 Events.SubscriptionRestoredEvent subscriptionRestored => new ReceivingState()
                 {

--- a/src/Api/PubnubApi/Properties/AssemblyInfo.cs
+++ b/src/Api/PubnubApi/Properties/AssemblyInfo.cs
@@ -11,8 +11,8 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyProduct("Pubnub C# SDK")]
 [assembly: AssemblyCopyright("Copyright ©  2021")]
 [assembly: AssemblyTrademark("")]
-[assembly: AssemblyVersion("7.1.3.0")]
-[assembly: AssemblyFileVersion("7.1.3.0")]
+[assembly: AssemblyVersion("7.2.0.0")]
+[assembly: AssemblyFileVersion("7.2.0.0")]
 // Setting ComVisible to false makes the types in this assembly not visible
 // to COM components.  If you need to access a type in this assembly from
 // COM, set the ComVisible attribute to true on that type.

--- a/src/Api/PubnubApi/PubnubApi.csproj
+++ b/src/Api/PubnubApi/PubnubApi.csproj
@@ -14,7 +14,7 @@
 
   <PropertyGroup>
     <PackageId>Pubnub</PackageId>
-    <PackageVersion>7.1.3.0</PackageVersion>
+    <PackageVersion>7.2.0.0</PackageVersion>
     <Title>PubNub C# .NET - Web Data Push API</Title>
     <Authors>Pandu Masabathula</Authors>
     <Owners>PubNub</Owners>
@@ -22,7 +22,8 @@
     <PackageIconUrl>http://pubnub.s3.amazonaws.com/2011/powered-by-pubnub/pubnub-icon-600x600.png</PackageIconUrl>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
     <RepositoryUrl>https://github.com/pubnub/c-sharp/</RepositoryUrl>
-    <PackageReleaseNotes>Informative log statements throughout SDK.</PackageReleaseNotes>
+    <PackageReleaseNotes>Added new optional parameter `IfMatchesEtag` for `setUUIDMetadata` and `setChannelMetadata`. When provided, the server compares the argument value with the eTag on the server and if they don't match a HTTP 412 error is returned.
+Fixes issue of not getting `PNSubscriptionChangedCategory` status when subscription change happens.</PackageReleaseNotes>
     <PackageTags>Web Data Push Real-time Notifications ESB Message Broadcasting Distributed Computing</PackageTags>
     <!--<Summary>PubNub is a Massively Scalable Web Push Service for Web and Mobile Games.  This is a cloud-based service for broadcasting messages to thousands of web and mobile clients simultaneously</Summary>-->
     <Description>PubNub is a Massively Scalable Web Push Service for Web and Mobile Games.  This is a cloud-based service for broadcasting messages to thousands of web and mobile clients simultaneously</Description>

--- a/src/Api/PubnubApi/Transport/HttpClientService.cs
+++ b/src/Api/PubnubApi/Transport/HttpClientService.cs
@@ -205,7 +205,7 @@ namespace PubnubApi
 				{
 					foreach (var kvp in transportRequest.Headers)
 					{
-						requestMessage.Headers.Add(kvp.Key, kvp.Value);
+						requestMessage.Headers.Add(kvp.Key, $"\"{kvp.Value}\"");
 					}
 				}
 

--- a/src/Api/PubnubApi/Transport/Middleware.cs
+++ b/src/Api/PubnubApi/Transport/Middleware.cs
@@ -99,8 +99,9 @@ namespace PubnubApi
 				RequestUrl = urlString,
 				BodyContentString = requestParameter.BodyContentString,
 				FormData = requestParameter.FormData,
-				CancellationToken = cts.Token
+				CancellationToken = cts.Token,
 			};
+			if(requestParameter.Headers.Count>0) transportRequest.Headers = requestParameter.Headers;
 			return transportRequest;
 		}
 

--- a/src/Api/PubnubApi/Transport/RequestParameter.cs
+++ b/src/Api/PubnubApi/Transport/RequestParameter.cs
@@ -9,5 +9,7 @@ namespace PubnubApi
 		public Dictionary<string, string> Query { get; set; } = new Dictionary<string, string>();
 		public string BodyContentString { get; set; }
 		public byte[] FormData { get; set; }
+
+		public Dictionary<string, string> Headers { get; set; } = new Dictionary<string, string>();
 	}
 }

--- a/src/Api/PubnubApiPCL/PubnubApiPCL.csproj
+++ b/src/Api/PubnubApiPCL/PubnubApiPCL.csproj
@@ -15,7 +15,7 @@
 
   <PropertyGroup>
     <PackageId>PubnubPCL</PackageId>
-    <PackageVersion>7.1.3.0</PackageVersion>
+    <PackageVersion>7.2.0.0</PackageVersion>
     <Title>PubNub C# .NET - Web Data Push API</Title>
     <Authors>Pandu Masabathula</Authors>
     <Owners>PubNub</Owners>
@@ -23,7 +23,8 @@
     <PackageIconUrl>http://pubnub.s3.amazonaws.com/2011/powered-by-pubnub/pubnub-icon-600x600.png</PackageIconUrl>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
     <RepositoryUrl>https://github.com/pubnub/c-sharp/</RepositoryUrl>
-    <PackageReleaseNotes>Informative log statements throughout SDK.</PackageReleaseNotes>
+    <PackageReleaseNotes>Added new optional parameter `IfMatchesEtag` for `setUUIDMetadata` and `setChannelMetadata`. When provided, the server compares the argument value with the eTag on the server and if they don't match a HTTP 412 error is returned.
+Fixes issue of not getting `PNSubscriptionChangedCategory` status when subscription change happens.</PackageReleaseNotes>
     <PackageTags>Web Data Push Real-time Notifications ESB Message Broadcasting Distributed Computing</PackageTags>
     <!--<Summary>PubNub is a Massively Scalable Web Push Service for Web and Mobile Games.  This is a cloud-based service for broadcasting messages to thousands of web and mobile clients simultaneously</Summary>-->
     <Description>PubNub is a Massively Scalable Web Push Service for Web and Mobile Games.  This is a cloud-based service for broadcasting messages to thousands of web and mobile clients simultaneously</Description>

--- a/src/Api/PubnubApiUWP/PubnubApiUWP.csproj
+++ b/src/Api/PubnubApiUWP/PubnubApiUWP.csproj
@@ -16,7 +16,7 @@
 
   <PropertyGroup>
     <PackageId>PubnubUWP</PackageId>
-    <PackageVersion>7.1.3.0</PackageVersion>
+    <PackageVersion>7.2.0.0</PackageVersion>
     <Title>PubNub C# .NET - Web Data Push API</Title>
     <Authors>Pandu Masabathula</Authors>
     <Owners>PubNub</Owners>
@@ -24,7 +24,8 @@
     <PackageIconUrl>http://pubnub.s3.amazonaws.com/2011/powered-by-pubnub/pubnub-icon-600x600.png</PackageIconUrl>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
     <RepositoryUrl>https://github.com/pubnub/c-sharp/</RepositoryUrl>
-    <PackageReleaseNotes>Informative log statements throughout SDK.</PackageReleaseNotes>
+    <PackageReleaseNotes>Added new optional parameter `IfMatchesEtag` for `setUUIDMetadata` and `setChannelMetadata`. When provided, the server compares the argument value with the eTag on the server and if they don't match a HTTP 412 error is returned.
+Fixes issue of not getting `PNSubscriptionChangedCategory` status when subscription change happens.</PackageReleaseNotes>
     <PackageTags>Web Data Push Real-time Notifications ESB Message Broadcasting Distributed Computing</PackageTags>
     <!--<Summary>PubNub is a Massively Scalable Web Push Service for Web and Mobile Games.  This is a cloud-based service for broadcasting messages to thousands of web and mobile clients simultaneously</Summary>-->
     <Description>PubNub is a Massively Scalable Web Push Service for Web and Mobile Games.  This is a cloud-based service for broadcasting messages to thousands of web and mobile clients simultaneously</Description>

--- a/src/Api/PubnubApiUnity/PubnubApiUnity.csproj
+++ b/src/Api/PubnubApiUnity/PubnubApiUnity.csproj
@@ -15,7 +15,7 @@
 
   <PropertyGroup>
     <PackageId>PubnubApiUnity</PackageId>
-    <PackageVersion>7.1.3.0</PackageVersion>
+    <PackageVersion>7.2.0.0</PackageVersion>
     <Title>PubNub C# .NET - Web Data Push API</Title>
     <Authors>Pandu Masabathula</Authors>
     <Owners>PubNub</Owners>

--- a/src/UnitTests/PubnubApi.Tests/WhenSubscribedToAChannel3.cs
+++ b/src/UnitTests/PubnubApi.Tests/WhenSubscribedToAChannel3.cs
@@ -152,14 +152,13 @@ namespace PubNubMessaging.Tests
                 delegate (Pubnub pnObj, PNStatus status)
                 {
                     Debug.WriteLine("Received STATUS callback");
-                    if (status.AffectedChannels != null && status.Category == PNStatusCategory.PNConnectedCategory)
+                    if (status.AffectedChannels != null && (status.Category == PNStatusCategory.PNConnectedCategory || status.Category == PNStatusCategory.PNSubscriptionChangedCategory))
                     {
-                        if (status.AffectedChannels.Contains(channel))
+                        if (status.Category == PNStatusCategory.PNConnectedCategory && status.AffectedChannels.Contains(channel))
                         {
                             firstChannel.Set();
-                            return;
                         }
-                        if (status.AffectedChannels.Contains(channel2))
+                        if (status.Category == PNStatusCategory.PNSubscriptionChangedCategory && status.AffectedChannels.Contains(channel2))
                         {
                             secondChannel.Set();
                         }
@@ -170,6 +169,7 @@ namespace PubNubMessaging.Tests
             pubnub.AddListener(eventListener);
             pubnub.Subscribe<string>().Channels(new []{channel}).Execute();
             var firstCallbackSuccess = firstChannel.WaitOne(5000);
+            await Task.Delay(2000);
             pubnub.Subscribe<string>().Channels(new []{channel2}).Execute();
             var secondCallbackSuccess = secondChannel.WaitOne(5000);
             Assert.True(firstCallbackSuccess && secondCallbackSuccess);

--- a/src/UnitTests/PubnubApi.Tests/WhenSubscribedToAChannel3.cs
+++ b/src/UnitTests/PubnubApi.Tests/WhenSubscribedToAChannel3.cs
@@ -25,6 +25,7 @@ namespace PubNubMessaging.Tests
 
         private static int manualResetEventWaitTimeout = 310 * 1000;
         private static string channel = "hello_my_channel";
+        private static string channel2 = "hello_my_channel_2";
         private static string[] channelsGrant = { "hello_my_channel", "hello_my_channel1", "hello_my_channel2" };
         private static string authKey = "myauth";
         private static string currentTestCase = "";
@@ -101,11 +102,8 @@ namespace PubNubMessaging.Tests
                             channel,authValues 
                         },
                         {
-                            channelsGrant[1],authValues 
-                        },
-                        {
-                            channelsGrant[2],authValues 
-                        },
+                            channel2,authValues
+                        }
                     }
                 }).ExecuteAsync();
             await Task.Delay(4000);
@@ -129,6 +127,52 @@ namespace PubNubMessaging.Tests
                 pubnub = null;
             }
             server.Stop();
+        }
+
+        [Test]
+        public static async Task ThenStatusCallbackShouldKeepFiring()
+        {
+            PNConfiguration config = new PNConfiguration(new UserId("mytestuuid"))
+            {
+                PublishKey = PubnubCommon.PublishKey,
+                SubscribeKey = PubnubCommon.SubscribeKey,
+                LogVerbosity = PNLogVerbosity.BODY
+            };
+            if (!string.IsNullOrEmpty(authKey) && !PubnubCommon.SuppressAuthKey)
+            {
+                config.AuthKey = authKey;
+            }
+
+            var firstChannel = new ManualResetEvent(false);
+            var secondChannel = new ManualResetEvent(false);
+            SubscribeCallbackExt eventListener = new SubscribeCallbackExt(
+                delegate (Pubnub pnObj, PNObjectEventResult eventResult)
+                {
+                },
+                delegate (Pubnub pnObj, PNStatus status)
+                {
+                    Debug.WriteLine("Received STATUS callback");
+                    if (status.AffectedChannels != null && status.Category == PNStatusCategory.PNConnectedCategory)
+                    {
+                        if (status.AffectedChannels.Contains(channel))
+                        {
+                            firstChannel.Set();
+                            return;
+                        }
+                        if (status.AffectedChannels.Contains(channel2))
+                        {
+                            secondChannel.Set();
+                        }
+                    }
+                }
+            );
+            pubnub = createPubNubInstance(config, authToken);
+            pubnub.AddListener(eventListener);
+            pubnub.Subscribe<string>().Channels(new []{channel}).Execute();
+            var firstCallbackSuccess = firstChannel.WaitOne(5000);
+            pubnub.Subscribe<string>().Channels(new []{channel2}).Execute();
+            var secondCallbackSuccess = secondChannel.WaitOne(5000);
+            Assert.True(firstCallbackSuccess && secondCallbackSuccess);
         }
 
         [Test]


### PR DESCRIPTION
feat: Support for `eTag` in setUUIDMetadata and setChannelMetadata.

Added new optional parameter `IfMatchesEtag` for `setUUIDMetadata` and `setChannelMetadata`. When provided, the server compares the argument value with the eTag on the server and if they don't match a HTTP 412 error is returned.

fix: status callback for subscription changes.

Fixes issue of not getting `PNSubscriptionChangedCategory` status when subscription change happens.