### PR TITLE
Callback results refactor

### DIFF
--- a/.pubnub.yml
+++ b/.pubnub.yml
@@ -1,8 +1,15 @@
 name: c-sharp
-version: "7.4.0"
+version: "7.4.1"
 schema: 1
 scm: github.com/pubnub/c-sharp
 changelog:
+  - date: 2025-07-30
+    version: v7.4.1
+    changes:
+      - type: bug
+        text: "Added MembershipMetadata container inside PNObjectEventResult to correctly parse and forward data when object event type is "membership"."
+      - type: bug
+        text: "Fixed issue where some result objects like PNMessageResult had UserMetadata declared as an object instead of the standard Dictionary<string, object> format for metadata."
   - date: 2025-07-23
     version: v7.4.0
     changes:
@@ -929,7 +936,7 @@ features:
     - QUERY-PARAM
 supported-platforms:
   -
-    version: Pubnub 'C#' 7.4.0
+    version: Pubnub 'C#' 7.4.1
     platforms:
       - Windows 10 and up
       - Windows Server 2008 and up
@@ -940,7 +947,7 @@ supported-platforms:
       - .Net Framework 4.6.1+
       - .Net Framework 6.0
   -
-    version: PubnubPCL 'C#' 7.4.0
+    version: PubnubPCL 'C#' 7.4.1
     platforms:
       - Xamarin.Android
       - Xamarin.iOS
@@ -960,7 +967,7 @@ supported-platforms:
       - .Net Core
       - .Net 6.0
   -
-    version: PubnubUWP 'C#' 7.4.0
+    version: PubnubUWP 'C#' 7.4.1
     platforms:
       - Windows Phone 10
       - Universal Windows Apps
@@ -984,7 +991,7 @@ sdks:
             distribution-type: source
             distribution-repository: GitHub
             package-name: Pubnub
-            location: https://github.com/pubnub/c-sharp/releases/tag/v7.4.0.0
+            location: https://github.com/pubnub/c-sharp/releases/tag/v7.4.1.0
             requires:
               -
                 name: ".Net"
@@ -1267,7 +1274,7 @@ sdks:
             distribution-type: source
             distribution-repository: GitHub
             package-name: PubNubPCL
-            location: https://github.com/pubnub/c-sharp/releases/tag/v7.4.0.0
+            location: https://github.com/pubnub/c-sharp/releases/tag/v7.4.1.0
             requires:
               -
                 name: ".Net Core"
@@ -1626,7 +1633,7 @@ sdks:
             distribution-type: source
             distribution-repository: GitHub
             package-name: PubnubUWP
-            location: https://github.com/pubnub/c-sharp/releases/tag/v7.4.0.0
+            location: https://github.com/pubnub/c-sharp/releases/tag/v7.4.1.0
             requires:
               -
                 name: "Universal Windows Platform Development"

--- a/.pubnub.yml
+++ b/.pubnub.yml
@@ -7,7 +7,7 @@ changelog:
     version: v7.4.1
     changes:
       - type: bug
-        text: "Added MembershipMetadata container inside PNObjectEventResult to correctly parse and forward data when object event type is "membership"."
+        text: "Added MembershipMetadata container inside PNObjectEventResult to correctly parse and forward data when object event type is `membership`."
       - type: bug
         text: "Fixed issue where some result objects like PNMessageResult had UserMetadata declared as an object instead of the standard Dictionary<string, object> format for metadata."
   - date: 2025-07-23

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,8 @@
+v7.4.1 - July 30 2025
+-----------------------------
+- Fixed: added MembershipMetadata container inside PNObjectEventResult to correctly parse and forward data when object event type is "membership".
+- Fixed: fixed issue where some result objects like PNMessageResult had UserMetadata declared as an object instead of the standard Dictionary<string, object> format for metadata.
+
 v7.4.0 - July 23 2025
 -----------------------------
 - Added: added support for `status` and `type` fields for uuid, channel and members app context apis.

--- a/src/Api/PubnubApi/JsonDataParse/DeserializeToInternalObjectUtility.cs
+++ b/src/Api/PubnubApi/JsonDataParse/DeserializeToInternalObjectUtility.cs
@@ -193,7 +193,7 @@ namespace PubnubApi
 
                     if (listObject[1] != null)
                     {
-                        ack.UserMetadata = listObject[1];
+                        ack.UserMetadata = jsonPlug.ConvertToDictionaryObject(listObject[1]);
                     }
 
                     if (ack.Event != null && ack.Event.ToLowerInvariant() == "interval")

