### PR TITLE
Change injection method of logger into IHttpClientService

### DIFF
--- a/.pubnub.yml
+++ b/.pubnub.yml
@@ -1,8 +1,13 @@
 name: c-sharp
-version: "7.3.8"
+version: "7.3.9"
 schema: 1
 scm: github.com/pubnub/c-sharp
 changelog:
+  - date: 2025-05-09
+    version: v7.3.9
+    changes:
+      - type: improvement
+        text: "Changed the way the PubNub logger is injected into IHtttpClientService for better custom-transport-layers handling."
   - date: 2025-04-08
     version: v7.3.8
     changes:
@@ -887,7 +892,7 @@ features:
     - QUERY-PARAM
 supported-platforms:
   -
-    version: Pubnub 'C#' 7.3.8
+    version: Pubnub 'C#' 7.3.9
     platforms:
       - Windows 10 and up
       - Windows Server 2008 and up
@@ -898,7 +903,7 @@ supported-platforms:
       - .Net Framework 4.6.1+
       - .Net Framework 6.0
   -
-    version: PubnubPCL 'C#' 7.3.8
+    version: PubnubPCL 'C#' 7.3.9
     platforms:
       - Xamarin.Android
       - Xamarin.iOS
@@ -918,7 +923,7 @@ supported-platforms:
       - .Net Core
       - .Net 6.0
   -
-    version: PubnubUWP 'C#' 7.3.8
+    version: PubnubUWP 'C#' 7.3.9
     platforms:
       - Windows Phone 10
       - Universal Windows Apps
@@ -942,7 +947,7 @@ sdks:
             distribution-type: source
             distribution-repository: GitHub
             package-name: Pubnub
-            location: https://github.com/pubnub/c-sharp/releases/tag/v7.3.8.0
+            location: https://github.com/pubnub/c-sharp/releases/tag/v7.3.9.0
             requires:
               -
                 name: ".Net"
@@ -1225,7 +1230,7 @@ sdks:
             distribution-type: source
             distribution-repository: GitHub
             package-name: PubNubPCL
-            location: https://github.com/pubnub/c-sharp/releases/tag/v7.3.8.0
+            location: https://github.com/pubnub/c-sharp/releases/tag/v7.3.9.0
             requires:
               -
                 name: ".Net Core"
@@ -1584,7 +1589,7 @@ sdks:
             distribution-type: source
             distribution-repository: GitHub
             package-name: PubnubUWP
-            location: https://github.com/pubnub/c-sharp/releases/tag/v7.3.8.0
+            location: https://github.com/pubnub/c-sharp/releases/tag/v7.3.9.0
             requires:
               -
                 name: "Universal Windows Platform Development"

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+v7.3.9 - May 09 2025
+-----------------------------
+- Modified: changed the way the PubNub logger is injected into IHtttpClientService for better custom-transport-layers handling.
+
 v7.3.8 - April 08 2025
 -----------------------------
 - Modified: subscribe with custom timetoken scenario handling improvements.

--- a/src/Api/PubnubApi/EndPoint/PubSub/SubscribeManager2.cs
+++ b/src/Api/PubnubApi/EndPoint/PubSub/SubscribeManager2.cs
@@ -120,7 +120,7 @@ namespace PubnubApi.EndPoint
 			} catch (Exception ex)
 			{
 				logger?.Error(
-					$" Receiving effect exception for \n channel(s)={string.Join(",", channels.OrderBy(x => x).ToArray())} \n cg(s)={string.Join(",", channelGroups.OrderBy(x => x).ToArray())} \n Exception Details={ex}");
+					$" Receiving effect exception for \n channel(s)={string.Join(",", channels.OrderBy(x => x).ToArray())} \n cg(s)={string.Join(",", channelGroups.OrderBy(x => x).ToArray())} \n Exception Details={ex} \n Stack trace={ex.StackTrace}");
 			}
 			return resp;
 		}

--- a/src/Api/PubnubApi/PNConfiguration.cs
+++ b/src/Api/PubnubApi/PNConfiguration.cs
@@ -93,7 +93,7 @@ namespace PubnubApi
             }
         }
 