--- a/src/Api/PubnubApi/JsonDataParse/EventDeserializer.cs
+++ b/src/Api/PubnubApi/JsonDataParse/EventDeserializer.cs
@@ -95,7 +95,7 @@ public class EventDeserializer
 
             if (jsonFields.TryGetValue("userMetadata", out object userMetadataValue))
             {
-                presenceEvent.UserMetadata = userMetadataValue;
+                presenceEvent.UserMetadata = jsonLibrary.ConvertToDictionaryObject(userMetadataValue);
             }
 
             if (presenceEvent.Event != null && presenceEvent.Event.ToLowerInvariant() == "interval")

--- a/src/Api/PubnubApi/JsonDataParse/PNObjectEventJsonDataParse.cs
+++ b/src/Api/PubnubApi/JsonDataParse/PNObjectEventJsonDataParse.cs
@@ -37,6 +37,14 @@ internal static class PNObjectEventJsonDataParse
                 var dataFields = objectEventDicObj["data"] as Dictionary<string, object>;
                 if (dataFields != null)
                 {
+                    //Common fields
+                    var custom = dataFields.ContainsKey("custom") && dataFields["custom"] != null
+                        ? jsonPlug.ConvertToDictionaryObject(dataFields["custom"])
+                        : null;
+                    var status = GetStringValue(dataFields, "status");
+                    var type = GetStringValue(dataFields, "type");
+                    var updated = GetStringValue(dataFields, "updated");
+                    
                     if (result.Type?.ToLowerInvariant() == "uuid" && dataFields.ContainsKey("id"))
                     {
                         result.UuidMetadata = new PNUuidMetadataResult
@@ -46,12 +54,10 @@ internal static class PNObjectEventJsonDataParse
                             ExternalId = GetStringValue(dataFields, "externalId"),
                             ProfileUrl = GetStringValue(dataFields, "profileUrl"),
                             Email = GetStringValue(dataFields, "email"),
-                            Status = GetStringValue(dataFields, "status"),
-                            Type = GetStringValue(dataFields, "type"),
-                            Custom = dataFields.ContainsKey("custom") && dataFields["custom"] != null
-                                ? jsonPlug.ConvertToDictionaryObject(dataFields["custom"])
-                                : null,
-                            Updated = GetStringValue(dataFields, "updated")
+                            Status = status,
+                            Type = type,
+                            Custom = custom,
+                            Updated = updated
                         };
                     }
                     else if (result.Type.ToLowerInvariant() == "channel" && dataFields.ContainsKey("id"))
@@ -61,33 +67,31 @@ internal static class PNObjectEventJsonDataParse
                             Channel = dataFields["id"]?.ToString(),
                             Name = GetStringValue(dataFields, "name"),
                             Description = GetStringValue(dataFields, "description"),
-                            Status = GetStringValue(dataFields, "status"),
-                            Type = GetStringValue(dataFields, "type"),
-                            Custom = dataFields.ContainsKey("custom") && dataFields["custom"] != null
-                                ? jsonPlug.ConvertToDictionaryObject(dataFields["custom"])
-                                : null,
-                            Updated = GetStringValue(dataFields, "updated")
+                            Status = status,
+                            Type = type,
+                            Custom = custom,
+                            Updated = updated
                         };
                     }
                     else if (result.Type.ToLowerInvariant() == "membership" && dataFields.ContainsKey("uuid") &&
                              dataFields.ContainsKey("channel"))
                     {
+                        result.MembershipMetadata = new PNMembershipMetadataResult()
+                        {
+                            Custom = custom,
+                            Status = status,
+                            Type = type,
+                            Updated = updated
+                        };
                         var userMetadataFields = dataFields["uuid"] as Dictionary<string, object>;
                         if (userMetadataFields != null && userMetadataFields.ContainsKey("id"))
                         {
-                            result.UuidMetadata = new PNUuidMetadataResult
-                            {
-                                Uuid = userMetadataFields["id"]?.ToString()
-                            };
+                            result.MembershipMetadata.Uuid = userMetadataFields["id"]?.ToString();
                         }
-
                         var channelMetadataFields = dataFields["channel"] as Dictionary<string, object>;
                         if (channelMetadataFields != null && channelMetadataFields.ContainsKey("id"))
                         {
-                            result.ChannelMetadata = new PNChannelMetadataResult
-                            {
-                                Channel = channelMetadataFields["id"]?.ToString()
-                            };
+                            result.MembershipMetadata.Channel = channelMetadataFields["id"]?.ToString();
                         }
                     }
                 }