-        public PubnubLogModule Logger { get; set; }
+        public PubnubLogModule Logger { get; internal set; }
 
         public string AuthKey
         {

--- a/src/Api/PubnubApi/Properties/AssemblyInfo.cs
+++ b/src/Api/PubnubApi/Properties/AssemblyInfo.cs
@@ -11,8 +11,8 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyProduct("Pubnub C# SDK")]
 [assembly: AssemblyCopyright("Copyright ©  2021")]
 [assembly: AssemblyTrademark("")]
-[assembly: AssemblyVersion("7.3.8.0")]
-[assembly: AssemblyFileVersion("7.3.8.0")]
+[assembly: AssemblyVersion("7.3.9.0")]
+[assembly: AssemblyFileVersion("7.3.9.0")]
 // Setting ComVisible to false makes the types in this assembly not visible
 // to COM components.  If you need to access a type in this assembly from
 // COM, set the ComVisible attribute to true on that type.

--- a/src/Api/PubnubApi/Pubnub.cs
+++ b/src/Api/PubnubApi/Pubnub.cs
@@ -1227,7 +1227,8 @@ namespace PubnubApi
             //Defaulting to DotNet PNSDK source if no custom one is specified
             Version = (ipnsdkSource == default) ? new DotNetPNSDKSource().GetPNSDK() : ipnsdkSource.GetPNSDK();
             IHttpClientService httpClientService =
-                httpTransportService ?? new HttpClientService(proxy: config.Proxy, configuration: config);
+                httpTransportService ?? new HttpClientService(proxy: config.Proxy);
+            httpClientService.SetLogger(logger);
             transportMiddleware = middleware ?? new Middleware(httpClientService, config, this, tokenManager);
             logger?.Debug(GetConfigurationLogString(config));
         }

--- a/src/Api/PubnubApi/PubnubApi.csproj
+++ b/src/Api/PubnubApi/PubnubApi.csproj
@@ -14,7 +14,7 @@
 
   <PropertyGroup>
     <PackageId>Pubnub</PackageId>
-    <PackageVersion>7.3.8.0</PackageVersion>
+    <PackageVersion>7.3.9.0</PackageVersion>
     <Title>PubNub C# .NET - Web Data Push API</Title>
     <Authors>Pandu Masabathula</Authors>
     <Owners>PubNub</Owners>
@@ -22,7 +22,7 @@
     <PackageIconUrl>http://pubnub.s3.amazonaws.com/2011/powered-by-pubnub/pubnub-icon-600x600.png</PackageIconUrl>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
     <RepositoryUrl>https://github.com/pubnub/c-sharp/</RepositoryUrl>
-    <PackageReleaseNotes>Subscribe with custom timetoken scenario handling improvements.</PackageReleaseNotes>
+    <PackageReleaseNotes>Changed the way the PubNub logger is injected into IHtttpClientService for better custom-transport-layers handling.</PackageReleaseNotes>
     <PackageTags>Web Data Push Real-time Notifications ESB Message Broadcasting Distributed Computing</PackageTags>
     <!--<Summary>PubNub is a Massively Scalable Web Push Service for Web and Mobile Games.  This is a cloud-based service for broadcasting messages to thousands of web and mobile clients simultaneously</Summary>-->
     <Description>PubNub is a Massively Scalable Web Push Service for Web and Mobile Games.  This is a cloud-based service for broadcasting messages to thousands of web and mobile clients simultaneously</Description>

--- a/src/Api/PubnubApi/Transport/HttpClientService.cs
+++ b/src/Api/PubnubApi/Transport/HttpClientService.cs
@@ -15,17 +15,17 @@ namespace PubnubApi
 
         public HttpClientService(IWebProxy proxy)
         {
-            var handler = new HttpClientHandler
-            {
-                MaxConnectionsPerServer = 50,
-                UseProxy = proxy != null,
-                Proxy = proxy
-            };
-
-            httpClient = new HttpClient(handler)
+            httpClient = new HttpClient()
             {
                 Timeout = Timeout.InfiniteTimeSpan
             };
+            if (proxy == null) return;
+            httpClient = new HttpClient(new HttpClientHandler()
+            {
+                Proxy = proxy,
+                UseProxy = true
+            });
+            httpClient.Timeout = Timeout.InfiniteTimeSpan;
         }
 
         public void SetLogger(PubnubLogModule logger)

--- a/src/Api/PubnubApi/Transport/HttpClientService.cs
+++ b/src/Api/PubnubApi/Transport/HttpClientService.cs
@@ -11,12 +11,10 @@ namespace PubnubApi
     public class HttpClientService : IHttpClientService
     {
         private readonly HttpClient httpClient;
-        private readonly PubnubLogModule logger;
+        private PubnubLogModule logger;
 
-        public HttpClientService(IWebProxy proxy, PNConfiguration configuration)
+        public HttpClientService(IWebProxy proxy)
         {
-            logger = configuration.Logger;
-
             var handler = new HttpClientHandler
             {
                 MaxConnectionsPerServer = 50,
@@ -28,6 +26,11 @@ namespace PubnubApi
             {
                 Timeout = Timeout.InfiniteTimeSpan
             };
+        }
+
+        public void SetLogger(PubnubLogModule logger)
+        {
+            this.logger = logger;
         }
 
         public async Task<TransportResponse> GetRequest(TransportRequest transportRequest)

--- a/src/Api/PubnubApi/TransportContract/IHttpClientService.cs
+++ b/src/Api/PubnubApi/TransportContract/IHttpClientService.cs
@@ -9,5 +9,6 @@ namespace PubnubApi
 		Task<TransportResponse> PostRequest(TransportRequest transportRequest);
 		Task<TransportResponse> PatchRequest(TransportRequest transportRequest);
 		Task<TransportResponse> PutRequest(TransportRequest transportRequest);
+		void SetLogger(PubnubLogModule logger);
 	}
 }

--- a/src/Api/PubnubApiPCL/PubnubApiPCL.csproj
+++ b/src/Api/PubnubApiPCL/PubnubApiPCL.csproj
@@ -14,7 +14,7 @@
 
   <PropertyGroup>
     <PackageId>PubnubPCL</PackageId>
-    <PackageVersion>7.3.8.0</PackageVersion>
+    <PackageVersion>7.3.9.0</PackageVersion>
     <Title>PubNub C# .NET - Web Data Push API</Title>
     <Authors>Pandu Masabathula</Authors>
     <Owners>PubNub</Owners>
@@ -22,7 +22,7 @@
     <PackageIconUrl>http://pubnub.s3.amazonaws.com/2011/powered-by-pubnub/pubnub-icon-600x600.png</PackageIconUrl>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
     <RepositoryUrl>https://github.com/pubnub/c-sharp/</RepositoryUrl>
-    <PackageReleaseNotes>Subscribe with custom timetoken scenario handling improvements.</PackageReleaseNotes>
+    <PackageReleaseNotes>Changed the way the PubNub logger is injected into IHtttpClientService for better custom-transport-layers handling.</PackageReleaseNotes>
     <PackageTags>Web Data Push Real-time Notifications ESB Message Broadcasting Distributed Computing</PackageTags>
     <!--<Summary>PubNub is a Massively Scalable Web Push Service for Web and Mobile Games.  This is a cloud-based service for broadcasting messages to thousands of web and mobile clients simultaneously</Summary>-->
     <Description>PubNub is a Massively Scalable Web Push Service for Web and Mobile Games.  This is a cloud-based service for broadcasting messages to thousands of web and mobile clients simultaneously</Description>

--- a/src/Api/PubnubApiUWP/PubnubApiUWP.csproj
+++ b/src/Api/PubnubApiUWP/PubnubApiUWP.csproj
@@ -16,7 +16,7 @@
 
   <PropertyGroup>
     <PackageId>PubnubUWP</PackageId>