--- a/src/Api/PubnubApi/Model/Consumer/Objects/PNChannelMetadataResult.cs
+++ b/src/Api/PubnubApi/Model/Consumer/Objects/PNChannelMetadataResult.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
+﻿using System.Collections.Generic;
 
 namespace PubnubApi
 {

--- a/src/Api/PubnubApi/Model/Consumer/Objects/PNMembershipMetadataResult.cs
+++ b/src/Api/PubnubApi/Model/Consumer/Objects/PNMembershipMetadataResult.cs
@@ -1,0 +1,13 @@
+using System.Collections.Generic;
+
+namespace PubnubApi;
+
+public class PNMembershipMetadataResult
+{
+    public string Channel { get; internal set; }
+    public string Uuid { get; internal set; }
+    public Dictionary<string, object> Custom { get; internal set; }
+    public string Status { get; internal set; }
+    public string Type { get; internal set; }
+    public string Updated { get; internal set; }
+}

--- a/src/Api/PubnubApi/Model/Consumer/Pubsub/PNMessageResult.cs
+++ b/src/Api/PubnubApi/Model/Consumer/Pubsub/PNMessageResult.cs
@@ -1,4 +1,4 @@
-﻿using System;
+﻿using System.Collections.Generic;
 
 namespace PubnubApi
 {
@@ -10,7 +10,7 @@ namespace PubnubApi
         public long Timetoken { get; internal set; }
 
         public string CustomMessageType { get; internal set; }
-        public object UserMetadata { get; internal set; }
+        public Dictionary<string, object> UserMetadata { get; internal set; }
         public string Publisher { get; internal set; }
     }
 }

--- a/src/Api/PubnubApi/Model/Consumer/Pubsub/PNObjectEventResult.cs
+++ b/src/Api/PubnubApi/Model/Consumer/Pubsub/PNObjectEventResult.cs
@@ -1,24 +1,14 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-
-namespace PubnubApi
+﻿namespace PubnubApi
 {
     public class PNObjectEventResult
     {
-        public PNObjectEventResult()
-        {
-            this.Event = ""; //values = set/delete for uuid/channel/UuidAssociation/ChannelAssociation
-            this.Type = "";  //values = uuid/channel/membership
-            this.Channel = "";
-        }
-        public string Event { get; internal set; }
-        public string Type { get; internal set; }
+        public string Event { get; internal set; } = ""; //values = set/delete for uuid/channel/UuidAssociation/ChannelAssociation
+        public string Type { get; internal set; } = ""; //values = uuid/channel/membership
         public PNUuidMetadataResult UuidMetadata { get; internal set; } //Populate when Type = uuid
         public PNChannelMetadataResult ChannelMetadata { get; internal set; } //Populate when Type = channel
+        public PNMembershipMetadataResult MembershipMetadata { get; internal set; } //Populate when Type = membership
         public long Timestamp { get; internal set; }
-        public string Channel { get; internal set; } //Subscribed channel
+        public string Channel { get; internal set; } = ""; //Subscribed channel
         public string Subscription { get; internal set; }
     }
 }

--- a/src/Api/PubnubApi/Model/Consumer/Pubsub/PNPresenceEventResult.cs
+++ b/src/Api/PubnubApi/Model/Consumer/Pubsub/PNPresenceEventResult.cs
@@ -23,7 +23,7 @@ namespace PubnubApi
         public string Subscription { get; internal set; }
 
         public long Timetoken { get; internal set; }
-        public object UserMetadata { get; internal set; }
+        public Dictionary<string, object> UserMetadata { get; internal set; }
         public string[] Join { get; internal set; }
         public string[] Timeout { get; internal set; }
         public string[] Leave { get; internal set; }

--- a/src/Api/PubnubApi/NewtonsoftJsonDotNet.cs
+++ b/src/Api/PubnubApi/NewtonsoftJsonDotNet.cs
@@ -400,7 +400,7 @@ namespace PubnubApi
                 if (jsonFields["userMetadata"] != null)
                 {
                     PropertyInfo userMetadataProp = specific.GetRuntimeProperty("UserMetadata");
-                    userMetadataProp.SetValue(message, jsonFields["userMetadata"], null);
+                    userMetadataProp.SetValue(message, ConvertToDictionaryObject(jsonFields["userMetadata"]), null);
                 }
                 
 

--- a/src/Api/PubnubApi/Properties/AssemblyInfo.cs
+++ b/src/Api/PubnubApi/Properties/AssemblyInfo.cs
@@ -11,8 +11,8 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyProduct("Pubnub C# SDK")]
 [assembly: AssemblyCopyright("Copyright ©  2021")]
 [assembly: AssemblyTrademark("")]
-[assembly: AssemblyVersion("7.4.0.0")]
-[assembly: AssemblyFileVersion("7.4.0.0")]
+[assembly: AssemblyVersion("7.4.1.0")]
+[assembly: AssemblyFileVersion("7.4.1.0")]
 // Setting ComVisible to false makes the types in this assembly not visible
 // to COM components.  If you need to access a type in this assembly from
 // COM, set the ComVisible attribute to true on that type.

--- a/src/Api/PubnubApi/PubnubApi.csproj
+++ b/src/Api/PubnubApi/PubnubApi.csproj
@@ -23,7 +23,7 @@
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
     <RepositoryUrl>https://github.com/pubnub/c-sharp/</RepositoryUrl>
     <PackageReleaseNotes>Added MembershipMetadata container inside PNObjectEventResult to correctly parse and forward data when object event type is `membership`.
-Fixed issue where some result objects like PNMessageResult had UserMetadata declared as an object instead of the standard Dictionary<string, object> format for metadata.</PackageReleaseNotes>
+Fixed issue where some result objects like PNMessageResult had UserMetadata declared as an object instead of the standard Dictionary format for metadata.</PackageReleaseNotes>
     <PackageTags>Web Data Push Real-time Notifications ESB Message Broadcasting Distributed Computing</PackageTags>
     <!--<Summary>PubNub is a Massively Scalable Web Push Service for Web and Mobile Games.  This is a cloud-based service for broadcasting messages to thousands of web and mobile clients simultaneously</Summary>-->
     <Description>PubNub is a Massively Scalable Web Push Service for Web and Mobile Games.  This is a cloud-based service for broadcasting messages to thousands of web and mobile clients simultaneously</Description>

--- a/src/Api/PubnubApi/PubnubApi.csproj
+++ b/src/Api/PubnubApi/PubnubApi.csproj
@@ -22,7 +22,7 @@
     <PackageIconUrl>http://pubnub.s3.amazonaws.com/2011/powered-by-pubnub/pubnub-icon-600x600.png</PackageIconUrl>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
     <RepositoryUrl>https://github.com/pubnub/c-sharp/</RepositoryUrl>
-    <PackageReleaseNotes>Added MembershipMetadata container inside PNObjectEventResult to correctly parse and forward data when object event type is "membership".
+    <PackageReleaseNotes>Added MembershipMetadata container inside PNObjectEventResult to correctly parse and forward data when object event type is `membership`.
 Fixed issue where some result objects like PNMessageResult had UserMetadata declared as an object instead of the standard Dictionary<string, object> format for metadata.</PackageReleaseNotes>
     <PackageTags>Web Data Push Real-time Notifications ESB Message Broadcasting Distributed Computing</PackageTags>
     <!--<Summary>PubNub is a Massively Scalable Web Push Service for Web and Mobile Games.  This is a cloud-based service for broadcasting messages to thousands of web and mobile clients simultaneously</Summary>-->

--- a/src/Api/PubnubApi/PubnubApi.csproj
+++ b/src/Api/PubnubApi/PubnubApi.csproj
@@ -14,7 +14,7 @@
 
   <PropertyGroup>
     <PackageId>Pubnub</PackageId>
-    <PackageVersion>7.4.0.0</PackageVersion>
+    <PackageVersion>7.4.1.0</PackageVersion>
     <Title>PubNub C# .NET - Web Data Push API</Title>
     <Authors>Pandu Masabathula</Authors>
     <Owners>PubNub</Owners>