-    <PackageVersion>7.3.8.0</PackageVersion>
+    <PackageVersion>7.3.9.0</PackageVersion>
     <Title>PubNub C# .NET - Web Data Push API</Title>
     <Authors>Pandu Masabathula</Authors>
     <Owners>PubNub</Owners>
@@ -24,7 +24,7 @@
     <PackageIconUrl>http://pubnub.s3.amazonaws.com/2011/powered-by-pubnub/pubnub-icon-600x600.png</PackageIconUrl>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
     <RepositoryUrl>https://github.com/pubnub/c-sharp/</RepositoryUrl>
-    <PackageReleaseNotes>Subscribe with custom timetoken scenario handling improvements.</PackageReleaseNotes>
+    <PackageReleaseNotes>Changed the way the PubNub logger is injected into IHtttpClientService for better custom-transport-layers handling.</PackageReleaseNotes>
     <PackageTags>Web Data Push Real-time Notifications ESB Message Broadcasting Distributed Computing</PackageTags>
     <!--<Summary>PubNub is a Massively Scalable Web Push Service for Web and Mobile Games.  This is a cloud-based service for broadcasting messages to thousands of web and mobile clients simultaneously</Summary>-->
     <Description>PubNub is a Massively Scalable Web Push Service for Web and Mobile Games.  This is a cloud-based service for broadcasting messages to thousands of web and mobile clients simultaneously</Description>

--- a/src/Api/PubnubApiUnity/PubnubApiUnity.csproj
+++ b/src/Api/PubnubApiUnity/PubnubApiUnity.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>net6.0;netstandard2.0</TargetFrameworks>
+	<GenerateDocumentationFile>true</GenerateDocumentationFile>
     <LangVersion>default</LangVersion>
     <SignAssembly>True</SignAssembly>
     <AssemblyOriginatorKeyFile>pubnub.snk</AssemblyOriginatorKeyFile>
@@ -671,178 +672,6 @@
   <ItemGroup>
     <None Include="..\PubnubApi\LICENSE.txt" Link="LICENSE.txt" Pack="true" PackagePath="" />
   </ItemGroup>