@@ -22,7 +22,8 @@
     <PackageIconUrl>http://pubnub.s3.amazonaws.com/2011/powered-by-pubnub/pubnub-icon-600x600.png</PackageIconUrl>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
     <RepositoryUrl>https://github.com/pubnub/c-sharp/</RepositoryUrl>
-    <PackageReleaseNotes>Added support for `status` and `type` fields for uuid, channel and members app context apis.</PackageReleaseNotes>
+    <PackageReleaseNotes>Added MembershipMetadata container inside PNObjectEventResult to correctly parse and forward data when object event type is "membership".
+Fixed issue where some result objects like PNMessageResult had UserMetadata declared as an object instead of the standard Dictionary<string, object> format for metadata.</PackageReleaseNotes>
     <PackageTags>Web Data Push Real-time Notifications ESB Message Broadcasting Distributed Computing</PackageTags>
     <!--<Summary>PubNub is a Massively Scalable Web Push Service for Web and Mobile Games.  This is a cloud-based service for broadcasting messages to thousands of web and mobile clients simultaneously</Summary>-->
     <Description>PubNub is a Massively Scalable Web Push Service for Web and Mobile Games.  This is a cloud-based service for broadcasting messages to thousands of web and mobile clients simultaneously</Description>

--- a/src/Api/PubnubApiPCL/PubnubApiPCL.csproj
+++ b/src/Api/PubnubApiPCL/PubnubApiPCL.csproj
@@ -379,6 +379,9 @@
     <Compile Include="..\PubnubApi\Model\Consumer\Objects\PNGetChannelMetadataResult.cs" Link="Model\Consumer\Objects\PNGetChannelMetadataResult.cs" />
     <Compile Include="..\PubnubApi\Model\Consumer\Objects\PNGetUuidMetadataResult.cs" Link="Model\Consumer\Objects\PNGetUuidMetadataResult.cs" />
     <Compile Include="..\PubnubApi\Model\Consumer\Objects\PNMembership.cs" Link="Model\Consumer\Objects\PNMembership.cs" />
+    <Compile Include="..\PubnubApi\Model\Consumer\Objects\PNMembershipMetadataResult.cs">
+      <Link>Model\Consumer\Objects\PNMembershipMetadataResult.cs</Link>
+    </Compile>
     <Compile Include="..\PubnubApi\Model\Consumer\Objects\PNMembershipsItemResult.cs" Link="Model\Consumer\Objects\PNMembershipsItemResult.cs" />
     <Compile Include="..\PubnubApi\Model\Consumer\Objects\PNMembershipsResult.cs" Link="Model\Consumer\Objects\PNMembershipsResult.cs" />
     <Compile Include="..\PubnubApi\Model\Consumer\Objects\PNPage.cs" Link="Model\Consumer\Objects\PNPage.cs" />

--- a/src/Api/PubnubApiPCL/PubnubApiPCL.csproj
+++ b/src/Api/PubnubApiPCL/PubnubApiPCL.csproj
@@ -23,7 +23,7 @@
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
     <RepositoryUrl>https://github.com/pubnub/c-sharp/</RepositoryUrl>
     <PackageReleaseNotes>Added MembershipMetadata container inside PNObjectEventResult to correctly parse and forward data when object event type is `membership`.
-Fixed issue where some result objects like PNMessageResult had UserMetadata declared as an object instead of the standard Dictionary<string, object> format for metadata.</PackageReleaseNotes>
+Fixed issue where some result objects like PNMessageResult had UserMetadata declared as an object instead of the standard Dictionary format for metadata.</PackageReleaseNotes>
     <PackageTags>Web Data Push Real-time Notifications ESB Message Broadcasting Distributed Computing</PackageTags>
     <!--<Summary>PubNub is a Massively Scalable Web Push Service for Web and Mobile Games.  This is a cloud-based service for broadcasting messages to thousands of web and mobile clients simultaneously</Summary>-->
     <Description>PubNub is a Massively Scalable Web Push Service for Web and Mobile Games.  This is a cloud-based service for broadcasting messages to thousands of web and mobile clients simultaneously</Description>

--- a/src/Api/PubnubApiPCL/PubnubApiPCL.csproj
+++ b/src/Api/PubnubApiPCL/PubnubApiPCL.csproj
@@ -14,7 +14,7 @@
 
   <PropertyGroup>
     <PackageId>PubnubPCL</PackageId>
-    <PackageVersion>7.4.0.0</PackageVersion>
+    <PackageVersion>7.4.1.0</PackageVersion>
     <Title>PubNub C# .NET - Web Data Push API</Title>
     <Authors>Pandu Masabathula</Authors>
     <Owners>PubNub</Owners>
@@ -22,7 +22,8 @@
     <PackageIconUrl>http://pubnub.s3.amazonaws.com/2011/powered-by-pubnub/pubnub-icon-600x600.png</PackageIconUrl>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
     <RepositoryUrl>https://github.com/pubnub/c-sharp/</RepositoryUrl>
-    <PackageReleaseNotes>Added support for `status` and `type` fields for uuid, channel and members app context apis.</PackageReleaseNotes>
+    <PackageReleaseNotes>Added MembershipMetadata container inside PNObjectEventResult to correctly parse and forward data when object event type is "membership".
+Fixed issue where some result objects like PNMessageResult had UserMetadata declared as an object instead of the standard Dictionary<string, object> format for metadata.</PackageReleaseNotes>
     <PackageTags>Web Data Push Real-time Notifications ESB Message Broadcasting Distributed Computing</PackageTags>
     <!--<Summary>PubNub is a Massively Scalable Web Push Service for Web and Mobile Games.  This is a cloud-based service for broadcasting messages to thousands of web and mobile clients simultaneously</Summary>-->
     <Description>PubNub is a Massively Scalable Web Push Service for Web and Mobile Games.  This is a cloud-based service for broadcasting messages to thousands of web and mobile clients simultaneously</Description>

--- a/src/Api/PubnubApiPCL/PubnubApiPCL.csproj
+++ b/src/Api/PubnubApiPCL/PubnubApiPCL.csproj
@@ -22,7 +22,7 @@
     <PackageIconUrl>http://pubnub.s3.amazonaws.com/2011/powered-by-pubnub/pubnub-icon-600x600.png</PackageIconUrl>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
     <RepositoryUrl>https://github.com/pubnub/c-sharp/</RepositoryUrl>
-    <PackageReleaseNotes>Added MembershipMetadata container inside PNObjectEventResult to correctly parse and forward data when object event type is "membership".
+    <PackageReleaseNotes>Added MembershipMetadata container inside PNObjectEventResult to correctly parse and forward data when object event type is `membership`.
 Fixed issue where some result objects like PNMessageResult had UserMetadata declared as an object instead of the standard Dictionary<string, object> format for metadata.</PackageReleaseNotes>
     <PackageTags>Web Data Push Real-time Notifications ESB Message Broadcasting Distributed Computing</PackageTags>
     <!--<Summary>PubNub is a Massively Scalable Web Push Service for Web and Mobile Games.  This is a cloud-based service for broadcasting messages to thousands of web and mobile clients simultaneously</Summary>-->

--- a/src/Api/PubnubApiUWP/PubnubApiUWP.csproj
+++ b/src/Api/PubnubApiUWP/PubnubApiUWP.csproj
@@ -24,7 +24,7 @@
     <PackageIconUrl>http://pubnub.s3.amazonaws.com/2011/powered-by-pubnub/pubnub-icon-600x600.png</PackageIconUrl>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
     <RepositoryUrl>https://github.com/pubnub/c-sharp/</RepositoryUrl>
-    <PackageReleaseNotes>Added MembershipMetadata container inside PNObjectEventResult to correctly parse and forward data when object event type is "membership".
+    <PackageReleaseNotes>Added MembershipMetadata container inside PNObjectEventResult to correctly parse and forward data when object event type is `membership`.
 Fixed issue where some result objects like PNMessageResult had UserMetadata declared as an object instead of the standard Dictionary<string, object> format for metadata.</PackageReleaseNotes>
     <PackageTags>Web Data Push Real-time Notifications ESB Message Broadcasting Distributed Computing</PackageTags>
     <!--<Summary>PubNub is a Massively Scalable Web Push Service for Web and Mobile Games.  This is a cloud-based service for broadcasting messages to thousands of web and mobile clients simultaneously</Summary>-->