-
-  <ItemGroup>
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.3">
-      <PrivateAssets>None</PrivateAssets>
-    </PackageReference>
-    <PackageReference Include="PeterO.Cbor" Version="4.5.5" />
-  </ItemGroup>
-
-  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard1.0' ">
-    <Reference Include="System.Runtime" />
-    <PackageReference Include="NETStandard.Library" Version="1.6.1">
-      <PrivateAssets>None</PrivateAssets>
-    </PackageReference>
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.3">
-      <PrivateAssets>None</PrivateAssets>
-    </PackageReference>
-    <PackageReference Include="PeterO.Cbor" Version="4.5.2" />
-    <PackageReference Include="System.Security.Cryptography.Algorithms" Version="4.3.0" />
-    <PackageReference Include="System.Net.Requests" Version="4.0.11">
-      <PrivateAssets>None</PrivateAssets>
-    </PackageReference>
-    <PackageReference Include="System.Reflection" Version="4.3.0">
-      <PrivateAssets>None</PrivateAssets>
-    </PackageReference>
-    <PackageReference Include="System.Reflection.Primitives" Version="4.3.0">
-      <PrivateAssets>None</PrivateAssets>
-    </PackageReference>
-    <PackageReference Include="System.Reflection.TypeExtensions" Version="4.3.0">
-      <PrivateAssets>None</PrivateAssets>
-    </PackageReference>
-    <PackageReference Include="System.Linq.Queryable" Version="4.0.1">
-      <PrivateAssets>None</PrivateAssets>
-    </PackageReference>
-    <PackageReference Include="System.Text.Encoding" Version="4.3.0">
-      <PrivateAssets>None</PrivateAssets>
-    </PackageReference>
-    <PackageReference Include="System.Text.Encoding.Extensions" Version="4.3.0">
-      <PrivateAssets>None</PrivateAssets>
-    </PackageReference>
-    <PackageReference Include="System.Net.Primitives" Version="4.3.0">
-      <PrivateAssets>None</PrivateAssets>
-    </PackageReference>
-    <PackageReference Include="System.ValueTuple" Version="4.4.0">
-      <PrivateAssets>None</PrivateAssets>
-    </PackageReference>
-    <PackageReference Include="System.Collections.Concurrent" Version="4.3.0">
-      <PrivateAssets>None</PrivateAssets>
-    </PackageReference>
-  </ItemGroup>
-  
-  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard1.1' ">
-    <Reference Include="System.Runtime" />
-    <PackageReference Include="NETStandard.Library" Version="1.6.1">
-      <PrivateAssets>None</PrivateAssets>
-    </PackageReference>
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.3">
-      <PrivateAssets>None</PrivateAssets>
-    </PackageReference>
-    <PackageReference Include="PeterO.Cbor" Version="4.5.2" />
-    <PackageReference Include="System.Security.Cryptography.Algorithms" Version="4.3.0" />
-    <PackageReference Include="System.Net.Requests" Version="4.0.11">
-      <PrivateAssets>None</PrivateAssets>
-    </PackageReference>
-    <PackageReference Include="System.Reflection" Version="4.3.0">
-      <PrivateAssets>None</PrivateAssets>
-    </PackageReference>
-    <PackageReference Include="System.Reflection.TypeExtensions" Version="4.3.0">
-      <PrivateAssets>None</PrivateAssets>
-    </PackageReference>
-    <PackageReference Include="System.ValueTuple" Version="4.4.0">
-      <PrivateAssets>None</PrivateAssets>
-    </PackageReference>
-    <PackageReference Include="System.Collections.Concurrent" Version="4.3.0">
-      <PrivateAssets>None</PrivateAssets>
-    </PackageReference>
-  </ItemGroup>
-  
-  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard1.3' ">
-    <Reference Include="System.Runtime" />
-    <PackageReference Include="NETStandard.Library" Version="1.6.1">
-      <PrivateAssets>None</PrivateAssets>
-    </PackageReference>
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.3">
-      <PrivateAssets>None</PrivateAssets>
-    </PackageReference>
-    <PackageReference Include="PeterO.Cbor" Version="4.5.2" />
-    <PackageReference Include="System.Security.Cryptography.Algorithms" Version="4.3.0" />
-    <PackageReference Include="System.Net.Requests" Version="4.0.11">
-      <PrivateAssets>None</PrivateAssets>
-    </PackageReference>
-    <PackageReference Include="System.Reflection.Primitives" Version="4.3.0">
-      <PrivateAssets>None</PrivateAssets>
-    </PackageReference>
-    <PackageReference Include="System.Reflection.TypeExtensions" Version="4.3.0">
-      <PrivateAssets>None</PrivateAssets>
-    </PackageReference>
-    <PackageReference Include="System.Threading.ThreadPool" Version="4.0.10">
-      <PrivateAssets>None</PrivateAssets>
-    </PackageReference>
-    <PackageReference Include="System.Threading.Thread" Version="4.0.0">
-      <PrivateAssets>None</PrivateAssets>
-    </PackageReference>
-    <PackageReference Include="System.Linq.Queryable" Version="4.0.1">
-      <PrivateAssets>None</PrivateAssets>
-    </PackageReference>
-    <PackageReference Include="System.Text.Encoding" Version="4.3.0">
-      <PrivateAssets>None</PrivateAssets>
-    </PackageReference>
-    <PackageReference Include="System.Text.Encoding.Extensions" Version="4.3.0">
-      <PrivateAssets>None</PrivateAssets>
-    </PackageReference>
-    <PackageReference Include="System.Net.Http" Version="4.3.4">
-      <PrivateAssets>None</PrivateAssets>
-    </PackageReference>
-    <PackageReference Include="System.Net.Primitives" Version="4.3.0">
-      <PrivateAssets>None</PrivateAssets>
-    </PackageReference>
-    <PackageReference Include="System.ValueTuple" Version="4.4.0">
-      <PrivateAssets>None</PrivateAssets>
-    </PackageReference>
-    <PackageReference Include="System.Collections.Concurrent" Version="4.3.0">
-      <PrivateAssets>None</PrivateAssets>
-    </PackageReference>
-  </ItemGroup>
-
-  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard1.4' ">
-    <Reference Include="System.Runtime" />
-    <PackageReference Include="NETStandard.Library" Version="1.6.1">
-      <PrivateAssets>None</PrivateAssets>
-    </PackageReference>
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.3">
-      <PrivateAssets>None</PrivateAssets>
-    </PackageReference>
-    <PackageReference Include="PeterO.Cbor" Version="4.5.2" />
-    <PackageReference Include="System.Security.Cryptography.Algorithms" Version="4.3.0" />
-    <PackageReference Include="System.Net.Requests" Version="4.0.11">
-      <PrivateAssets>None</PrivateAssets>
-    </PackageReference>
-    <PackageReference Include="System.Reflection.Primitives" Version="4.3.0">
-      <PrivateAssets>None</PrivateAssets>
-    </PackageReference>
-    <PackageReference Include="System.Reflection.TypeExtensions" Version="4.3.0">
-      <PrivateAssets>None</PrivateAssets>
-    </PackageReference>
-    <PackageReference Include="System.Threading.ThreadPool" Version="4.0.10">
-      <PrivateAssets>None</PrivateAssets>
-    </PackageReference>
-    <PackageReference Include="System.Threading.Thread" Version="4.0.0">
-      <PrivateAssets>None</PrivateAssets>
-    </PackageReference>
-    <PackageReference Include="System.Linq.Queryable" Version="4.0.1">
-      <PrivateAssets>None</PrivateAssets>
-    </PackageReference>
-    <PackageReference Include="System.Text.Encoding" Version="4.3.0">
-      <PrivateAssets>None</PrivateAssets>
-    </PackageReference>
-    <PackageReference Include="System.Text.Encoding.Extensions" Version="4.3.0">
-      <PrivateAssets>None</PrivateAssets>
-    </PackageReference>
-    <PackageReference Include="System.Net.Http" Version="4.3.4">
-      <PrivateAssets>None</PrivateAssets>
-    </PackageReference>
-    <PackageReference Include="System.Net.Primitives" Version="4.3.0">
-      <PrivateAssets>None</PrivateAssets>
-    </PackageReference>
-    <PackageReference Include="System.ValueTuple" Version="4.4.0">
-      <PrivateAssets>None</PrivateAssets>
-    </PackageReference>
-    <PackageReference Include="System.Collections.Concurrent" Version="4.3.0">
-      <PrivateAssets>None</PrivateAssets>
-    </PackageReference>
-  </ItemGroup>
   
   <ItemGroup>
     <Folder Include="Builder\" />
@@ -884,6 +713,11 @@
     <Folder Include="Proxy\" />
     <Folder Include="Security\Crypto\Common\" />
     <Folder Include="Security\Crypto\Cryptors\" />
+  </ItemGroup>
+  
+  <ItemGroup>
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
+    <PackageReference Include="PeterO.Cbor" Version="4.5.5" />
   </ItemGroup>
   
   <!--<ItemGroup Condition=" '$(TargetFramework)' == 'netstandard1.4' ">

--- a/src/Api/PubnubApiUnity/PubnubApiUnity.csproj
+++ b/src/Api/PubnubApiUnity/PubnubApiUnity.csproj
@@ -15,7 +15,7 @@
 
   <PropertyGroup>
     <PackageId>PubnubApiUnity</PackageId>
-    <PackageVersion>7.3.8.0</PackageVersion>
+    <PackageVersion>7.3.9.0</PackageVersion>
     <Title>PubNub C# .NET - Web Data Push API</Title>
     <Authors>Pandu Masabathula</Authors>
     <Owners>PubNub</Owners>


### PR DESCRIPTION
refactor: transport layer logger injection change

Changed the way the PubNub logger is injected into IHtttpClientService for better custom-transport-layers handling