--- a/src/Api/PubnubApiUWP/PubnubApiUWP.csproj
+++ b/src/Api/PubnubApiUWP/PubnubApiUWP.csproj
@@ -16,7 +16,7 @@
 
   <PropertyGroup>
     <PackageId>PubnubUWP</PackageId>
-    <PackageVersion>7.4.0.0</PackageVersion>
+    <PackageVersion>7.4.1.0</PackageVersion>
     <Title>PubNub C# .NET - Web Data Push API</Title>
     <Authors>Pandu Masabathula</Authors>
     <Owners>PubNub</Owners>
@@ -24,7 +24,8 @@
     <PackageIconUrl>http://pubnub.s3.amazonaws.com/2011/powered-by-pubnub/pubnub-icon-600x600.png</PackageIconUrl>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
     <RepositoryUrl>https://github.com/pubnub/c-sharp/</RepositoryUrl>
-    <PackageReleaseNotes>Added support for `status` and `type` fields for uuid, channel and members app context apis.</PackageReleaseNotes>
+    <PackageReleaseNotes>Added MembershipMetadata container inside PNObjectEventResult to correctly parse and forward data when object event type is "membership".
+Fixed issue where some result objects like PNMessageResult had UserMetadata declared as an object instead of the standard Dictionary<string, object> format for metadata.</PackageReleaseNotes>
     <PackageTags>Web Data Push Real-time Notifications ESB Message Broadcasting Distributed Computing</PackageTags>
     <!--<Summary>PubNub is a Massively Scalable Web Push Service for Web and Mobile Games.  This is a cloud-based service for broadcasting messages to thousands of web and mobile clients simultaneously</Summary>-->
     <Description>PubNub is a Massively Scalable Web Push Service for Web and Mobile Games.  This is a cloud-based service for broadcasting messages to thousands of web and mobile clients simultaneously</Description>

--- a/src/Api/PubnubApiUWP/PubnubApiUWP.csproj
+++ b/src/Api/PubnubApiUWP/PubnubApiUWP.csproj
@@ -25,7 +25,7 @@
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
     <RepositoryUrl>https://github.com/pubnub/c-sharp/</RepositoryUrl>
     <PackageReleaseNotes>Added MembershipMetadata container inside PNObjectEventResult to correctly parse and forward data when object event type is `membership`.
-Fixed issue where some result objects like PNMessageResult had UserMetadata declared as an object instead of the standard Dictionary<string, object> format for metadata.</PackageReleaseNotes>
+Fixed issue where some result objects like PNMessageResult had UserMetadata declared as an object instead of the standard Dictionary format for metadata.</PackageReleaseNotes>
     <PackageTags>Web Data Push Real-time Notifications ESB Message Broadcasting Distributed Computing</PackageTags>
     <!--<Summary>PubNub is a Massively Scalable Web Push Service for Web and Mobile Games.  This is a cloud-based service for broadcasting messages to thousands of web and mobile clients simultaneously</Summary>-->
     <Description>PubNub is a Massively Scalable Web Push Service for Web and Mobile Games.  This is a cloud-based service for broadcasting messages to thousands of web and mobile clients simultaneously</Description>

--- a/src/Api/PubnubApiUWP/PubnubApiUWP.csproj
+++ b/src/Api/PubnubApiUWP/PubnubApiUWP.csproj
@@ -508,6 +508,9 @@
     <Compile Include="..\PubnubApi\Model\Consumer\Objects\PNGetChannelMetadataResult.cs" Link="Model\Consumer\Objects\PNGetChannelMetadataResult.cs" />
     <Compile Include="..\PubnubApi\Model\Consumer\Objects\PNGetUuidMetadataResult.cs" Link="Model\Consumer\Objects\PNGetUuidMetadataResult.cs" />
     <Compile Include="..\PubnubApi\Model\Consumer\Objects\PNMembership.cs" Link="Model\Consumer\Objects\PNMembership.cs" />
+    <Compile Include="..\PubnubApi\Model\Consumer\Objects\PNMembershipMetadataResult.cs">
+      <Link>Model\Consumer\Objects\PNMembershipMetadataResult.cs</Link>
+    </Compile>
     <Compile Include="..\PubnubApi\Model\Consumer\Objects\PNMembershipsItemResult.cs" Link="Model\Consumer\Objects\PNMembershipsItemResult.cs" />
     <Compile Include="..\PubnubApi\Model\Consumer\Objects\PNMembershipsResult.cs" Link="Model\Consumer\Objects\PNMembershipsResult.cs" />
     <Compile Include="..\PubnubApi\Model\Consumer\Objects\PNPage.cs" Link="Model\Consumer\Objects\PNPage.cs" />

--- a/src/Api/PubnubApiUnity/PubnubApiUnity.csproj
+++ b/src/Api/PubnubApiUnity/PubnubApiUnity.csproj
@@ -226,6 +226,9 @@
     <Compile Include="..\PubnubApi\JsonDataParse\DeserializeToInternalObjectUtility.cs">
       <Link>JsonDataParse\DeserializeToInternalObjectUtility.cs</Link>
     </Compile>
+    <Compile Include="..\PubnubApi\Model\Consumer\Objects\PNMembershipMetadataResult.cs">
+      <Link>Model\Consumer\Objects\PNMembershipMetadataResult.cs</Link>
+    </Compile>
     <Compile Include="..\PubnubApi\PNSDK\DotNetPNSDKSource.cs">
       <Link>PNSDK\DotNetPNSDKSource.cs</Link>
     </Compile>

--- a/src/Api/PubnubApiUnity/PubnubApiUnity.csproj
+++ b/src/Api/PubnubApiUnity/PubnubApiUnity.csproj
@@ -15,7 +15,7 @@
 
   <PropertyGroup>
     <PackageId>PubnubApiUnity</PackageId>
-    <PackageVersion>7.4.0.0</PackageVersion>
+    <PackageVersion>7.4.1.0</PackageVersion>
     <Title>PubNub C# .NET - Web Data Push API</Title>
     <Authors>Pandu Masabathula</Authors>
     <Owners>PubNub</Owners>

--- a/src/UnitTests/PubnubApi.Tests/WhenObjectChannelMember.cs
+++ b/src/UnitTests/PubnubApi.Tests/WhenObjectChannelMember.cs
@@ -2078,7 +2078,7 @@ namespace PubNubMessaging.Tests
             };
             channelSubscription.Subscribe<object>();
             
-            await Task.Delay(2500);
+            await Task.Delay(2000);
             
             // 1. Set UUIDMetadata for random user
             var setUuidMetadata = await pubnub.SetUuidMetadata()

--- a/src/UnitTests/PubnubApi.Tests/WhenObjectChannelMember.cs
+++ b/src/UnitTests/PubnubApi.Tests/WhenObjectChannelMember.cs
@@ -2078,7 +2078,7 @@ namespace PubNubMessaging.Tests
             };
             channelSubscription.Subscribe<object>();
             
-            await Task.Delay(2000);
+            await Task.Delay(2500);
             
             // 1. Set UUIDMetadata for random user
             var setUuidMetadata = await pubnub.SetUuidMetadata()

--- a/src/UnitTests/PubnubApi.Tests/WhenObjectMembership.cs
+++ b/src/UnitTests/PubnubApi.Tests/WhenObjectMembership.cs
@@ -2792,7 +2792,7 @@ namespace PubNubMessaging.Tests
             //Clean previous memberships
             await pubnub.RemoveMemberships().Channels(new List<string>() { channelMetadataId }).Uuid(uuidMetadataId)
                 .ExecuteAsync();
-            await Task.Delay(3000);
+            await Task.Delay(4000);
 
             var setReset = new ManualResetEvent(false);
             SubscribeCallbackExt eventListener = new SubscribeCallbackExt(
@@ -2853,6 +2853,12 @@ namespace PubNubMessaging.Tests
 
             var set = setReset.WaitOne(20000);
             Assert.True(set, "Didn't receive objects callback after setting memberships.");
+            
+            //Cleanup
+            await pubnub.RemoveMemberships().Channels(new List<string>() { channelMetadataId }).Uuid(uuidMetadataId)
+                .ExecuteAsync();
+            pubnub.RemoveListener(eventListener);
+            pubnub.Destroy();
         }
         
     }


### PR DESCRIPTION
fix: added MembershipMetadata container to PNObjectEventResult

Added MembershipMetadata container inside PNObjectEventResult to correctly parse and forward data when object event type is "membership"

fix: changed UserMetadata from object to Dictionary<string, object>

Fixed issue where some result objects like PNMessageResult had UserMetadata declared as an object instead of the standard Dictionary<string, object> format for metadata