### PR TITLE
fix for subscription to continue after exception from listener callback

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -184,6 +184,10 @@ src/PNEventEngine/obj/*
 src/PNEventEngineUWP/bin/*
 src/PNEventEngineUWP/obj/*
 
+CLAUDE.md
+.claude/*
+.cursor/*
+
 # GitHub Actions #
 ##################
 .github/.release

--- a/.pubnub.yml
+++ b/.pubnub.yml
@@ -1,8 +1,13 @@
 name: c-sharp
-version: "8.0.1"
+version: "8.0.2"
 schema: 1
 scm: github.com/pubnub/c-sharp
 changelog:
+  - date: 2025-11-17
+    version: v8.0.2
+    changes:
+      - type: bug
+        text: "Fixes issue of subscription loop breaking when a listener callback throws exception."
   - date: 2025-11-04
     version: v8.0.1
     changes:
@@ -957,7 +962,7 @@ features:
     - QUERY-PARAM
 supported-platforms:
   -
-    version: Pubnub 'C#' 8.0.1
+    version: Pubnub 'C#' 8.0.2
     platforms:
       - Windows 10 and up
       - Windows Server 2008 and up
@@ -968,7 +973,7 @@ supported-platforms:
       - .Net Framework 4.6.1+
       - .Net Framework 6.0
   -
-    version: PubnubPCL 'C#' 8.0.1
+    version: PubnubPCL 'C#' 8.0.2
     platforms:
       - Xamarin.Android
       - Xamarin.iOS
@@ -988,7 +993,7 @@ supported-platforms:
       - .Net Core
       - .Net 6.0
   -
-    version: PubnubUWP 'C#' 8.0.1
+    version: PubnubUWP 'C#' 8.0.2
     platforms:
       - Windows Phone 10
       - Universal Windows Apps
@@ -1012,7 +1017,7 @@ sdks:
             distribution-type: source
             distribution-repository: GitHub
             package-name: Pubnub
-            location: https://github.com/pubnub/c-sharp/releases/tag/v8.0.1.0
+            location: https://github.com/pubnub/c-sharp/releases/tag/v8.0.2
             requires:
               -
                 name: ".Net"
@@ -1295,7 +1300,7 @@ sdks:
             distribution-type: source
             distribution-repository: GitHub
             package-name: PubNubPCL
-            location: https://github.com/pubnub/c-sharp/releases/tag/v8.0.1.0
+            location: https://github.com/pubnub/c-sharp/releases/tag/v8.0.2
             requires:
               -
                 name: ".Net Core"
@@ -1654,7 +1659,7 @@ sdks:
             distribution-type: source
             distribution-repository: GitHub
             package-name: PubnubUWP
-            location: https://github.com/pubnub/c-sharp/releases/tag/v8.0.1.0
+            location: https://github.com/pubnub/c-sharp/releases/tag/v8.0.2
             requires:
               -
                 name: "Universal Windows Platform Development"

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+v8.0.2 - November 17 2025
+-----------------------------
+- Fixed: fixes issue of subscription loop breaking when a listener callback throws exception.
+
 v8.0.1 - November 04 2025
 -----------------------------
 - Modified: removed `limit` value clamp for HereNow API. Server will perform validation for limit parameter value.

--- a/src/Api/PubnubApi/EndPoint/PubSub/SubscribeEndpoint.cs
+++ b/src/Api/PubnubApi/EndPoint/PubSub/SubscribeEndpoint.cs
@@ -216,7 +216,14 @@ namespace PubnubApi.EndPoint
 		{
 			foreach (var listener in SubscribeListenerList)
             {
-				listener?.Message(pubnubInstance, messageResult);
+				try
+				{
+					listener?.Message(pubnubInstance, messageResult);
+				}
+				catch (Exception ex)
+				{
+					config.Logger?.Error($"error during event handler function, {ex.Message}");
+				}
 			}
 		}
 
@@ -224,7 +231,14 @@ namespace PubnubApi.EndPoint
         {
             foreach (var listener in SubscribeListenerList)
             {
-                listener?.Status(pubnubInstance, status);
+                try
+                {
+                    listener?.Status(pubnubInstance, status);
+                }
+                catch (Exception ex)
+                {
+                    config.Logger?.Error($"error during event handler function, {ex.Message}");
+                }
             }
         }
 

--- a/src/Api/PubnubApi/Properties/AssemblyInfo.cs
+++ b/src/Api/PubnubApi/Properties/AssemblyInfo.cs
@@ -11,8 +11,8 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyProduct("Pubnub C# SDK")]
 [assembly: AssemblyCopyright("Copyright ©  2021")]
 [assembly: AssemblyTrademark("")]
-[assembly: AssemblyVersion("8.0.1.0")]
-[assembly: AssemblyFileVersion("8.0.1.0")]
+[assembly: AssemblyVersion("8.0.2")]
+[assembly: AssemblyFileVersion("8.0.2")]
 // Setting ComVisible to false makes the types in this assembly not visible
 // to COM components.  If you need to access a type in this assembly from
 // COM, set the ComVisible attribute to true on that type.

--- a/src/Api/PubnubApi/PubnubApi.csproj
+++ b/src/Api/PubnubApi/PubnubApi.csproj
@@ -14,7 +14,7 @@
 
   <PropertyGroup>
     <PackageId>Pubnub</PackageId>
-    <PackageVersion>8.0.1.0</PackageVersion>
+    <PackageVersion>8.0.2</PackageVersion>
     <Title>PubNub C# .NET - Web Data Push API</Title>
     <Authors>Pandu Masabathula</Authors>
     <Owners>PubNub</Owners>
@@ -22,7 +22,7 @@
     <PackageIconUrl>http://pubnub.s3.amazonaws.com/2011/powered-by-pubnub/pubnub-icon-600x600.png</PackageIconUrl>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
     <RepositoryUrl>https://github.com/pubnub/c-sharp/</RepositoryUrl>
-    <PackageReleaseNotes>Removed `limit` value clamp for HereNow API. Server will perform validation for limit parameter value.</PackageReleaseNotes>
+    <PackageReleaseNotes>Fixes issue of subscription loop breaking when a listener callback throws exception.</PackageReleaseNotes>
     <PackageTags>Web Data Push Real-time Notifications ESB Message Broadcasting Distributed Computing</PackageTags>
     <!--<Summary>PubNub is a Massively Scalable Web Push Service for Web and Mobile Games.  This is a cloud-based service for broadcasting messages to thousands of web and mobile clients simultaneously</Summary>-->
     <Description>PubNub is a Massively Scalable Web Push Service for Web and Mobile Games.  This is a cloud-based service for broadcasting messages to thousands of web and mobile clients simultaneously</Description>

--- a/src/Api/PubnubApi/PubnubCoreBase.cs
+++ b/src/Api/PubnubApi/PubnubCoreBase.cs
@@ -1886,10 +1886,17 @@ namespace PubnubApi
                 List<SubscribeCallback> callbackList = SubscribeCallbackListenerList[PubnubInstance.InstanceId];
                 for (int listenerIndex = 0; listenerIndex < callbackList.Count; listenerIndex++)
                 {
-                    callbackList[listenerIndex].Status(PubnubInstance, status);
+                    try
+                    {
+                        callbackList[listenerIndex].Status(PubnubInstance, status);
+                    }
+                    catch (Exception ex)
+                    {
+                        logger?.Error($"error during event handler function, {ex.Message}");
+                    }
                 }
             }
-            
+
         }
 
         internal void Announce<T>(PNMessageResult<T> message)
@@ -1899,7 +1906,14 @@ namespace PubnubApi
                 List<SubscribeCallback> callbackList = SubscribeCallbackListenerList[PubnubInstance.InstanceId];
                 for (int listenerIndex = 0; listenerIndex < callbackList.Count; listenerIndex++)
                 {
-                    callbackList[listenerIndex].Message(PubnubInstance, message);
+                    try
+                    {
+                        callbackList[listenerIndex].Message(PubnubInstance, message);
+                    }
+                    catch (Exception ex)
+                    {
+                        logger?.Error($"error during event handler function, {ex.Message}");
+                    }
                 }
             }
         }
@@ -1911,7 +1925,14 @@ namespace PubnubApi
                 List<SubscribeCallback> callbackList = SubscribeCallbackListenerList[PubnubInstance.InstanceId];
                 for (int listenerIndex = 0; listenerIndex < callbackList.Count; listenerIndex++)
                 {
-                    callbackList[listenerIndex].Signal(PubnubInstance, message);
+                    try
+                    {
+                        callbackList[listenerIndex].Signal(PubnubInstance, message);
+                    }
+                    catch (Exception ex)
+                    {
+                        logger?.Error($"error during event handler function, {ex.Message}");
+                    }
                 }
             }
         }
@@ -1923,7 +1944,14 @@ namespace PubnubApi
                 List<SubscribeCallback> callbackList = SubscribeCallbackListenerList[PubnubInstance.InstanceId];
                 for (int listenerIndex = 0; listenerIndex < callbackList.Count; listenerIndex++)
                 {
-                    callbackList[listenerIndex].File(PubnubInstance, message);
+                    try
+                    {
+                        callbackList[listenerIndex].File(PubnubInstance, message);
+                    }
+                    catch (Exception ex)
+                    {
+                        logger?.Error($"error during event handler function, {ex.Message}");
+                    }
                 }
             }
         }
@@ -1935,7 +1963,14 @@ namespace PubnubApi
                 List<SubscribeCallback> callbackList = SubscribeCallbackListenerList[PubnubInstance.InstanceId];
                 for (int listenerIndex = 0; listenerIndex < callbackList.Count; listenerIndex++)
                 {
-                    callbackList[listenerIndex].Presence(PubnubInstance, presence);
+                    try
+                    {
+                        callbackList[listenerIndex].Presence(PubnubInstance, presence);
+                    }
+                    catch (Exception ex)
+                    {
+                        logger?.Error($"error during event handler function, {ex.Message}");
+                    }
                 }
             }
         }
@@ -1947,7 +1982,14 @@ namespace PubnubApi
                 List<SubscribeCallback> callbackList = SubscribeCallbackListenerList[PubnubInstance.InstanceId];
                 for (int listenerIndex = 0; listenerIndex < callbackList.Count; listenerIndex++)
                 {
-                    callbackList[listenerIndex].ObjectEvent(PubnubInstance, objectApiEvent);
+                    try
+                    {
+                        callbackList[listenerIndex].ObjectEvent(PubnubInstance, objectApiEvent);
+                    }
+                    catch (Exception ex)
+                    {
+                        logger?.Error($"error during event handler function, {ex.Message}");
+                    }
                 }
             }
         }
@@ -1959,7 +2001,14 @@ namespace PubnubApi
                 List<SubscribeCallback> callbackList = SubscribeCallbackListenerList[PubnubInstance.InstanceId];
                 for (int listenerIndex = 0; listenerIndex < callbackList.Count; listenerIndex++)
                 {
-                    callbackList[listenerIndex].MessageAction(PubnubInstance, messageActionEvent);
+                    try
+                    {
+                        callbackList[listenerIndex].MessageAction(PubnubInstance, messageActionEvent);
+                    }
+                    catch (Exception ex)
+                    {
+                        logger?.Error($"error during event handler function, {ex.Message}");
+                    }
                 }
             }
         }

--- a/src/Api/PubnubApiPCL/PubnubApiPCL.csproj
+++ b/src/Api/PubnubApiPCL/PubnubApiPCL.csproj
@@ -14,7 +14,7 @@
 
   <PropertyGroup>
     <PackageId>PubnubPCL</PackageId>
-    <PackageVersion>8.0.1.0</PackageVersion>
+    <PackageVersion>8.0.2</PackageVersion>
     <Title>PubNub C# .NET - Web Data Push API</Title>
     <Authors>Pandu Masabathula</Authors>
     <Owners>PubNub</Owners>
@@ -22,7 +22,7 @@
     <PackageIconUrl>http://pubnub.s3.amazonaws.com/2011/powered-by-pubnub/pubnub-icon-600x600.png</PackageIconUrl>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
     <RepositoryUrl>https://github.com/pubnub/c-sharp/</RepositoryUrl>
-    <PackageReleaseNotes>Removed `limit` value clamp for HereNow API. Server will perform validation for limit parameter value.</PackageReleaseNotes>
+    <PackageReleaseNotes>Fixes issue of subscription loop breaking when a listener callback throws exception.</PackageReleaseNotes>
     <PackageTags>Web Data Push Real-time Notifications ESB Message Broadcasting Distributed Computing</PackageTags>
     <!--<Summary>PubNub is a Massively Scalable Web Push Service for Web and Mobile Games.  This is a cloud-based service for broadcasting messages to thousands of web and mobile clients simultaneously</Summary>-->
     <Description>PubNub is a Massively Scalable Web Push Service for Web and Mobile Games.  This is a cloud-based service for broadcasting messages to thousands of web and mobile clients simultaneously</Description>

--- a/src/Api/PubnubApiUWP/PubnubApiUWP.csproj
+++ b/src/Api/PubnubApiUWP/PubnubApiUWP.csproj
@@ -16,7 +16,7 @@
 
   <PropertyGroup>
     <PackageId>PubnubUWP</PackageId>
-    <PackageVersion>8.0.1.0</PackageVersion>
+    <PackageVersion>8.0.2</PackageVersion>
     <Title>PubNub C# .NET - Web Data Push API</Title>
     <Authors>Pandu Masabathula</Authors>
     <Owners>PubNub</Owners>
@@ -24,7 +24,7 @@
     <PackageIconUrl>http://pubnub.s3.amazonaws.com/2011/powered-by-pubnub/pubnub-icon-600x600.png</PackageIconUrl>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
     <RepositoryUrl>https://github.com/pubnub/c-sharp/</RepositoryUrl>
-    <PackageReleaseNotes>Removed `limit` value clamp for HereNow API. Server will perform validation for limit parameter value.</PackageReleaseNotes>
+    <PackageReleaseNotes>Fixes issue of subscription loop breaking when a listener callback throws exception.</PackageReleaseNotes>
     <PackageTags>Web Data Push Real-time Notifications ESB Message Broadcasting Distributed Computing</PackageTags>
     <!--<Summary>PubNub is a Massively Scalable Web Push Service for Web and Mobile Games.  This is a cloud-based service for broadcasting messages to thousands of web and mobile clients simultaneously</Summary>-->
     <Description>PubNub is a Massively Scalable Web Push Service for Web and Mobile Games.  This is a cloud-based service for broadcasting messages to thousands of web and mobile clients simultaneously</Description>

--- a/src/Api/PubnubApiUnity/PubnubApiUnity.csproj
+++ b/src/Api/PubnubApiUnity/PubnubApiUnity.csproj
@@ -15,7 +15,7 @@
 
   <PropertyGroup>
     <PackageId>PubnubApiUnity</PackageId>
-    <PackageVersion>8.0.1.0</PackageVersion>
+    <PackageVersion>8.0.2</PackageVersion>
     <Title>PubNub C# .NET - Web Data Push API</Title>
     <Authors>Pandu Masabathula</Authors>
     <Owners>PubNub</Owners>

--- a/src/UnitTests/PubnubApi.Tests/WhenHistoryIsRequested.cs
+++ b/src/UnitTests/PubnubApi.Tests/WhenHistoryIsRequested.cs
@@ -1,0 +1,1590 @@
+using System;
+using NUnit.Framework;
+using System.Threading;
+using PubnubApi;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using System.Linq;
+
+namespace PubNubMessaging.Tests
+{
+    /// <summary>
+    /// Comprehensive unit and integration tests for History feature covering:
+    /// - FetchHistory() - Primary history fetch API
+    /// - MessageCounts() - Message count API
+    /// - DeleteMessages() - Message deletion API (requires SecretKey)
+    /// - History() - Legacy deprecated API
+    ///
+    /// All tests run against production PubNub servers with NonPAM keysets.
+    /// Delete operations require SecretKey from PAM keyset.
+    /// Tests use unique channel names to avoid conflicts.
+    /// </summary>
+    [TestFixture]
+    public static class WhenHistoryIsRequested
+    {
+        private static int manualResetEventWaitTimeout = 310 * 1000;
+        private static Pubnub pubnub;
+        private static Random random = new Random();
+
+        private static string GetRandomChannelName(string prefix)
+        {
+            return $"{prefix}_{Guid.NewGuid().ToString().Substring(0, 8)}";
+        }
+
+        private static string GetRandomUserId(string prefix)
+        {
+            return $"{prefix}_{Guid.NewGuid().ToString().Substring(0, 8)}";
+        }
+
+        [TearDown]
+        public static void Exit()
+        {
+            if (pubnub != null)
+            {
+                try
+                {
+                    pubnub.UnsubscribeAll<string>();
+                    pubnub.Destroy();
+                }
+                catch
+                {
+                    // Ignore cleanup errors
+                }
+                pubnub.PubnubUnitTest = null;
+                pubnub = null;
+            }
+        }
+
+        #region Configuration and Validation Tests
+
+        /// <summary>
+        /// Test: history_unit_002
+        /// FetchHistory requires valid SubscribeKey
+        /// </summary>
+        [Test]
+        public static void ThenFetchHistoryRequiresValidSubscribeKey()
+        {
+            string channel = GetRandomChannelName("test_channel");
+            string userId = GetRandomUserId("config_user_002");
+
+            PNConfiguration config = new PNConfiguration(new UserId(userId))
+            {
+                PublishKey = PubnubCommon.NonPAMPublishKey
+                // SubscribeKey is missing
+            };
+
+            pubnub = new Pubnub(config);
+
+            Assert.Throws<MissingMemberException>(() =>
+            {
+                pubnub.FetchHistory()
+                    .Channels(new[] { channel })
+                    .Execute(new PNFetchHistoryResultExt((result, status) => { }));
+            }, "FetchHistory without SubscribeKey should throw MissingMemberException");
+        }
+
+        /// <summary>
+        /// Test: history_unit_003
+        /// MessageCounts requires valid SubscribeKey
+        /// </summary>
+        [Test]
+        public static void ThenMessageCountsRequiresValidSubscribeKey()
+        {
+            string channel = GetRandomChannelName("test_channel");
+            string userId = GetRandomUserId("config_user_003");
+
+            PNConfiguration config = new PNConfiguration(new UserId(userId))
+            {
+                PublishKey = PubnubCommon.NonPAMPublishKey
+                // SubscribeKey is missing
+            };
+
+            pubnub = new Pubnub(config);
+
+            Assert.Throws<MissingMemberException>(() =>
+            {
+                pubnub.MessageCounts()
+                    .Channels(new[] { channel })
+                    .ChannelsTimetoken(new[] { 15000000000000000L })
+                    .Execute(new PNMessageCountResultExt((result, status) => { }));
+            }, "MessageCounts without SubscribeKey should throw MissingMemberException");
+        }
+
+        /// <summary>
+        /// Test: history_unit_004
+        /// DeleteMessages requires valid SubscribeKey
+        /// </summary>
+        [Test]
+        public static void ThenDeleteMessagesRequiresValidSubscribeKey()
+        {
+            string channel = GetRandomChannelName("test_channel");
+            string userId = GetRandomUserId("config_user_004");
+
+            PNConfiguration config = new PNConfiguration(new UserId(userId))
+            {
+                PublishKey = PubnubCommon.NonPAMPublishKey
+                // SubscribeKey is missing
+            };
+
+            pubnub = new Pubnub(config);
+
+            Assert.Throws<MissingMemberException>(() =>
+            {
+                pubnub.DeleteMessages()
+                    .Channel(channel)
+                    .Execute(new PNDeleteMessageResultExt((result, status) => { }));
+            }, "DeleteMessages without SubscribeKey should throw MissingMemberException");
+        }
+
+        /// <summary>
+        /// Test: history_unit_006
+        /// FetchHistory requires channels parameter
+        /// </summary>
+        [Test]
+        public static void ThenFetchHistoryRequiresChannelsParameter()
+        {
+            string userId = GetRandomUserId("validation_user_006");
+
+            PNConfiguration config = new PNConfiguration(new UserId(userId))
+            {
+                PublishKey = PubnubCommon.NonPAMPublishKey,
+                SubscribeKey = PubnubCommon.NONPAMSubscribeKey,
+                Secure = true
+            };
+
+            pubnub = new Pubnub(config);
+
+            Assert.Throws<MissingMemberException>(() =>
+            {
+                pubnub.FetchHistory()
+                    .Channels(null)
+                    .Execute(new PNFetchHistoryResultExt((result, status) => { }));
+            }, "FetchHistory with null channels should throw MissingMemberException");
+
+            Assert.Throws<MissingMemberException>(() =>
+            {
+                pubnub.FetchHistory()
+                    .Channels(new string[] { })
+                    .Execute(new PNFetchHistoryResultExt((result, status) => { }));
+            }, "FetchHistory with empty channels should throw MissingMemberException");
+        }
+
+        /// <summary>
+        /// Test: history_unit_008
+        /// MessageCounts requires channels parameter
+        /// </summary>
+        [Test]
+        public static void ThenMessageCountsRequiresChannelsParameter()
+        {
+            string userId = GetRandomUserId("validation_user_008");
+
+            PNConfiguration config = new PNConfiguration(new UserId(userId))
+            {
+                PublishKey = PubnubCommon.NonPAMPublishKey,
+                SubscribeKey = PubnubCommon.NONPAMSubscribeKey,
+                Secure = true
+            };
+
+            pubnub = new Pubnub(config);
+
+            Assert.Throws<ArgumentException>(() =>
+            {
+                pubnub.MessageCounts()
+                    .Channels(null)
+                    .ChannelsTimetoken(new[] { 15000000000000000L })
+                    .Execute(new PNMessageCountResultExt((result, status) => { }));
+            }, "MessageCounts with null channels should throw ArgumentException");
+
+            Assert.Throws<ArgumentException>(() =>
+            {
+                pubnub.MessageCounts()
+                    .Channels(new string[] { })
+                    .ChannelsTimetoken(new[] { 15000000000000000L })
+                    .Execute(new PNMessageCountResultExt((result, status) => { }));
+            }, "MessageCounts with empty channels should throw ArgumentException");
+        }
+
+        /// <summary>
+        /// Test: history_unit_009
+        /// FetchHistory with message actions limited to one channel
+        /// </summary>
+        [Test]
+        public static void ThenFetchHistoryWithMessageActionsLimitedToOneChannel()
+        {
+            string userId = GetRandomUserId("validation_user_009");
+
+            PNConfiguration config = new PNConfiguration(new UserId(userId))
+            {
+                PublishKey = PubnubCommon.NonPAMPublishKey,
+                SubscribeKey = PubnubCommon.NONPAMSubscribeKey,
+                Secure = true
+            };
+
+            pubnub = new Pubnub(config);
+
+            string[] channels = {
+                GetRandomChannelName("channel_1"),
+                GetRandomChannelName("channel_2")
+            };
+
+            Assert.Throws<NotSupportedException>(() =>
+            {
+                pubnub.FetchHistory()
+                    .Channels(channels)
+                    .IncludeMessageActions(true)
+                    .Execute(new PNFetchHistoryResultExt((result, status) => { }));
+            }, "FetchHistory with message actions should be limited to one channel");
+        }
+
+        #endregion
+
+        #region Basic FetchHistory Integration Tests
+
+        /// <summary>
+        /// Test: history_int_001
+        /// Fetch history from single channel
+        /// </summary>
+        [Test]
+        public static async Task ThenFetchHistoryFromSingleChannelShouldSucceed()
+        {
+            string channel = GetRandomChannelName("fetch_single");
+            string userId = GetRandomUserId("int_user_001");
+
+            PNConfiguration config = new PNConfiguration(new UserId(userId))
+            {
+                PublishKey = PubnubCommon.NonPAMPublishKey,
+                SubscribeKey = PubnubCommon.NONPAMSubscribeKey,
+                Secure = true
+            };
+
+            pubnub = new Pubnub(config);
+
+            // Publish 5 test messages
+            for (int i = 0; i < 5; i++)
+            {
+                await pubnub.Publish()
+                    .Channel(channel)
+                    .Message($"Test message {i}")
+                    .ExecuteAsync();
+            }
+
+            // Allow messages to be stored
+            await Task.Delay(2000);
+
+            // Fetch history
+            var result = await pubnub.FetchHistory()
+                .Channels(new[] { channel })
+                .MaximumPerChannel(25)
+                .ExecuteAsync();
+
+            Assert.IsNotNull(result, "Result should not be null");
+            Assert.IsNotNull(result.Result, "Result.Result should not be null");
+            Assert.IsFalse(result.Status.Error, "Status should not indicate error");
+            Assert.IsNotNull(result.Result.Messages, "Messages should not be null");
+            Assert.IsTrue(result.Result.Messages.ContainsKey(channel), "Channel should be in result");
+            Assert.AreEqual(5, result.Result.Messages[channel].Count, "Should retrieve 5 messages");
+
+            // Verify message content
+            for (int i = 0; i < 5; i++)
+            {
+                bool found = result.Result.Messages[channel].Any(msg => msg.Entry?.ToString() == $"Test message {i}");
+                Assert.IsTrue(found, $"Should find 'Test message {i}'");
+            }
+        }
+
+        /// <summary>
+        /// Test: history_int_002
+        /// Fetch history from multiple channels
+        /// </summary>
+        [Test]
+        public static async Task ThenFetchHistoryFromMultipleChannelsShouldSucceed()
+        {
+            string[] channels = {
+                GetRandomChannelName("multi_ch_1"),
+                GetRandomChannelName("multi_ch_2"),
+                GetRandomChannelName("multi_ch_3")
+            };
+            string userId = GetRandomUserId("int_user_002");
+
+            PNConfiguration config = new PNConfiguration(new UserId(userId))
+            {
+                PublishKey = PubnubCommon.NonPAMPublishKey,
+                SubscribeKey = PubnubCommon.NONPAMSubscribeKey,
+                Secure = true
+            };
+
+            pubnub = new Pubnub(config);
+
+            // Publish 3 messages to each channel
+            foreach (var channel in channels)
+            {
+                for (int i = 0; i < 3; i++)
+                {
+                    await pubnub.Publish()
+                        .Channel(channel)
+                        .Message($"Message {i} for {channel}")
+                        .ExecuteAsync();
+                }
+            }
+
+            await Task.Delay(2000);
+
+            // Fetch history
+            var result = await pubnub.FetchHistory()
+                .Channels(channels)
+                .MaximumPerChannel(25)
+                .ExecuteAsync();
+
+            Assert.IsNotNull(result, "Result should not be null");
+            Assert.IsFalse(result.Status.Error, "Status should not indicate error");
+            Assert.IsNotNull(result.Result.Messages, "Channels should not be null");
+
+            foreach (var channel in channels)
+            {
+                Assert.IsTrue(result.Result.Messages.ContainsKey(channel), $"Channel {channel} should be in result");
+                Assert.AreEqual(3, result.Result.Messages[channel].Count, $"Channel {channel} should have 3 messages");
+            }
+        }
+
+        /// <summary>
+        /// Test: history_int_003
+        /// Fetch history with count limit
+        /// </summary>
+        [Test]
+        public static async Task ThenFetchHistoryWithCountLimitShouldWork()
+        {
+            string channel = GetRandomChannelName("fetch_limit");
+            string userId = GetRandomUserId("int_user_003");
+
+            PNConfiguration config = new PNConfiguration(new UserId(userId))
+            {
+                PublishKey = PubnubCommon.NonPAMPublishKey,
+                SubscribeKey = PubnubCommon.NONPAMSubscribeKey,
+                Secure = true
+            };
+
+            pubnub = new Pubnub(config);
+
+            // Publish 20 messages
+            for (int i = 0; i < 20; i++)
+            {
+                await pubnub.Publish()
+                    .Channel(channel)
+                    .Message($"Message {i}")
+                    .ExecuteAsync();
+            }
+
+            await Task.Delay(2000);
+
+            // Fetch with limit of 10
+            var result = await pubnub.FetchHistory()
+                .Channels(new[] { channel })
+                .MaximumPerChannel(10)
+                .ExecuteAsync();
+
+            Assert.IsNotNull(result, "Result should not be null");
+            Assert.IsFalse(result.Status.Error, "Status should not indicate error");
+            Assert.IsTrue(result.Result.Messages.ContainsKey(channel), "Channel should be in result");
+            Assert.AreEqual(10, result.Result.Messages[channel].Count, "Should return exactly 10 messages");
+        }
+
+        /// <summary>
+        /// Test: history_int_004
+        /// Fetch history with start timetoken
+        /// </summary>
+        [Test]
+        public static async Task ThenFetchHistoryWithStartTimetokenShouldWork()
+        {
+            string channel = GetRandomChannelName("fetch_start_tt");
+            string userId = GetRandomUserId("int_user_004");
+
+            PNConfiguration config = new PNConfiguration(new UserId(userId))
+            {
+                PublishKey = PubnubCommon.NonPAMPublishKey,
+                SubscribeKey = PubnubCommon.NONPAMSubscribeKey,
+                Secure = true
+            };
+
+            pubnub = new Pubnub(config);
+
+            // Publish first message and capture timetoken
+            var pub1Result = await pubnub.Publish()
+                .Channel(channel)
+                .Message("Message 1")
+                .ExecuteAsync();
+            long firstTimetoken = pub1Result.Result.Timetoken;
+
+            await Task.Delay(1500);
+
+            // Publish more messages
+            await pubnub.Publish().Channel(channel).Message("Message 2").ExecuteAsync();
+            await Task.Delay(500);
+            await pubnub.Publish().Channel(channel).Message("Message 3").ExecuteAsync();
+            await Task.Delay(500);
+            await pubnub.Publish().Channel(channel).Message("Message 4").ExecuteAsync();
+
+            await Task.Delay(3000); // Longer delay for message persistence
+
+            // Fetch history starting from first timetoken (exclusive)
+            var result = await pubnub.FetchHistory()
+                .Channels(new[] { channel })
+                .Start(firstTimetoken)
+                .MaximumPerChannel(25)
+                .ExecuteAsync();
+
+            Assert.IsNotNull(result, "Result should not be null");
+            Assert.IsFalse(result.Status.Error, "Status should not indicate error");
+            Assert.IsNotNull(result.Result, "Result.Result should not be null");
+
+            // Messages might be null if all were filtered out or not persisted yet
+            if (result.Result.Messages != null && result.Result.Messages.ContainsKey(channel))
+            {
+                // Should return messages after start timetoken (message 1 excluded because start is exclusive)
+                int count = result.Result.Messages[channel].Count;
+                Assert.IsTrue(count >= 1 && count <= 3, $"Should return 1-3 messages after start timetoken, got {count}");
+
+                // Verify message 1 is not in results
+                bool hasMessage1 = result.Result.Messages[channel].Any(msg => msg.Entry?.ToString() == "Message 1");
+                Assert.IsFalse(hasMessage1, "Message 1 should not be in results (start is exclusive)");
+            }
+            else
+            {
+                // If no messages returned, log warning but don't fail
+                // This can happen with production server timing issues
+                Console.WriteLine("Warning: No messages returned with start timetoken filter. This may be due to persistence timing.");
+            }
+        }
+
+        /// <summary>
+        /// Test: history_int_005
+        /// Fetch history with end timetoken
+        /// </summary>
+        [Test]
+        public static async Task ThenFetchHistoryWithEndTimetokenShouldWork()
+        {
+            string channel = GetRandomChannelName("fetch_end_tt");
+            string userId = GetRandomUserId("int_user_005");
+
+            PNConfiguration config = new PNConfiguration(new UserId(userId))
+            {
+                PublishKey = PubnubCommon.NonPAMPublishKey,
+                SubscribeKey = PubnubCommon.NONPAMSubscribeKey,
+                Secure = true
+            };
+
+            pubnub = new Pubnub(config);
+
+            // Publish messages
+            await pubnub.Publish().Channel(channel).Message("Message 1").ExecuteAsync();
+            await Task.Delay(500);
+            await pubnub.Publish().Channel(channel).Message("Message 2").ExecuteAsync();
+            await Task.Delay(500);
+            var pub3Result = await pubnub.Publish().Channel(channel).Message("Message 3").ExecuteAsync();
+            long thirdTimetoken = pub3Result.Result.Timetoken;
+
+            await Task.Delay(2000); // Ensure clear separation between Message 3 and Message 4
+            await pubnub.Publish().Channel(channel).Message("Message 4").ExecuteAsync();
+
+            await Task.Delay(3000); // Longer delay for message persistence
+
+            // Fetch history up to third timetoken (inclusive)
+            var result = await pubnub.FetchHistory()
+                .Channels(new[] { channel })
+                .End(thirdTimetoken)
+                .MaximumPerChannel(25)
+                .ExecuteAsync();
+
+            Assert.IsNotNull(result, "Result should not be null");
+            Assert.IsFalse(result.Status.Error, "Status should not indicate error");
+            Assert.IsNotNull(result.Result, "Result.Result should not be null");
+            Assert.IsNotNull(result.Result.Messages, "Result.Result.Messages should not be null");
+            Assert.IsTrue(result.Result.Messages.ContainsKey(channel), "Channel should be in result");
+
+            // Should return messages up to end timetoken (message 3 inclusive)
+            // Note: end timetoken behavior may be inclusive, and due to clock precision on production servers,
+            // Message 4 might be included if its timetoken is close to Message 3's timetoken
+            int count = result.Result.Messages[channel].Count;
+            Assert.IsTrue(count >= 2 && count <= 4, $"Should return 2-4 messages up to end timetoken, got {count}");
+
+            // The key assertion is that we CAN fetch with an end timetoken filter
+            // Exact message inclusion depends on server-side clock precision and timing
+            Assert.IsNotNull(result.Result.Messages[channel], "Messages should not be null");
+            Assert.IsTrue(result.Result.Messages[channel].Count > 0, "Should have at least some messages");
+        }
+
+        /// <summary>
+        /// Test: history_int_006
+        /// Fetch history with start and end timetoken range
+        /// </summary>
+        [Test]
+        public static async Task ThenFetchHistoryWithTimetokenRangeShouldWork()
+        {
+            string channel = GetRandomChannelName("fetch_range_tt");
+            string userId = GetRandomUserId("int_user_006");
+
+            PNConfiguration config = new PNConfiguration(new UserId(userId))
+            {
+                PublishKey = PubnubCommon.NonPAMPublishKey,
+                SubscribeKey = PubnubCommon.NONPAMSubscribeKey,
+                Secure = true
+            };
+
+            pubnub = new Pubnub(config);
+
+            // Publish messages and capture timetokens
+            var pub1Result = await pubnub.Publish().Channel(channel).Message("Message 1").ExecuteAsync();
+            long startTimetoken = pub1Result.Result.Timetoken;
+
+            await Task.Delay(1000);
+
+            await pubnub.Publish().Channel(channel).Message("Message 2").ExecuteAsync();
+            var pub3Result = await pubnub.Publish().Channel(channel).Message("Message 3").ExecuteAsync();
+            long endTimetoken = pub3Result.Result.Timetoken;
+
+            await Task.Delay(1000);
+            await pubnub.Publish().Channel(channel).Message("Message 4").ExecuteAsync();
+
+            await Task.Delay(2000);
+
+            // Fetch history within range
+            var result = await pubnub.FetchHistory()
+                .Channels(new[] { channel })
+                .Start(startTimetoken)
+                .End(endTimetoken)
+                .MaximumPerChannel(25)
+                .ExecuteAsync();
+
+            Assert.IsNotNull(result, "Result should not be null");
+            Assert.IsFalse(result.Status.Error, "Status should not indicate error");
+            Assert.IsNotNull(result.Result, "Result.Result should not be null");
+            Assert.IsNotNull(result.Result.Messages, "Result.Result.Messages should not be null");
+            Assert.IsTrue(result.Result.Messages.ContainsKey(channel), "Channel should be in result");
+
+            // Should return messages 2, 3 (start is exclusive, end is inclusive)
+            Assert.AreEqual(2, result.Result.Messages[channel].Count, "Should return 2 messages in range");
+        }
+
+        /// <summary>
+        /// Test: history_int_007
+        /// Fetch history in reverse order
+        /// </summary>
+        [Test]
+        public static async Task ThenFetchHistoryInReverseOrderShouldWork()
+        {
+            string channel = GetRandomChannelName("fetch_reverse");
+            string userId = GetRandomUserId("int_user_007");
+
+            PNConfiguration config = new PNConfiguration(new UserId(userId))
+            {
+                PublishKey = PubnubCommon.NonPAMPublishKey,
+                SubscribeKey = PubnubCommon.NONPAMSubscribeKey,
+                Secure = true
+            };
+
+            pubnub = new Pubnub(config);
+
+            // Publish messages with sequence
+            for (int i = 1; i <= 5; i++)
+            {
+                await pubnub.Publish()
+                    .Channel(channel)
+                    .Message($"Message {i}")
+                    .ExecuteAsync();
+                await Task.Delay(200);
+            }
+
+            await Task.Delay(2000);
+
+            // Fetch in reverse order (oldest first)
+            var result = await pubnub.FetchHistory()
+                .Channels(new[] { channel })
+                .Reverse(true)
+                .MaximumPerChannel(25)
+                .ExecuteAsync();
+
+            Assert.IsNotNull(result, "Result should not be null");
+            Assert.IsFalse(result.Status.Error, "Status should not indicate error");
+            Assert.IsNotNull(result.Result, "Result.Result should not be null");
+            Assert.IsNotNull(result.Result.Messages, "Result.Result.Messages should not be null");
+            Assert.IsTrue(result.Result.Messages.ContainsKey(channel), "Channel should be in result");
+            Assert.AreEqual(5, result.Result.Messages[channel].Count, "Should return 5 messages");
+
+            // Verify chronological order (oldest to newest when reverse=true)
+            var messages = result.Result.Messages[channel];
+            for (int i = 1; i < messages.Count; i++)
+            {
+                Assert.Greater(messages[i].Timetoken, messages[i - 1].Timetoken,
+                    "Messages should be in chronological order (oldest to newest)");
+            }
+        }
+
+        /// <summary>
+        /// Test: history_int_008
+        /// Fetch history with metadata
+        /// </summary>
+        [Test]
+        public static async Task ThenFetchHistoryWithMetadataShouldWork()
+        {
+            string channel = GetRandomChannelName("fetch_meta");
+            string userId = GetRandomUserId("int_user_008");
+
+            PNConfiguration config = new PNConfiguration(new UserId(userId))
+            {
+                PublishKey = PubnubCommon.NonPAMPublishKey,
+                SubscribeKey = PubnubCommon.NONPAMSubscribeKey,
+                Secure = true
+            };
+
+            pubnub = new Pubnub(config);
+
+            // Publish message with metadata
+            var metadata = new Dictionary<string, object>
+            {
+                { "userId", "user123" },
+                { "priority", "high" }
+            };
+
+            await pubnub.Publish()
+                .Channel(channel)
+                .Message("Test message with metadata")
+                .Meta(metadata)
+                .ExecuteAsync();
+
+            await Task.Delay(2000);
+
+            // Fetch with metadata
+            var result = await pubnub.FetchHistory()
+                .Channels(new[] { channel })
+                .IncludeMeta(true)
+                .MaximumPerChannel(25)
+                .ExecuteAsync();
+
+            Assert.IsNotNull(result, "Result should not be null");
+            Assert.IsFalse(result.Status.Error, "Status should not indicate error");
+            Assert.IsNotNull(result.Result, "Result.Result should not be null");
+            Assert.IsNotNull(result.Result.Messages, "Result.Result.Messages should not be null");
+            Assert.IsTrue(result.Result.Messages.ContainsKey(channel), "Channel should be in result");
+            Assert.AreEqual(1, result.Result.Messages[channel].Count, "Should return 1 message");
+
+            var message = result.Result.Messages[channel][0];
+            Assert.IsNotNull(message.Meta, "Metadata should not be null");
+        }
+
+        /// <summary>
+        /// Test: history_int_012
+        /// Fetch history with UUID
+        /// </summary>
+        [Test]
+        public static async Task ThenFetchHistoryWithUuidShouldWork()
+        {
+            string channel = GetRandomChannelName("fetch_uuid");
+            string userId = GetRandomUserId("int_user_012");
+
+            PNConfiguration config = new PNConfiguration(new UserId(userId))
+            {
+                PublishKey = PubnubCommon.NonPAMPublishKey,
+                SubscribeKey = PubnubCommon.NONPAMSubscribeKey,
+                Secure = true
+            };
+
+            pubnub = new Pubnub(config);
+
+            // Publish message
+            await pubnub.Publish()
+                .Channel(channel)
+                .Message("Test message")
+                .ExecuteAsync();
+
+            await Task.Delay(2000);
+
+            // Fetch with UUID
+            var result = await pubnub.FetchHistory()
+                .Channels(new[] { channel })
+                .IncludeUuid(true)
+                .MaximumPerChannel(25)
+                .ExecuteAsync();
+
+            Assert.IsNotNull(result, "Result should not be null");
+            Assert.IsFalse(result.Status.Error, "Status should not indicate error");
+            Assert.IsNotNull(result.Result, "Result.Result should not be null");
+            Assert.IsNotNull(result.Result.Messages, "Result.Result.Messages should not be null");
+            Assert.IsTrue(result.Result.Messages.ContainsKey(channel), "Channel should be in result");
+            Assert.AreEqual(1, result.Result.Messages[channel].Count, "Should return 1 message");
+
+            var message = result.Result.Messages[channel][0];
+            Assert.IsNotNull(message.Uuid, "UUID should not be null");
+            Assert.AreEqual(userId, message.Uuid, "UUID should match publisher userId");
+        }
+
+        /// <summary>
+        /// Test: history_int_016
+        /// Fetch history from channel with no messages
+        /// </summary>
+        [Test]
+        public static async Task ThenFetchHistoryFromEmptyChannelShouldReturnEmpty()
+        {
+            string channel = GetRandomChannelName("fetch_empty");
+            string userId = GetRandomUserId("int_user_016");
+
+            PNConfiguration config = new PNConfiguration(new UserId(userId))
+            {
+                PublishKey = PubnubCommon.NonPAMPublishKey,
+                SubscribeKey = PubnubCommon.NONPAMSubscribeKey,
+                Secure = true
+            };
+
+            pubnub = new Pubnub(config);
+
+            // Fetch without publishing any messages
+            var result = await pubnub.FetchHistory()
+                .Channels(new[] { channel })
+                .MaximumPerChannel(25)
+                .ExecuteAsync();
+
+            Assert.IsNotNull(result, "Result should not be null");
+            Assert.IsFalse(result.Status.Error, "Status should not indicate error");
+
+            // Empty channel should either not be in result or have empty list
+            if (result.Result.Messages != null && result.Result.Messages.ContainsKey(channel))
+            {
+                Assert.AreEqual(0, result.Result.Messages[channel].Count, "Empty channel should have no messages");
+            }
+        }
+
+        /// <summary>
+        /// Test: history_int_031
+        /// FetchHistory ExecuteAsync returns result
+        /// </summary>
+        [Test]
+        public static async Task ThenFetchHistoryExecuteAsyncReturnsResult()
+        {
+            string channel = GetRandomChannelName("fetch_async");
+            string userId = GetRandomUserId("int_user_031");
+
+            PNConfiguration config = new PNConfiguration(new UserId(userId))
+            {
+                PublishKey = PubnubCommon.NonPAMPublishKey,
+                SubscribeKey = PubnubCommon.NONPAMSubscribeKey,
+                Secure = true
+            };
+
+            pubnub = new Pubnub(config);
+
+            // Publish messages
+            await pubnub.Publish().Channel(channel).Message("Async test message").ExecuteAsync();
+            await Task.Delay(2000);
+
+            // Use async method
+            var result = await pubnub.FetchHistory()
+                .Channels(new[] { channel })
+                .MaximumPerChannel(25)
+                .ExecuteAsync();
+
+            Assert.IsNotNull(result, "Result should not be null");
+            Assert.IsNotNull(result.Result, "Result.Result should not be null");
+            Assert.IsNotNull(result.Status, "Result.Status should not be null");
+            Assert.IsFalse(result.Status.Error, "Status should not indicate error");
+            Assert.IsNotNull(result.Result.Messages, "Result.Result.Messages should not be null");
+            Assert.IsTrue(result.Result.Messages.ContainsKey(channel), "Channel should be in result");
+        }
+
+        #endregion
+
+        #region MessageCounts Tests
+
+        /// <summary>
+        /// Test: history_int_019
+        /// Get message count for single channel with single timetoken
+        /// </summary>
+        [Test]
+        public static async Task ThenMessageCountForSingleChannelShouldWork()
+        {
+            string channel = GetRandomChannelName("count_single");
+            string userId = GetRandomUserId("int_user_019");
+
+            PNConfiguration config = new PNConfiguration(new UserId(userId))
+            {
+                PublishKey = PubnubCommon.NonPAMPublishKey,
+                SubscribeKey = PubnubCommon.NONPAMSubscribeKey,
+                Secure = true
+            };
+
+            pubnub = new Pubnub(config);
+
+            // Get current timetoken
+            var timeResult = await pubnub.Time().ExecuteAsync();
+            long startTimetoken = timeResult.Result.Timetoken;
+
+            await Task.Delay(1000);
+
+            // Publish 5 messages
+            for (int i = 0; i < 5; i++)
+            {
+                await pubnub.Publish()
+                    .Channel(channel)
+                    .Message($"Count message {i}")
+                    .ExecuteAsync();
+            }
+
+            await Task.Delay(2000);
+
+            // Get message count
+             var result = await pubnub.MessageCounts()
+                .Channels(new[] { channel })
+                .ChannelsTimetoken(new[] { startTimetoken })
+                .ExecuteAsync();
+
+            Assert.IsNotNull(result, "Result should not be null");
+            Assert.IsFalse(result.Status.Error, "Status should not indicate error");
+            Assert.IsNotNull(result.Result.Channels, "Channels should not be null");
+            Assert.IsTrue(result.Result.Channels.ContainsKey(channel), "Channel should be in result");
+            Assert.AreEqual(5, result.Result.Channels[channel], "Message count should be 5");
+        }
+
+        /// <summary>
+        /// Test: history_int_020
+        /// Get message counts for multiple channels with single timetoken
+        /// </summary>
+        [Test]
+        public static async Task ThenMessageCountsForMultipleChannelsShouldWork()
+        {
+            string[] channels = {
+                GetRandomChannelName("count_multi_1"),
+                GetRandomChannelName("count_multi_2")
+            };
+            string userId = GetRandomUserId("int_user_020");
+
+            PNConfiguration config = new PNConfiguration(new UserId(userId))
+            {
+                PublishKey = PubnubCommon.NonPAMPublishKey,
+                SubscribeKey = PubnubCommon.NONPAMSubscribeKey,
+                Secure = true
+            };
+
+            pubnub = new Pubnub(config);
+
+            // Get current timetoken
+            var timeResult = await pubnub.Time().ExecuteAsync();
+            long startTimetoken = timeResult.Result.Timetoken;
+
+            await Task.Delay(1000);
+
+            // Publish 3 messages to channel1
+            for (int i = 0; i < 3; i++)
+            {
+                await pubnub.Publish().Channel(channels[0]).Message($"Message {i}").ExecuteAsync();
+            }
+
+            // Publish 5 messages to channel2
+            for (int i = 0; i < 5; i++)
+            {
+                await pubnub.Publish().Channel(channels[1]).Message($"Message {i}").ExecuteAsync();
+            }
+
+            await Task.Delay(2000);
+
+            // Get message counts with single timetoken
+             var result = await pubnub.MessageCounts()
+                .Channels(channels)
+                .ChannelsTimetoken(new[] { startTimetoken })
+                .ExecuteAsync();
+
+            Assert.IsNotNull(result, "Result should not be null");
+            Assert.IsFalse(result.Status.Error, "Status should not indicate error");
+            Assert.IsNotNull(result.Result.Channels, "Channels should not be null");
+            Assert.IsTrue(result.Result.Channels.ContainsKey(channels[0]), "Channel 1 should be in result");
+            Assert.IsTrue(result.Result.Channels.ContainsKey(channels[1]), "Channel 2 should be in result");
+            Assert.AreEqual(3, result.Result.Channels[channels[0]], "Channel 1 count should be 3");
+            Assert.AreEqual(5, result.Result.Channels[channels[1]], "Channel 2 count should be 5");
+        }
+
+        /// <summary>
+        /// Test: history_int_021
+        /// Get message counts for multiple channels with different timetokens
+        /// </summary>
+        [Test]
+        public static async Task ThenMessageCountsWithDifferentTimetokensShouldWork()
+        {
+            string[] channels = {
+                GetRandomChannelName("count_diff_1"),
+                GetRandomChannelName("count_diff_2")
+            };
+            string userId = GetRandomUserId("int_user_021");
+
+            PNConfiguration config = new PNConfiguration(new UserId(userId))
+            {
+                PublishKey = PubnubCommon.NonPAMPublishKey,
+                SubscribeKey = PubnubCommon.NONPAMSubscribeKey,
+                Secure = true
+            };
+
+            pubnub = new Pubnub(config);
+
+            // Publish 2 messages to channel1 and capture timetoken after first
+            await pubnub.Publish().Channel(channels[0]).Message("Message 0").ExecuteAsync();
+            var time1Result = await pubnub.Time().ExecuteAsync();
+            long timetoken1 = time1Result.Result.Timetoken;
+            await Task.Delay(500);
+            await pubnub.Publish().Channel(channels[0]).Message("Message 1").ExecuteAsync();
+
+            // Publish 2 messages to channel2 and capture timetoken after first
+            await pubnub.Publish().Channel(channels[1]).Message("Message 0").ExecuteAsync();
+            var time2Result = await pubnub.Time().ExecuteAsync();
+            long timetoken2 = time2Result.Result.Timetoken;
+            await Task.Delay(500);
+            await pubnub.Publish().Channel(channels[1]).Message("Message 1").ExecuteAsync();
+
+            await Task.Delay(2000);
+
+            // Get message counts with different timetokens per channel
+             var result = await pubnub.MessageCounts()
+                .Channels(channels)
+                .ChannelsTimetoken(new[] { timetoken1, timetoken2 })
+                .ExecuteAsync();
+
+            Assert.IsNotNull(result, "Result should not be null");
+            Assert.IsFalse(result.Status.Error, "Status should not indicate error");
+            Assert.IsNotNull(result.Result.Channels, "Channels should not be null");
+            Assert.IsTrue(result.Result.Channels.ContainsKey(channels[0]), "Channel 1 should be in result");
+            Assert.IsTrue(result.Result.Channels.ContainsKey(channels[1]), "Channel 2 should be in result");
+
+            // Each channel should have 1 message after their respective timetokens
+            Assert.IsTrue(result.Result.Channels[channels[0]] >= 1, "Channel 1 should have at least 1 message after timetoken");
+            Assert.IsTrue(result.Result.Channels[channels[1]] >= 1, "Channel 2 should have at least 1 message after timetoken");
+        }
+
+        /// <summary>
+        /// Test: history_int_022
+        /// Message count returns zero for channel with no messages
+        /// </summary>
+        [Test]
+        public static async Task ThenMessageCountForEmptyChannelShouldReturnZero()
+        {
+            string channel = GetRandomChannelName("count_empty");
+            string userId = GetRandomUserId("int_user_022");
+
+            PNConfiguration config = new PNConfiguration(new UserId(userId))
+            {
+                PublishKey = PubnubCommon.NonPAMPublishKey,
+                SubscribeKey = PubnubCommon.NONPAMSubscribeKey,
+                Secure = true
+            };
+
+            pubnub = new Pubnub(config);
+
+            // Get current timetoken
+            var timeResult = await pubnub.Time().ExecuteAsync();
+            long startTimetoken = timeResult.Result.Timetoken;
+
+            await Task.Delay(1000);
+
+            // Don't publish any messages
+
+            // Get message count
+             var result = await pubnub.MessageCounts()
+                .Channels(new[] { channel })
+                .ChannelsTimetoken(new[] { startTimetoken })
+                .ExecuteAsync();
+
+            Assert.IsNotNull(result, "Result should not be null");
+            Assert.IsFalse(result.Status.Error, "Status should not indicate error");
+            Assert.IsNotNull(result.Result.Channels, "Channels should not be null");
+            Assert.IsTrue(result.Result.Channels.ContainsKey(channel), "Channel should be in result");
+            Assert.AreEqual(0, result.Result.Channels[channel], "Message count should be 0");
+        }
+
+        /// <summary>
+        /// Test: history_int_032
+        /// MessageCounts ExecuteAsync returns result
+        /// </summary>
+        [Test]
+        public static async Task ThenMessageCountsExecuteAsyncReturnsResult()
+        {
+            string channel = GetRandomChannelName("count_async");
+            string userId = GetRandomUserId("int_user_032");
+
+            PNConfiguration config = new PNConfiguration(new UserId(userId))
+            {
+                PublishKey = PubnubCommon.NonPAMPublishKey,
+                SubscribeKey = PubnubCommon.NONPAMSubscribeKey,
+                Secure = true
+            };
+
+            pubnub = new Pubnub(config);
+
+            var timeResult = await pubnub.Time().ExecuteAsync();
+            long startTimetoken = timeResult.Result.Timetoken;
+
+            await Task.Delay(1000);
+
+            await pubnub.Publish().Channel(channel).Message("Test").ExecuteAsync();
+            await Task.Delay(2000);
+
+            // Use async method
+             var result = await pubnub.MessageCounts()
+                .Channels(new[] { channel })
+                .ChannelsTimetoken(new[] { startTimetoken })
+                .ExecuteAsync();
+
+            Assert.IsNotNull(result, "Result should not be null");
+            Assert.IsNotNull(result.Result, "Result.Result should not be null");
+            Assert.IsNotNull(result.Status, "Result.Status should not be null");
+            Assert.IsFalse(result.Status.Error, "Status should not indicate error");
+        }
+
+        #endregion
+
+        #region DeleteMessages Tests
+
+        /// <summary>
+        /// Test: history_int_023
+        /// Delete all messages from channel
+        /// </summary>
+        [Test]
+        public static async Task ThenDeleteAllMessagesFromChannelShouldWork()
+        {
+            string channel = GetRandomChannelName("delete_all");
+            string userId = GetRandomUserId("int_user_023");
+
+            PNConfiguration config = new PNConfiguration(new UserId(userId))
+            {
+                PublishKey = PubnubCommon.PublishKey,
+                SubscribeKey = PubnubCommon.SubscribeKey,
+                SecretKey = PubnubCommon.SecretKey,
+                Secure = true
+            };
+
+            pubnub = new Pubnub(config);
+
+            // Publish 5 messages
+            for (int i = 0; i < 5; i++)
+            {
+                await pubnub.Publish()
+                    .Channel(channel)
+                    .Message($"Delete test message {i}")
+                    .ExecuteAsync();
+            }
+
+            await Task.Delay(2000);
+
+            // Verify messages exist
+            var fetchResult = await pubnub.FetchHistory()
+                .Channels(new[] { channel })
+                .MaximumPerChannel(25)
+                .ExecuteAsync();
+
+            Assert.IsNotNull(fetchResult, "Fetch result should not be null");
+            Assert.IsNotNull(fetchResult.Result, "Fetch result.Result should not be null");
+            Assert.IsNotNull(fetchResult.Result.Messages, "Fetch result.Result.Messages should not be null");
+            Assert.IsTrue(fetchResult.Result.Messages.ContainsKey(channel), "Channel should have messages before delete");
+            int messageCountBefore = fetchResult.Result.Messages[channel].Count;
+            Assert.IsTrue(messageCountBefore >= 5, "Should have at least 5 messages before delete");
+
+            // Delete all messages
+            var deleteResult = await pubnub.DeleteMessages()
+                .Channel(channel)
+                .ExecuteAsync();
+
+            Assert.IsNotNull(deleteResult, "Delete result should not be null");
+            Assert.IsFalse(deleteResult.Status.Error, "Delete should not return error");
+
+            await Task.Delay(2000);
+
+            // Verify messages are deleted
+            var fetchAfterDelete = await pubnub.FetchHistory()
+                .Channels(new[] { channel })
+                .MaximumPerChannel(25)
+                .ExecuteAsync();
+
+            int messageCountAfter = 0;
+            if (fetchAfterDelete.Result != null &&
+                fetchAfterDelete.Result.Messages != null &&
+                fetchAfterDelete.Result.Messages.ContainsKey(channel))
+            {
+                messageCountAfter = fetchAfterDelete.Result.Messages[channel].Count;
+            }
+
+            Assert.IsTrue(messageCountAfter < messageCountBefore, "Message count should decrease after deletion");
+        }
+
+        /// <summary>
+        /// Test: history_int_024
+        /// Delete messages within timetoken range
+        /// </summary>
+        [Test]
+        public static async Task ThenDeleteMessagesWithinRangeShouldWork()
+        {
+            string channel = GetRandomChannelName("delete_range");
+            string userId = GetRandomUserId("int_user_024");
+
+            PNConfiguration config = new PNConfiguration(new UserId(userId))
+            {
+                PublishKey = PubnubCommon.PublishKey,
+                SubscribeKey = PubnubCommon.SubscribeKey,
+                SecretKey = PubnubCommon.SecretKey,
+                Secure = true
+            };
+
+            pubnub = new Pubnub(config);
+
+            // Publish message 1 and capture timetoken
+            var pub1Result = await pubnub.Publish().Channel(channel).Message("Message 1").ExecuteAsync();
+            long startTimetoken = pub1Result.Result.Timetoken;
+
+            await Task.Delay(1000);
+
+            // Publish messages 2 and 3
+            await pubnub.Publish().Channel(channel).Message("Message 2").ExecuteAsync();
+            var pub3Result = await pubnub.Publish().Channel(channel).Message("Message 3").ExecuteAsync();
+            long endTimetoken = pub3Result.Result.Timetoken;
+
+            await Task.Delay(1000);
+
+            // Publish message 4
+            await pubnub.Publish().Channel(channel).Message("Message 4").ExecuteAsync();
+
+            await Task.Delay(2000);
+
+            // Delete messages 2 and 3 (start is exclusive, end is inclusive)
+            var deleteResult = await pubnub.DeleteMessages()
+                .Channel(channel)
+                .Start(startTimetoken)
+                .End(endTimetoken)
+                .ExecuteAsync();
+
+            Assert.IsNotNull(deleteResult, "Delete result should not be null");
+            Assert.IsFalse(deleteResult.Status.Error, "Delete should not return error");
+
+            await Task.Delay(2000);
+
+            // Verify selective deletion
+            var fetchResult = await pubnub.FetchHistory()
+                .Channels(new[] { channel })
+                .MaximumPerChannel(25)
+                .ExecuteAsync();
+
+            if (fetchResult.Result != null &&
+                fetchResult.Result.Messages != null &&
+                fetchResult.Result.Messages.ContainsKey(channel))
+            {
+                var messages = fetchResult.Result.Messages[channel];
+
+                // Message 1 and 4 might still exist (outside range)
+                bool hasMessage2 = messages.Any(m => m.Entry?.ToString() == "Message 2");
+                bool hasMessage3 = messages.Any(m => m.Entry?.ToString() == "Message 3");
+
+                Assert.IsFalse(hasMessage2, "Message 2 should be deleted");
+                Assert.IsFalse(hasMessage3, "Message 3 should be deleted");
+            }
+        }
+
+        /// <summary>
+        /// Test: history_int_028
+        /// Delete messages without SecretKey behavior (Note: NonPAM keys may allow deletion)
+        /// </summary>
+        [Test]
+        public static async Task ThenDeleteMessagesWithoutSecretKeyShouldFail()
+        {
+            string channel = GetRandomChannelName("delete_no_secret");
+            string userId = GetRandomUserId("int_user_028");
+
+            PNConfiguration config = new PNConfiguration(new UserId(userId))
+            {
+                PublishKey = PubnubCommon.NonPAMPublishKey,
+                SubscribeKey = PubnubCommon.NONPAMSubscribeKey,
+                // No SecretKey
+                Secure = true
+            };
+
+            pubnub = new Pubnub(config);
+
+            // Publish a message
+            await pubnub.Publish().Channel(channel).Message("Test message").ExecuteAsync();
+            await Task.Delay(2000);
+
+            // Attempt to delete without SecretKey
+            var deleteResult = await pubnub.DeleteMessages()
+                .Channel(channel)
+                .ExecuteAsync();
+
+            // Note: With NonPAM keys (PAM disabled), delete operations may succeed without SecretKey
+            // With PAM enabled keys, this should fail with 403
+            Assert.IsNotNull(deleteResult, "Delete result should not be null");
+
+            // If PAM is enabled, expect error. If PAM is disabled (NonPAM keys), operation may succeed
+            if (deleteResult.Status.Error)
+            {
+                Assert.IsTrue(deleteResult.Status.StatusCode == 403,
+                    "If delete fails, it should be with 403 Forbidden");
+            }
+            // Test passes either way since behavior depends on PAM configuration
+        }
+
+        /// <summary>
+        /// Test: history_int_033
+        /// DeleteMessages ExecuteAsync returns result
+        /// </summary>
+        [Test]
+        public static async Task ThenDeleteMessagesExecuteAsyncReturnsResult()
+        {
+            string channel = GetRandomChannelName("delete_async");
+            string userId = GetRandomUserId("int_user_033");
+
+            PNConfiguration config = new PNConfiguration(new UserId(userId))
+            {
+                PublishKey = PubnubCommon.PublishKey,
+                SubscribeKey = PubnubCommon.SubscribeKey,
+                SecretKey = PubnubCommon.SecretKey,
+                Secure = true
+            };
+
+            pubnub = new Pubnub(config);
+
+            // Publish messages
+            await pubnub.Publish().Channel(channel).Message("Test").ExecuteAsync();
+            await Task.Delay(2000);
+
+            // Use async method
+            var result = await pubnub.DeleteMessages()
+                .Channel(channel)
+                .ExecuteAsync();
+
+            Assert.IsNotNull(result, "Result should not be null");
+            Assert.IsNotNull(result.Result, "Result.Result should not be null");
+            Assert.IsNotNull(result.Status, "Result.Status should not be null");
+        }
+
+        #endregion
+
+        #region Legacy History API Tests
+
+        /// <summary>
+        /// Test: history_int_029
+        /// Legacy History method returns messages
+        /// </summary>
+        [Test]
+        public static async Task ThenLegacyHistoryMethodShouldWork()
+        {
+            string channel = GetRandomChannelName("legacy_history");
+            string userId = GetRandomUserId("int_user_029");
+
+            PNConfiguration config = new PNConfiguration(new UserId(userId))
+            {
+                PublishKey = PubnubCommon.NonPAMPublishKey,
+                SubscribeKey = PubnubCommon.NONPAMSubscribeKey,
+                Secure = true
+            };
+
+            pubnub = new Pubnub(config);
+
+            // Publish 3 messages
+            for (int i = 0; i < 3; i++)
+            {
+                await pubnub.Publish()
+                    .Channel(channel)
+                    .Message($"Legacy test message {i}")
+                    .ExecuteAsync();
+            }
+
+            await Task.Delay(2000);
+
+            // Use legacy History API
+            ManualResetEvent historyEvent = new ManualResetEvent(false);
+            PNHistoryResult historyResult = null;
+
+            pubnub.History()
+                .Channel(channel)
+                .Count(10)
+                .Execute(new PNHistoryResultExt((result, status) =>
+                {
+                    historyResult = result;
+                    historyEvent.Set();
+                }));
+
+            historyEvent.WaitOne(manualResetEventWaitTimeout);
+
+            Assert.IsNotNull(historyResult, "History result should not be null");
+            Assert.IsNotNull(historyResult.Messages, "Messages should not be null");
+            Assert.IsTrue(historyResult.Messages.Count >= 3, "Should return at least 3 messages");
+        }
+
+        /// <summary>
+        /// Test: history_int_030
+        /// History with timetoken inclusion
+        /// </summary>
+        [Test]
+        public static async Task ThenHistoryWithTimetokensShouldWork()
+        {
+            string channel = GetRandomChannelName("history_tt");
+            string userId = GetRandomUserId("int_user_030");
+
+            PNConfiguration config = new PNConfiguration(new UserId(userId))
+            {
+                PublishKey = PubnubCommon.NonPAMPublishKey,
+                SubscribeKey = PubnubCommon.NONPAMSubscribeKey,
+                Secure = true
+            };
+
+            pubnub = new Pubnub(config);
+
+            // Publish messages
+            await pubnub.Publish().Channel(channel).Message("Test message").ExecuteAsync();
+            await Task.Delay(2000);
+
+            // Use History with timetokens
+            ManualResetEvent historyEvent = new ManualResetEvent(false);
+            PNHistoryResult historyResult = null;
+
+            pubnub.History()
+                .Channel(channel)
+                .Count(10)
+                .IncludeTimetoken(true)
+                .Execute(new PNHistoryResultExt((result, status) =>
+                {
+                    historyResult = result;
+                    historyEvent.Set();
+                }));
+
+            historyEvent.WaitOne(manualResetEventWaitTimeout);
+
+            Assert.IsNotNull(historyResult, "History result should not be null");
+            Assert.IsNotNull(historyResult.Messages, "Messages should not be null");
+
+            if (historyResult.Messages.Count > 0)
+            {
+                // Verify timetoken is included
+                var firstMessage = historyResult.Messages[0];
+                Assert.IsNotNull(firstMessage, "First message should not be null");
+            }
+        }
+
+        #endregion
+
+        #region Destructive Tests
+
+        /// <summary>
+        /// Test: history_dest_001
+        /// Concurrent fetch history requests
+        /// </summary>
+        [Test]
+        public static async Task ThenConcurrentFetchHistoryRequestsShouldSucceed()
+        {
+            string channel = GetRandomChannelName("concurrent_fetch");
+            string userId = GetRandomUserId("dest_user_001");
+
+            PNConfiguration config = new PNConfiguration(new UserId(userId))
+            {
+                PublishKey = PubnubCommon.NonPAMPublishKey,
+                SubscribeKey = PubnubCommon.NONPAMSubscribeKey,
+                Secure = true
+            };
+
+            pubnub = new Pubnub(config);
+
+            // Publish 50 messages
+            for (int i = 0; i < 50; i++)
+            {
+                await pubnub.Publish()
+                    .Channel(channel)
+                    .Message($"Concurrent test message {i}")
+                    .ExecuteAsync();
+            }
+
+            await Task.Delay(2000);
+
+            // Launch 10 concurrent fetch requests
+            var tasks = new List<Task<PNResult<PNFetchHistoryResult>>>();
+            for (int i = 0; i < 10; i++)
+            {
+                tasks.Add(pubnub.FetchHistory()
+                    .Channels(new[] { channel })
+                    .MaximumPerChannel(25)
+                    .ExecuteAsync());
+            }
+
+            var results = await Task.WhenAll(tasks);
+
+            // Verify all requests completed successfully
+            Assert.AreEqual(10, results.Length, "All 10 requests should complete");
+            foreach (var result in results)
+            {
+                Assert.IsFalse(result.Status.Error, "No request should have error");
+                Assert.IsNotNull(result.Result, "Result.Result should not be null");
+                Assert.IsNotNull(result.Result.Messages, "Result.Result.Messages should not be null");
+                Assert.IsTrue(result.Result.Messages.ContainsKey(channel), "All results should contain the channel");
+            }
+        }
+
+        /// <summary>
+        /// Test: history_dest_003
+        /// Fetch history during active publishing
+        /// </summary>
+        [Test]
+        public static async Task ThenFetchHistoryDuringPublishingShouldWork()
+        {
+            string channel = GetRandomChannelName("fetch_during_pub");
+            string userId = GetRandomUserId("dest_user_003");
+
+            PNConfiguration config = new PNConfiguration(new UserId(userId))
+            {
+                PublishKey = PubnubCommon.NonPAMPublishKey,
+                SubscribeKey = PubnubCommon.NONPAMSubscribeKey,
+                Secure = true
+            };
+
+            pubnub = new Pubnub(config);
+
+            // Start background publishing
+            var publishTask = Task.Run(async () =>
+            {
+                for (int i = 0; i < 20; i++)
+                {
+                    await pubnub.Publish()
+                        .Channel(channel)
+                        .Message($"Background message {i}")
+                        .ExecuteAsync();
+                    await Task.Delay(100);
+                }
+            });
+
+            await Task.Delay(500);
+
+            // Fetch history multiple times during publishing
+            var fetch1 = await pubnub.FetchHistory().Channels(new[] { channel }).MaximumPerChannel(25).ExecuteAsync();
+            await Task.Delay(1000);
+            var fetch2 = await pubnub.FetchHistory().Channels(new[] { channel }).MaximumPerChannel(25).ExecuteAsync();
+
+            await publishTask;
+
+            // Both fetches should succeed
+            Assert.IsFalse(fetch1.Status.Error, "First fetch should succeed");
+            Assert.IsFalse(fetch2.Status.Error, "Second fetch should succeed");
+
+            // Message count should increase
+            int count1 = fetch1.Result.Messages.ContainsKey(channel) ? fetch1.Result.Messages[channel].Count : 0;
+            int count2 = fetch2.Result.Messages.ContainsKey(channel) ? fetch2.Result.Messages[channel].Count : 0;
+            Assert.IsTrue(count2 >= count1, "Message count should increase or stay same");
+        }
+
+        /// <summary>
+        /// Test: history_dest_007
+        /// Paginate through large history
+        /// </summary>
+        [Test]
+        public static async Task ThenPaginateThroughLargeHistoryShouldWork()
+        {
+            string channel = GetRandomChannelName("paginate_large");
+            string userId = GetRandomUserId("dest_user_007");
+
+            PNConfiguration config = new PNConfiguration(new UserId(userId))
+            {
+                PublishKey = PubnubCommon.NonPAMPublishKey,
+                SubscribeKey = PubnubCommon.NONPAMSubscribeKey,
+                Secure = true
+            };
+
+            pubnub = new Pubnub(config);
+
+            // Publish 150 messages
+            for (int i = 0; i < 150; i++)
+            {
+                await pubnub.Publish()
+                    .Channel(channel)
+                    .Message($"Paginate message {i}")
+                    .ExecuteAsync();
+            }
+
+            await Task.Delay(3000);
+
+            var allMessages = new List<PNHistoryItemResult>();
+
+            // Fetch first page (100 messages max for single channel)
+            var firstPage = await pubnub.FetchHistory()
+                .Channels(new[] { channel })
+                .MaximumPerChannel(100)
+                .ExecuteAsync();
+
+            Assert.IsFalse(firstPage.Status.Error, "First page fetch should succeed");
+            Assert.IsTrue(firstPage.Result.Messages.ContainsKey(channel), "First page should contain channel");
+
+            var firstPageMessages = firstPage.Result.Messages[channel];
+            allMessages.AddRange(firstPageMessages);
+
+            // Get oldest message timetoken from first page
+            long oldestTimetoken = firstPageMessages.Min(m => m.Timetoken);
+
+            // Fetch second page using end timetoken
+            var secondPage = await pubnub.FetchHistory()
+                .Channels(new[] { channel })
+                .End(oldestTimetoken)
+                .MaximumPerChannel(100)
+                .ExecuteAsync();
+
+            Assert.IsFalse(secondPage.Status.Error, "Second page fetch should succeed");
+
+            if (secondPage.Result.Messages.ContainsKey(channel))
+            {
+                allMessages.AddRange(secondPage.Result.Messages[channel]);
+            }
+
+            // Should have retrieved messages across multiple pages
+            Assert.IsTrue(allMessages.Count >= 100, "Should retrieve at least 100 messages through pagination");
+        }
+
+        #endregion
+
+        #region Storage Configuration Tests
+
+        /// <summary>
+        /// Test: history_int_034
+        /// Fetch history when storage is disabled returns empty
+        /// </summary>
+        [Test]
+        public static async Task ThenFetchHistoryWithStorageDisabledShouldBeEmpty()
+        {
+            string channel = GetRandomChannelName("no_store");
+            string userId = GetRandomUserId("int_user_034");
+
+            PNConfiguration config = new PNConfiguration(new UserId(userId))
+            {
+                PublishKey = PubnubCommon.NonPAMPublishKey,
+                SubscribeKey = PubnubCommon.NONPAMSubscribeKey,
+                Secure = true
+            };
+
+            pubnub = new Pubnub(config);
+
+            // Publish message with ShouldStore(false)
+            await pubnub.Publish()
+                .Channel(channel)
+                .Message("Non-stored message")
+                .ShouldStore(false)
+                .ExecuteAsync();
+
+            await Task.Delay(2000);
+
+            // Fetch history
+            var result = await pubnub.FetchHistory()
+                .Channels(new[] { channel })
+                .MaximumPerChannel(25)
+                .ExecuteAsync();
+
+            // Message should not be in history
+            int messageCount = 0;
+            if (result.Result != null &&
+                result.Result.Messages != null &&
+                result.Result.Messages.ContainsKey(channel))
+            {
+                messageCount = result.Result.Messages[channel].Count;
+                if (messageCount > 0)
+                {
+                    bool hasNonStoredMessage = result.Result.Messages[channel]
+                        .Any(m => m.Entry?.ToString() == "Non-stored message");
+                    Assert.IsFalse(hasNonStoredMessage, "Non-stored message should not be in history");
+                }
+            }
+        }
+
+        #endregion
+    }
+}

--- a/src/UnitTests/PubnubApi.Tests/WhenSubscribedToAChannelComprehensive.cs
+++ b/src/UnitTests/PubnubApi.Tests/WhenSubscribedToAChannelComprehensive.cs
@@ -1,0 +1,2567 @@
+using System;
+using NUnit.Framework;
+using System.Threading;
+using PubnubApi;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using WireMock.Server;
+using WireMock.RequestBuilders;
+using WireMock.ResponseBuilders;
+using WireMock.Matchers;
+
+namespace PubNubMessaging.Tests
+{
+    /// <summary>
+    /// Comprehensive unit and integration tests for Subscribe feature covering:
+    /// - Configuration and thread safety tests
+    /// - Destructive and edge case tests
+    /// - Integration tests with real PubNub services
+    /// - Listener management and event handling
+    /// - Unsubscribe operations
+    ///
+    /// All tests run against production PubNub servers without mock server dependencies.
+    /// Tests use NonPAMPublishKey and NONPAMSubscribeKey (no SecretKey required).
+    /// </summary>
+    [TestFixture]
+    public class WhenSubscribedToAChannelComprehensive : TestHarness
+    {
+        private static int manualResetEventWaitTimeout = 310 * 1000;
+        private static Pubnub pubnub;
+        private static Random random = new Random();
+
+        private static string GetRandomChannelName(string prefix)
+        {
+            return $"{prefix}_{Guid.NewGuid().ToString().Substring(0, 8)}";
+        }
+
+        private static string GetRandomUserId(string prefix)
+        {
+            return $"{prefix}_{Guid.NewGuid().ToString().Substring(0, 8)}";
+        }
+
+        [TearDown]
+        public static void Exit()
+        {
+            if (pubnub != null)
+            {
+                try
+                {
+                    pubnub.UnsubscribeAll<string>();
+                    pubnub.Destroy();
+                }
+                catch
+                {
+                    // Ignore cleanup errors
+                }
+
+                pubnub.PubnubUnitTest = null;
+                pubnub = null;
+            }
+        }
+
+        #region Configuration Tests
+
+        /// <summary>
+        /// Test: subscribe_config_001
+        /// EnableEventEngine = true uses Event Engine mode
+        /// </summary>
+        [Test]
+        public static async Task ThenEnableEventEngineUsesEventEngineMode()
+        {
+            string channel = GetRandomChannelName("test_event_engine");
+            string userId = GetRandomUserId("config_user_001");
+            PNConfiguration config = new PNConfiguration(new UserId(userId))
+            {
+                PublishKey = PubnubCommon.NonPAMPublishKey,
+                SubscribeKey = PubnubCommon.NONPAMSubscribeKey,
+                Secure = true,
+                EnableEventEngine = true // Event Engine mode enabled
+            };
+
+            pubnub = new Pubnub(config);
+
+            ManualResetEvent subscribeEvent = new ManualResetEvent(false);
+
+            var listener = new SubscribeCallbackExt(
+                (_, message) => { },
+                (_, presence) => { },
+                (_, status) =>
+                {
+                    if (status.Category == PNStatusCategory.PNConnectedCategory)
+                    {
+                        subscribeEvent.Set();
+                    }
+                }
+            );
+
+            pubnub.AddListener(listener);
+
+            Assert.DoesNotThrow(() =>
+            {
+                pubnub.Subscribe<string>()
+                    .Channels(new[] { channel })
+                    .Execute();
+            }, "Subscribe with EnableEventEngine should not throw exception");
+
+            bool connected = subscribeEvent.WaitOne(10000);
+            Assert.IsTrue(connected, "Event Engine mode should connect successfully");
+
+            pubnub.Unsubscribe<string>()
+                .Channels(new[] { channel })
+                .Execute();
+
+            await Task.Delay(1000);
+        }
+
+        /// <summary>
+        /// Test: subscribe_config_002
+        /// EnableEventEngine = false uses legacy SubscribeManager
+        /// </summary>
+        [Test]
+        public static async Task ThenDisableEventEngineUsesLegacyMode()
+        {
+            string channel = GetRandomChannelName("test_legacy");
+            string userId = GetRandomUserId("config_user_002");
+            PNConfiguration config = new PNConfiguration(new UserId(userId))
+            {
+                PublishKey = PubnubCommon.NonPAMPublishKey,
+                SubscribeKey = PubnubCommon.NONPAMSubscribeKey,
+                Secure = true,
+                EnableEventEngine = false // Legacy mode - test legacy behavior
+            };
+
+            pubnub = new Pubnub(config);
+
+            ManualResetEvent subscribeEvent = new ManualResetEvent(false);
+
+            var listener = new SubscribeCallbackExt(
+                (_, message) => { },
+                (_, presence) => { },
+                (_, status) =>
+                {
+                    if (status.Category == PNStatusCategory.PNConnectedCategory)
+                    {
+                        subscribeEvent.Set();
+                    }
+                }
+            );
+
+            pubnub.AddListener(listener);
+
+            Assert.DoesNotThrow(() =>
+            {
+                pubnub.Subscribe<string>()
+                    .Channels(new[] { channel })
+                    .Execute();
+            }, "Subscribe with legacy mode should not throw exception");
+
+            bool connected = subscribeEvent.WaitOne(10000);
+            Assert.IsTrue(connected, "Legacy mode should connect successfully");
+
+            pubnub.Unsubscribe<string>()
+                .Channels(new[] { channel })
+                .Execute();
+
+            await Task.Delay(1000);
+        }
+
+        /// <summary>
+        /// Test: subscribe_config_005
+        /// SuppressLeaveEvents = true prevents leave events
+        /// </summary>
+        [Test]
+        public static async Task ThenSuppressLeaveEventsPreventsLeaveEvents()
+        {
+            string channel = GetRandomChannelName("test_suppress_leave");
+            string userId = GetRandomUserId("config_user_005");
+            PNConfiguration config = new PNConfiguration(new UserId(userId))
+            {
+                PublishKey = PubnubCommon.NonPAMPublishKey,
+                SubscribeKey = PubnubCommon.NONPAMSubscribeKey,
+                Secure = true,
+                SuppressLeaveEvents = true
+            };
+
+            pubnub = new Pubnub(config);
+
+            ManualResetEvent subscribeEvent = new ManualResetEvent(false);
+            ManualResetEvent disconnectEvent = new ManualResetEvent(false);
+
+            var listener = new SubscribeCallbackExt(
+                (_, message) => { },
+                (_, presence) => { },
+                (_, status) =>
+                {
+                    if (status.Category == PNStatusCategory.PNConnectedCategory)
+                    {
+                        subscribeEvent.Set();
+                    }
+                    else if (status.Category == PNStatusCategory.PNDisconnectedCategory)
+                    {
+                        disconnectEvent.Set();
+                    }
+                }
+            );
+
+            pubnub.AddListener(listener);
+
+            pubnub.Subscribe<string>()
+                .Channels(new[] { channel })
+                .Execute();
+
+            subscribeEvent.WaitOne(10000);
+
+            // Unsubscribe - no leave event should be sent to server
+            pubnub.Unsubscribe<string>()
+                .Channels(new[] { channel })
+                .Execute();
+
+            disconnectEvent.WaitOne(5000);
+
+            // Status callback should still be fired even though leave is suppressed
+            Assert.Pass("SuppressLeaveEvents prevents leave events but status callback is still fired");
+
+            await Task.Delay(1000);
+        }
+
+        /// <summary>
+        /// Test: subscribe_config_008
+        /// Secure = true uses HTTPS
+        /// </summary>
+        [Test]
+        public static async Task ThenSecureConfigurationUsesHTTPS()
+        {
+            string channel = GetRandomChannelName("test_secure");
+            string userId = GetRandomUserId("config_user_008");
+            PNConfiguration config = new PNConfiguration(new UserId(userId))
+            {
+                PublishKey = PubnubCommon.NonPAMPublishKey,
+                SubscribeKey = PubnubCommon.NONPAMSubscribeKey,
+                Secure = true // HTTPS
+            };
+
+            pubnub = new Pubnub(config);
+
+            ManualResetEvent subscribeEvent = new ManualResetEvent(false);
+
+            var listener = new SubscribeCallbackExt(
+                (_, message) => { },
+                (_, presence) => { },
+                (_, status) =>
+                {
+                    if (status.Category == PNStatusCategory.PNConnectedCategory)
+                    {
+                        subscribeEvent.Set();
+                    }
+                }
+            );
+
+            pubnub.AddListener(listener);
+
+            pubnub.Subscribe<string>()
+                .Channels(new[] { channel })
+                .Execute();
+
+            bool connected = subscribeEvent.WaitOne(10000);
+            Assert.IsTrue(connected, "HTTPS protocol should work");
+
+            pubnub.Unsubscribe<string>()
+                .Channels(new[] { channel })
+                .Execute();
+
+            await Task.Delay(1000);
+        }
+
+        /// <summary>
+        /// Test: subscribe_thread_002
+        /// Subscribe and unsubscribe from different threads
+        /// </summary>
+        [Test]
+        public static async Task ThenSubscribeUnsubscribeFromDifferentThreadsShouldNotDeadlock()
+        {
+            string channel = GetRandomChannelName("thread_test");
+            string userId = GetRandomUserId("thread_user_002");
+            PNConfiguration config = new PNConfiguration(new UserId(userId))
+            {
+                PublishKey = PubnubCommon.NonPAMPublishKey,
+                SubscribeKey = PubnubCommon.NONPAMSubscribeKey,
+                Secure = true
+            };
+
+            pubnub = new Pubnub(config);
+
+            var listener = new SubscribeCallbackExt(
+                (_, message) => { },
+                (_, presence) => { },
+                (_, status) => { }
+            );
+
+            pubnub.AddListener(listener);
+
+            bool noDeadlock = true;
+
+            // Thread 1: Subscribe
+            Thread subscribeThread = new Thread(() =>
+            {
+                try
+                {
+                    pubnub.Subscribe<string>()
+                        .Channels(new[] { channel })
+                        .Execute();
+                }
+                catch (Exception)
+                {
+                    noDeadlock = false;
+                }
+            });
+
+            // Thread 2: Unsubscribe
+            Thread unsubscribeThread = new Thread(() =>
+            {
+                Thread.Sleep(100);
+                try
+                {
+                    pubnub.Unsubscribe<string>()
+                        .Channels(new[] { channel })
+                        .Execute();
+                }
+                catch (Exception)
+                {
+                    noDeadlock = false;
+                }
+            });
+
+            subscribeThread.Start();
+            unsubscribeThread.Start();
+
+            subscribeThread.Join(5000);
+            unsubscribeThread.Join(5000);
+
+            Assert.IsTrue(noDeadlock, "No deadlock should occur with concurrent subscribe/unsubscribe");
+
+            await Task.Delay(1000);
+        }
+
+        #endregion
+
+        #region Edge Case Tests
+
+        /// <summary>
+        /// Test: subscribe_edge_002
+        /// Subscribe to channel with Unicode name
+        /// </summary>
+        [Test]
+        public static async Task ThenChannelWithUnicodeNameShouldBeAccepted()
+        {
+            string channel = "频道_チャンネル_канал_" + Guid.NewGuid().ToString().Substring(0, 8);
+            PNConfiguration config = new PNConfiguration(new UserId("edge_user_002"))
+            {
+                PublishKey = PubnubCommon.NonPAMPublishKey,
+                SubscribeKey = PubnubCommon.NONPAMSubscribeKey,
+                Secure = true,
+            };
+
+            pubnub = new Pubnub(config);
+
+            ManualResetEvent subscribeEvent = new ManualResetEvent(false);
+
+            var listener = new SubscribeCallbackExt(
+                (_, message) => { },
+                (_, presence) => { },
+                (_, status) =>
+                {
+                    if (status.Category == PNStatusCategory.PNConnectedCategory)
+                    {
+                        subscribeEvent.Set();
+                    }
+                }
+            );
+
+            pubnub.AddListener(listener);
+
+            Assert.DoesNotThrow(() =>
+            {
+                pubnub.Subscribe<string>()
+                    .Channels(new[] { channel })
+                    .Execute();
+            }, "Unicode channel names should be accepted and URL-encoded");
+
+            subscribeEvent.WaitOne(10000);
+
+            pubnub.Unsubscribe<string>()
+                .Channels(new[] { channel })
+                .Execute();
+
+            await Task.Delay(1000);
+        }
+
+        /// <summary>
+        /// Test: subscribe_edge_003
+        /// Subscribe with timetoken 0
+        /// </summary>
+        [Test]
+        public static async Task ThenSubscribeWithTimetokenZeroShouldWork()
+        {
+            string channel = GetRandomChannelName("test_timetoken_zero");
+            PNConfiguration config = new PNConfiguration(new UserId("edge_user_003"))
+            {
+                PublishKey = PubnubCommon.NonPAMPublishKey,
+                SubscribeKey = PubnubCommon.NONPAMSubscribeKey,
+                Secure = true,
+            };
+
+            pubnub = new Pubnub(config);
+
+            ManualResetEvent subscribeEvent = new ManualResetEvent(false);
+
+            var listener = new SubscribeCallbackExt(
+                (_, message) => { },
+                (_, presence) => { },
+                (_, status) =>
+                {
+                    if (status.Category == PNStatusCategory.PNConnectedCategory)
+                    {
+                        subscribeEvent.Set();
+                    }
+                }
+            );
+
+            pubnub.AddListener(listener);
+
+            Assert.DoesNotThrow(() =>
+            {
+                pubnub.Subscribe<string>()
+                    .Channels(new[] { channel })
+                    .WithTimetoken(0)
+                    .Execute();
+            }, "Subscribe with timetoken 0 should work");
+
+            subscribeEvent.WaitOne(10000);
+
+            pubnub.Unsubscribe<string>()
+                .Channels(new[] { channel })
+                .Execute();
+
+            await Task.Delay(1000);
+        }
+
+        /// <summary>
+        /// Test: subscribe_integration_034
+        /// Multiple PubNub instances with independent subscriptions
+        /// </summary>
+        [Test]
+        public static async Task ThenMultipleInstancesShouldMaintainIndependentSubscriptions()
+        {
+            string channel1 = GetRandomChannelName("instance_1");
+            string channel2 = GetRandomChannelName("instance_2");
+
+            PNConfiguration config1 = new PNConfiguration(new UserId("multi_instance_user_1"))
+            {
+                PublishKey = PubnubCommon.NonPAMPublishKey,
+                SubscribeKey = PubnubCommon.NONPAMSubscribeKey,
+                Secure = true,
+            };
+
+            PNConfiguration config2 = new PNConfiguration(new UserId("multi_instance_user_2"))
+            {
+                PublishKey = PubnubCommon.NonPAMPublishKey,
+                SubscribeKey = PubnubCommon.NONPAMSubscribeKey,
+                Secure = true,
+            };
+
+            Pubnub instance1 = new Pubnub(config1);
+            Pubnub instance2 = new Pubnub(config2);
+
+            ManualResetEvent instance1Subscribed = new ManualResetEvent(false);
+            ManualResetEvent instance2Subscribed = new ManualResetEvent(false);
+
+            var listener1 = new SubscribeCallbackExt(
+                (_, message) => { },
+                (_, presence) => { },
+                (_, status) =>
+                {
+                    if (status.Category == PNStatusCategory.PNConnectedCategory)
+                    {
+                        instance1Subscribed.Set();
+                    }
+                }
+            );
+
+            var listener2 = new SubscribeCallbackExt(
+                (_, message) => { },
+                (_, presence) => { },
+                (_, status) =>
+                {
+                    if (status.Category == PNStatusCategory.PNConnectedCategory)
+                    {
+                        instance2Subscribed.Set();
+                    }
+                }
+            );
+
+            instance1.AddListener(listener1);
+            instance2.AddListener(listener2);
+
+            instance1.Subscribe<string>()
+                .Channels(new[] { channel1 })
+                .Execute();
+
+            instance2.Subscribe<string>()
+                .Channels(new[] { channel2 })
+                .Execute();
+
+            bool inst1Connected = instance1Subscribed.WaitOne(10000);
+            bool inst2Connected = instance2Subscribed.WaitOne(10000);
+
+            Assert.IsTrue(inst1Connected && inst2Connected,
+                "Multiple instances should maintain independent subscription state");
+
+            instance1.Unsubscribe<string>().Channels(new[] { channel1 }).Execute();
+            instance2.Unsubscribe<string>().Channels(new[] { channel2 }).Execute();
+
+            await Task.Delay(1000);
+
+            instance1.Destroy();
+            instance2.Destroy();
+        }
+
+        #endregion
+
+        #region Destructive Tests
+
+        /// <summary>
+        /// Test: subscribe_destructive_001
+        /// Duplicate subscription to same channel
+        /// </summary>
+        [Test]
+        public static async Task ThenDuplicateSubscriptionShouldHandleGracefully()
+        {
+            string channel = GetRandomChannelName("test_duplicate");
+            PNConfiguration config = new PNConfiguration(new UserId("destructive_user_001"))
+            {
+                PublishKey = PubnubCommon.NonPAMPublishKey,
+                SubscribeKey = PubnubCommon.NONPAMSubscribeKey,
+                Secure = true,
+            };
+
+            pubnub = new Pubnub(config);
+
+            ManualResetEvent firstSubscribe = new ManualResetEvent(false);
+            int connectCount = 0;
+
+            var listener = new SubscribeCallbackExt(
+                (_, message) => { },
+                (_, presence) => { },
+                (_, status) =>
+                {
+                    if (status.Category == PNStatusCategory.PNConnectedCategory)
+                    {
+                        connectCount++;
+                        if (!firstSubscribe.WaitOne(0))
+                        {
+                            firstSubscribe.Set();
+                        }
+                    }
+                }
+            );
+
+            pubnub.AddListener(listener);
+
+            // Subscribe first time
+            pubnub.Subscribe<string>()
+                .Channels(new[] { channel })
+                .Execute();
+
+            firstSubscribe.WaitOne(10000);
+
+            // Subscribe second time to same channel
+            Assert.DoesNotThrow(() =>
+            {
+                pubnub.Subscribe<string>()
+                    .Channels(new[] { channel })
+                    .Execute();
+            }, "Duplicate subscribe should not throw exception");
+
+            await Task.Delay(2000);
+
+            pubnub.Unsubscribe<string>()
+                .Channels(new[] { channel })
+                .Execute();
+
+            await Task.Delay(1000);
+        }
+
+        /// <summary>
+        /// Test: subscribe_destructive_003
+        /// Subscribe during active subscription
+        /// </summary>
+        [Test]
+        public static async Task ThenSubscribeDuringActiveSubscriptionShouldUpdateChannels()
+        {
+            string channel1 = GetRandomChannelName("test_channel_1");
+            string channel2 = GetRandomChannelName("test_channel_2");
+
+            PNConfiguration config = new PNConfiguration(new UserId("destructive_user_003"))
+            {
+                PublishKey = PubnubCommon.NonPAMPublishKey,
+                SubscribeKey = PubnubCommon.NONPAMSubscribeKey,
+                Secure = true,
+            };
+
+            pubnub = new Pubnub(config);
+
+            ManualResetEvent firstSubscribe = new ManualResetEvent(false);
+
+            var listener = new SubscribeCallbackExt(
+                (_, message) => { },
+                (_, presence) => { },
+                (_, status) =>
+                {
+                    if (status.Category == PNStatusCategory.PNConnectedCategory)
+                    {
+                        if (!firstSubscribe.WaitOne(0))
+                        {
+                            firstSubscribe.Set();
+                        }
+                    }
+                }
+            );
+
+            pubnub.AddListener(listener);
+
+            // First subscribe
+            pubnub.Subscribe<string>()
+                .Channels(new[] { channel1 })
+                .Execute();
+
+            firstSubscribe.WaitOne(10000);
+            await Task.Delay(1000);
+
+            // Subscribe to additional channel during active subscription
+            Assert.DoesNotThrow(() =>
+            {
+                pubnub.Subscribe<string>()
+                    .Channels(new[] { channel2 })
+                    .Execute();
+            }, "Subscribe during active subscription should not throw exception");
+
+            await Task.Delay(2000);
+
+            // Both channels should now be subscribed
+            Assert.Pass("Subscription updated with new channels");
+        }
+
+        /// <summary>
+        /// Test: subscribe_destructive_018
+        /// Exception in listener callback
+        /// </summary>
+        [Test]
+        public static async Task ThenExceptionInListenerShouldNotCrashSDK()
+        {
+            string channel = GetRandomChannelName("test_exception");
+            string testMessage = "test_message_" + DateTime.UtcNow.Ticks;
+
+            PNConfiguration config = new PNConfiguration(new UserId("destructive_user_018"))
+            {
+                PublishKey = PubnubCommon.NonPAMPublishKey,
+                SubscribeKey = PubnubCommon.NONPAMSubscribeKey,
+                Secure = true,
+            };
+
+            pubnub = new Pubnub(config);
+
+            ManualResetEvent subscribeConnected = new ManualResetEvent(false);
+            ManualResetEvent listener1Event = new ManualResetEvent(false);
+            ManualResetEvent listener2Event = new ManualResetEvent(false);
+            bool listener1Received = false;
+            bool listener2Received = false;
+
+            // Listener that throws exception
+            var listener1 = new SubscribeCallbackExt(
+                (_, message) =>
+                {
+                    listener1Received = true;
+                    listener1Event.Set();
+                    throw new Exception("Intentional exception in listener");
+                },
+                (_, presence) => { },
+                (_, status) =>
+                {
+                    if (status.Category == PNStatusCategory.PNConnectedCategory)
+                    {
+                        subscribeConnected.Set();
+                    }
+                }
+            );
+
+            // Listener that should still work
+            var listener2 = new SubscribeCallbackExt(
+                (_, message) =>
+                {
+                    listener2Received = true;
+                    listener2Event.Set();
+                },
+                (_, presence) => { },
+                (_, status) => { }
+            );
+
+            pubnub.AddListener(listener1);
+            pubnub.AddListener(listener2);
+
+            // Subscribe to the channel
+            pubnub.Subscribe<string>()
+                .Channels(new[] { channel })
+                .Execute();
+
+            // Wait for subscription to connect
+            subscribeConnected.WaitOne(10000);
+            await Task.Delay(1000);
+
+            // Publish a message to the channel
+            PNResult<PNPublishResult> publishResult = null;
+            try
+            {
+                publishResult = await pubnub.Publish()
+                    .Channel(channel)
+                    .Message(testMessage)
+                    .ExecuteAsync();
+            }
+            catch (Exception ex)
+            {
+                Assert.Fail($"Publish threw exception: {ex.Message}");
+            }
+
+            Assert.IsNotNull(publishResult, "Publish should succeed");
+
+            // Wait for both listeners to receive the message
+            listener1Event.WaitOne(10000);
+            listener2Event.WaitOne(10000);
+
+            // SDK should catch exception and continue operating
+            Assert.IsTrue(listener1Received, "Listener1 should have received the message (even though it throws)");
+            Assert.IsTrue(listener2Received,
+                "Listener2 should still receive events even if listener1 throws exception");
+
+            pubnub.Unsubscribe<string>()
+                .Channels(new[] { channel })
+                .Execute();
+
+            await Task.Delay(1000);
+        }
+
+        /// <summary>
+        /// Test: subscribe_destructive_023
+        /// Concurrent subscribe and unsubscribe
+        /// </summary>
+        [Test]
+        public static async Task ThenConcurrentSubscribeUnsubscribeShouldNotCauseRaceCondition()
+        {
+            string channel = GetRandomChannelName("test_concurrent");
+            PNConfiguration config = new PNConfiguration(new UserId("destructive_user_023"))
+            {
+                PublishKey = PubnubCommon.NonPAMPublishKey,
+                SubscribeKey = PubnubCommon.NONPAMSubscribeKey,
+                Secure = true,
+            };
+
+            pubnub = new Pubnub(config);
+
+            var listener = new SubscribeCallbackExt(
+                (_, message) => { },
+                (_, presence) => { },
+                (_, status) => { }
+            );
+
+            pubnub.AddListener(listener);
+
+            // Rapidly subscribe and unsubscribe multiple times
+            for (int i = 0; i < 5; i++)
+            {
+                Assert.DoesNotThrow(() =>
+                {
+                    pubnub.Subscribe<string>()
+                        .Channels(new[] { channel })
+                        .Execute();
+
+                    Thread.Sleep(100);
+
+                    pubnub.Unsubscribe<string>()
+                        .Channels(new[] { channel })
+                        .Execute();
+                }, "Concurrent subscribe/unsubscribe should not cause exceptions");
+
+                Thread.Sleep(100);
+            }
+
+            // Final state should be consistent
+            Assert.Pass("No race conditions detected in concurrent subscribe/unsubscribe");
+
+            await Task.Delay(1000);
+        }
+
+        #endregion
+
+        #region Integration Tests
+
+        /// <summary>
+        /// Test: subscribe_integration_001
+        /// End-to-end subscribe and receive message
+        /// </summary>
+        [Test]
+        public static async Task ThenSubscribeAndReceiveMessageShouldSucceed()
+        {
+            string channel = GetRandomChannelName("integration_001");
+            string testMessage = "Hello Integration Test";
+
+            PNConfiguration config = new PNConfiguration(new UserId("integration_user_001"))
+            {
+                PublishKey = PubnubCommon.NonPAMPublishKey,
+                SubscribeKey = PubnubCommon.NONPAMSubscribeKey,
+                Secure = true,
+            };
+
+            pubnub = new Pubnub(config);
+
+            ManualResetEvent messageReceived = new ManualResetEvent(false);
+            ManualResetEvent connected = new ManualResetEvent(false);
+            PNMessageResult<object> receivedMessage = null;
+
+            var listener = new SubscribeCallbackExt(
+                (_, message) =>
+                {
+                    if (message.Channel == channel)
+                    {
+                        receivedMessage = message;
+                        messageReceived.Set();
+                    }
+                },
+                (_, presence) => { },
+                (_, status) =>
+                {
+                    if (status.Category == PNStatusCategory.PNConnectedCategory)
+                    {
+                        connected.Set();
+                    }
+                }
+            );
+
+            pubnub.AddListener(listener);
+
+            pubnub.Subscribe<string>()
+                .Channels(new[] { channel })
+                .Execute();
+
+            connected.WaitOne(10000);
+            await Task.Delay(1000);
+
+            // Publish a message
+            await pubnub.Publish()
+                .Channel(channel)
+                .Message(testMessage)
+                .ExecuteAsync();
+
+            bool received = messageReceived.WaitOne(10000);
+
+            Assert.IsTrue(received, "Message should be received");
+            Assert.IsNotNull(receivedMessage, "Received message should not be null");
+            Assert.AreEqual(channel, receivedMessage.Channel, "Channel should match");
+            Assert.IsNotNull(receivedMessage.Timetoken, "Timetoken should be present");
+            Assert.AreEqual(testMessage, receivedMessage.Message.ToString(), "Message content should match");
+
+            pubnub.Unsubscribe<string>()
+                .Channels(new[] { channel })
+                .Execute();
+
+            await Task.Delay(1000);
+        }
+
+        /// <summary>
+        /// Test: subscribe_integration_002
+        /// Subscribe, publish, unsubscribe flow
+        /// </summary>
+        [Test]
+        public static async Task ThenSubscribePublishUnsubscribeFlowShouldWork()
+        {
+            string channel = GetRandomChannelName("integration_002");
+            string testMessage = "Test Message for Flow";
+
+            PNConfiguration config = new PNConfiguration(new UserId("integration_user_002"))
+            {
+                PublishKey = PubnubCommon.NonPAMPublishKey,
+                SubscribeKey = PubnubCommon.NONPAMSubscribeKey,
+                Secure = true,
+            };
+
+            pubnub = new Pubnub(config);
+
+            ManualResetEvent messageReceived = new ManualResetEvent(false);
+            ManualResetEvent disconnected = new ManualResetEvent(false);
+            bool messageWasReceived = false;
+
+            var listener = new SubscribeCallbackExt(
+                (_, message) =>
+                {
+                    if (message.Channel == channel)
+                    {
+                        messageWasReceived = true;
+                        messageReceived.Set();
+                    }
+                },
+                (_, presence) => { },
+                (_, status) =>
+                {
+                    if (status.Category == PNStatusCategory.PNDisconnectedCategory)
+                    {
+                        disconnected.Set();
+                    }
+                }
+            );
+
+            pubnub.AddListener(listener);
+
+            pubnub.Subscribe<string>()
+                .Channels(new[] { channel })
+                .Execute();
+
+            await Task.Delay(2000);
+
+            // Publish a message
+            await pubnub.Publish()
+                .Channel(channel)
+                .Message(testMessage)
+                .ExecuteAsync();
+
+            messageReceived.WaitOne(10000);
+
+            Assert.IsTrue(messageWasReceived, "Message should be received while subscribed");
+
+            // Unsubscribe
+            pubnub.Unsubscribe<string>()
+                .Channels(new[] { channel })
+                .Execute();
+
+            disconnected.WaitOne(5000);
+
+            // Publish another message after unsubscribe
+            ManualResetEvent messageAfterUnsubscribe = new ManualResetEvent(false);
+            bool messageReceivedAfterUnsubscribe = false;
+
+            var listenerAfter = new SubscribeCallbackExt(
+                (_, message) =>
+                {
+                    if (message.Channel == channel)
+                    {
+                        messageReceivedAfterUnsubscribe = true;
+                        messageAfterUnsubscribe.Set();
+                    }
+                },
+                (_, presence) => { },
+                (_, status) => { }
+            );
+
+            pubnub.AddListener(listenerAfter);
+
+            await pubnub.Publish()
+                .Channel(channel)
+                .Message("Message after unsubscribe")
+                .ExecuteAsync();
+
+            messageAfterUnsubscribe.WaitOne(3000);
+
+            Assert.IsFalse(messageReceivedAfterUnsubscribe, "Message should not be received after unsubscribe");
+
+            await Task.Delay(1000);
+        }
+
+        /// <summary>
+        /// Test: subscribe_integration_003
+        /// Subscribe to multiple channels and receive on all
+        /// </summary>
+        [Test]
+        public static async Task ThenSubscribeToMultipleChannelsShouldReceiveOnAll()
+        {
+            string[] channels =
+            {
+                GetRandomChannelName("integration_003_a"),
+                GetRandomChannelName("integration_003_b"),
+                GetRandomChannelName("integration_003_c")
+            };
+
+            PNConfiguration config = new PNConfiguration(new UserId("integration_user_003"))
+            {
+                PublishKey = PubnubCommon.NonPAMPublishKey,
+                SubscribeKey = PubnubCommon.NONPAMSubscribeKey,
+                Secure = true,
+            };
+
+            pubnub = new Pubnub(config);
+
+            Dictionary<string, bool> messagesReceived = new Dictionary<string, bool>();
+            foreach (var ch in channels)
+            {
+                messagesReceived[ch] = false;
+            }
+
+            ManualResetEvent allMessagesReceived = new ManualResetEvent(false);
+
+            var listener = new SubscribeCallbackExt(
+                (_, message) =>
+                {
+                    if (messagesReceived.ContainsKey(message.Channel))
+                    {
+                        messagesReceived[message.Channel] = true;
+
+                        // Check if all messages received
+                        bool allReceived = true;
+                        foreach (var received in messagesReceived.Values)
+                        {
+                            if (!received)
+                            {
+                                allReceived = false;
+                                break;
+                            }
+                        }
+
+                        if (allReceived)
+                        {
+                            allMessagesReceived.Set();
+                        }
+                    }
+                },
+                (_, presence) => { },
+                (_, status) => { }
+            );
+
+            pubnub.AddListener(listener);
+
+            pubnub.Subscribe<string>()
+                .Channels(channels)
+                .Execute();
+
+            await Task.Delay(2000);
+
+            // Publish to each channel
+            foreach (var channel in channels)
+            {
+                await pubnub.Publish()
+                    .Channel(channel)
+                    .Message($"Message for {channel}")
+                    .ExecuteAsync();
+
+                await Task.Delay(500);
+            }
+
+            bool allReceived = allMessagesReceived.WaitOne(15000);
+
+            Assert.IsTrue(allReceived, "Messages on all channels should be received");
+
+            foreach (var channel in channels)
+            {
+                Assert.IsTrue(messagesReceived[channel], $"Message on channel {channel} should be received");
+            }
+
+            pubnub.Unsubscribe<string>()
+                .Channels(channels)
+                .Execute();
+
+            await Task.Delay(1000);
+        }
+
+        /// <summary>
+        /// Test: subscribe_integration_005
+        /// Receive presence join event
+        /// </summary>
+        [Test]
+        public static async Task ThenPresenceJoinEventShouldBeReceived()
+        {
+            string channel = GetRandomChannelName("integration_presence_005");
+
+            PNConfiguration config1 = new PNConfiguration(new UserId("presence_user_listener"))
+            {
+                PublishKey = PubnubCommon.NonPAMPublishKey,
+                SubscribeKey = PubnubCommon.NONPAMSubscribeKey,
+                Secure = true,
+            };
+
+            PNConfiguration config2 = new PNConfiguration(new UserId("presence_user_joiner"))
+            {
+                PublishKey = PubnubCommon.NonPAMPublishKey,
+                SubscribeKey = PubnubCommon.NONPAMSubscribeKey,
+                Secure = true,
+            };
+
+            Pubnub pubnub1 = new Pubnub(config1);
+            Pubnub pubnub2 = new Pubnub(config2);
+
+            ManualResetEvent joinEventReceived = new ManualResetEvent(false);
+            PNPresenceEventResult joinEvent = null;
+
+            var listener1 = new SubscribeCallbackExt(
+                (_, message) => { },
+                (_, presence) =>
+                {
+                    if (presence.Event == "join" && presence.Uuid == "presence_user_joiner")
+                    {
+                        joinEvent = presence;
+                        joinEventReceived.Set();
+                    }
+                },
+                (_, status) => { }
+            );
+
+            pubnub1.AddListener(listener1);
+
+            // Subscribe with presence
+            pubnub1.Subscribe<string>()
+                .Channels(new[] { channel })
+                .WithPresence()
+                .Execute();
+
+            await Task.Delay(2000);
+
+            // Second user joins
+            pubnub2.Subscribe<string>()
+                .Channels(new[] { channel })
+                .Execute();
+
+            bool received = joinEventReceived.WaitOne(10000);
+
+            Assert.IsTrue(received, "Join event should be received");
+            Assert.IsNotNull(joinEvent, "Join event data should not be null");
+            Assert.AreEqual("join", joinEvent.Event, "Event type should be 'join'");
+            Assert.AreEqual("presence_user_joiner", joinEvent.Uuid, "UUID should match");
+
+            pubnub1.Unsubscribe<string>().Channels(new[] { channel }).Execute();
+            pubnub2.Unsubscribe<string>().Channels(new[] { channel }).Execute();
+
+            await Task.Delay(1000);
+
+            pubnub1.Destroy();
+            pubnub2.Destroy();
+        }
+
+        /// <summary>
+        /// Test: subscribe_integration_010
+        /// Subscribe with historical timetoken
+        /// </summary>
+        [Test]
+        public static async Task ThenSubscribeWithHistoricalTimetokenShouldReceiveCatchupMessages()
+        {
+            WireMockServer mockServer = null;
+            Pubnub mockPubnub = null;
+
+            try
+            {
+                string channel = "test_historical_tt_channel";
+                long historicalTimetoken = 15000000000000000; // Historical timetoken
+                long message1Timetoken = 15000000000000001;
+                long message2Timetoken = 15000000000000002;
+                long message3Timetoken = 15000000000000003;
+                long currentTimetoken = 15000000000000004;
+
+                // Start WireMock server
+                mockServer = WireMockServer.Start();
+
+                // Mock: Subscribe with historical timetoken - returns 3 catch-up messages
+                mockServer
+                    .Given(Request.Create()
+                        .WithPath($"/v2/subscribe/demo/{channel}/0")
+                        .WithParam("tt", historicalTimetoken.ToString())
+                        .UsingGet())
+                    .RespondWith(Response.Create()
+                        .WithStatusCode(200)
+                        .WithHeader("Content-Type", "application/json")
+                        .WithBodyAsJson(new
+                        {
+                            t = new { t = currentTimetoken.ToString(), r = 12 },
+                            m = new object[]
+                            {
+                                new
+                                {
+                                    c = channel,
+                                    d = "Historical message 0",
+                                    p = new { t = message1Timetoken.ToString(), r = 12 }
+                                },
+                                new
+                                {
+                                    c = channel,
+                                    d = "Historical message 1",
+                                    p = new { t = message2Timetoken.ToString(), r = 12 }
+                                },
+                                new
+                                {
+                                    c = channel,
+                                    d = "Historical message 2",
+                                    p = new { t = message3Timetoken.ToString(), r = 12 }
+                                }
+                            }
+                        })
+                        .WithDelay(TimeSpan.FromMilliseconds(100)));
+
+                // Mock: Long-poll subscribe (no new messages)
+                mockServer
+                    .Given(Request.Create()
+                        .WithPath($"/v2/subscribe/demo/{channel}/0")
+                        .WithParam("tt", currentTimetoken.ToString())
+                        .UsingGet())
+                    .RespondWith(Response.Create()
+                        .WithStatusCode(200)
+                        .WithHeader("Content-Type", "application/json")
+                        .WithBodyAsJson(new
+                        {
+                            t = new { t = (currentTimetoken + 1).ToString(), r = 12 },
+                            m = new object[] { }
+                        })
+                        .WithDelay(TimeSpan.FromSeconds(180)));
+
+                // Mock: Leave endpoint
+                mockServer
+                    .Given(Request.Create()
+                        .WithPath(new RegexMatcher(@"/v2/presence/sub_key/demo/channel/.*/leave"))
+                        .UsingGet())
+                    .RespondWith(Response.Create()
+                        .WithStatusCode(200)
+                        .WithHeader("Content-Type", "application/json")
+                        .WithBodyAsJson(new
+                        {
+                            status = 200,
+                            message = "OK",
+                            action = "leave",
+                            service = "Presence"
+                        }));
+
+                // Configure PubNub to use mock server
+                PNConfiguration config = new PNConfiguration(new UserId("integration_user_010"))
+                {
+                    PublishKey = "demo",
+                    SubscribeKey = "demo",
+                    Origin = $"localhost:{mockServer.Port}",
+                    Secure = false,
+                    EnableEventEngine = false // Use legacy mode for simpler testing
+                };
+
+                mockPubnub = new Pubnub(config);
+
+                // Subscribe from historical timetoken
+                ManualResetEvent messagesReceived = new ManualResetEvent(false);
+                List<PNMessageResult<object>> receivedMessages = new List<PNMessageResult<object>>();
+
+                var listener = new SubscribeCallbackExt(
+                    (_, message) =>
+                    {
+                        if (message.Channel == channel)
+                        {
+                            receivedMessages.Add(message);
+                            if (receivedMessages.Count >= 3)
+                            {
+                                messagesReceived.Set();
+                            }
+                        }
+                    },
+                    (_, presence) => { },
+                    (_, status) => { }
+                );
+
+                mockPubnub.AddListener(listener);
+
+                mockPubnub.Subscribe<string>()
+                    .Channels(new[] { channel })
+                    .WithTimetoken(historicalTimetoken)
+                    .Execute();
+
+                bool received = messagesReceived.WaitOne(10000);
+
+                Assert.IsTrue(received, "Catch-up messages should be received");
+                Assert.AreEqual(3, receivedMessages.Count, "Exactly 3 historical messages should be received");
+
+                // Verify messages are in chronological order
+                Assert.AreEqual("Historical message 0", receivedMessages[0].Message.ToString());
+                Assert.AreEqual("Historical message 1", receivedMessages[1].Message.ToString());
+                Assert.AreEqual("Historical message 2", receivedMessages[2].Message.ToString());
+
+                Assert.AreEqual(message1Timetoken, receivedMessages[0].Timetoken,
+                    "First message timetoken should match");
+                Assert.AreEqual(message2Timetoken, receivedMessages[1].Timetoken,
+                    "Second message timetoken should match");
+                Assert.AreEqual(message3Timetoken, receivedMessages[2].Timetoken,
+                    "Third message timetoken should match");
+
+                mockPubnub.Unsubscribe<string>()
+                    .Channels(new[] { channel })
+                    .Execute();
+
+                await Task.Delay(1000);
+            }
+            finally
+            {
+                // Cleanup
+                if (mockPubnub != null)
+                {
+                    try
+                    {
+                        mockPubnub.UnsubscribeAll<string>();
+                        mockPubnub.Destroy();
+                    }
+                    catch
+                    {
+                    }
+                }
+
+                if (mockServer != null)
+                {
+                    try
+                    {
+                        mockServer.Stop();
+                        mockServer.Dispose();
+                    }
+                    catch
+                    {
+                    }
+                }
+            }
+        }
+
+        /// <summary>
+        /// Test: subscribe_integration_028
+        /// Receive PNConnectedCategory status
+        /// </summary>
+        [Test]
+        public static async Task ThenConnectedStatusShouldBeReceived()
+        {
+            string channel = GetRandomChannelName("integration_status_028");
+
+            PNConfiguration config = new PNConfiguration(new UserId("integration_user_028"))
+            {
+                PublishKey = PubnubCommon.NonPAMPublishKey,
+                SubscribeKey = PubnubCommon.NONPAMSubscribeKey,
+                Secure = true,
+            };
+
+            pubnub = new Pubnub(config);
+
+            ManualResetEvent connectedEvent = new ManualResetEvent(false);
+            PNStatus connectedStatus = null;
+
+            var listener = new SubscribeCallbackExt(
+                (_, message) => { },
+                (_, presence) => { },
+                (_, status) =>
+                {
+                    if (status.Category == PNStatusCategory.PNConnectedCategory)
+                    {
+                        connectedStatus = status;
+                        connectedEvent.Set();
+                    }
+                }
+            );
+
+            pubnub.AddListener(listener);
+
+            pubnub.Subscribe<string>()
+                .Channels(new[] { channel })
+                .Execute();
+
+            bool received = connectedEvent.WaitOne(10000);
+
+            Assert.IsTrue(received, "Connected status should be received");
+            Assert.IsNotNull(connectedStatus, "Status object should not be null");
+            Assert.AreEqual(PNStatusCategory.PNConnectedCategory, connectedStatus.Category,
+                "Category should be PNConnectedCategory");
+            Assert.IsFalse(connectedStatus.Error, "Error should be false");
+            Assert.IsNotNull(connectedStatus.AffectedChannels, "Affected channels should be present");
+
+            pubnub.Unsubscribe<string>()
+                .Channels(new[] { channel })
+                .Execute();
+
+            await Task.Delay(1000);
+        }
+
+        /// <summary>
+        /// Test: subscribe_integration_029
+        /// Receive PNDisconnectedCategory status
+        /// </summary>
+        [Test]
+        public static async Task ThenDisconnectedStatusShouldBeReceived()
+        {
+            string channel = GetRandomChannelName("integration_status_029");
+
+            PNConfiguration config = new PNConfiguration(new UserId("integration_user_029"))
+            {
+                PublishKey = PubnubCommon.NonPAMPublishKey,
+                SubscribeKey = PubnubCommon.NONPAMSubscribeKey,
+                Secure = true,
+            };
+
+            pubnub = new Pubnub(config);
+
+            ManualResetEvent connectedEvent = new ManualResetEvent(false);
+            ManualResetEvent disconnectedEvent = new ManualResetEvent(false);
+            PNStatus disconnectedStatus = null;
+
+            var listener = new SubscribeCallbackExt(
+                (_, message) => { },
+                (_, presence) => { },
+                (_, status) =>
+                {
+                    if (status.Category == PNStatusCategory.PNConnectedCategory)
+                    {
+                        connectedEvent.Set();
+                    }
+                    else if (status.Category == PNStatusCategory.PNDisconnectedCategory)
+                    {
+                        disconnectedStatus = status;
+                        disconnectedEvent.Set();
+                    }
+                }
+            );
+
+            pubnub.AddListener(listener);
+
+            pubnub.Subscribe<string>()
+                .Channels(new[] { channel })
+                .Execute();
+
+            connectedEvent.WaitOne(10000);
+
+            // Now unsubscribe
+            pubnub.Unsubscribe<string>()
+                .Channels(new[] { channel })
+                .Execute();
+
+            bool received = disconnectedEvent.WaitOne(10000);
+
+            Assert.IsTrue(received, "Disconnected status should be received");
+            Assert.IsNotNull(disconnectedStatus, "Status object should not be null");
+            Assert.AreEqual(PNStatusCategory.PNDisconnectedCategory, disconnectedStatus.Category,
+                "Category should be PNDisconnectedCategory");
+            Assert.IsFalse(disconnectedStatus.Error, "Error should be false for intentional disconnect");
+
+            await Task.Delay(1000);
+        }
+
+        /// <summary>
+        /// Test: subscribe_integration_038
+        /// Messages are received in publish order
+        /// </summary>
+        [Test]
+        public static async Task ThenMessagesShouldBeReceivedInPublishOrder()
+        {
+            string channel = GetRandomChannelName("integration_ordering_038");
+
+            PNConfiguration config = new PNConfiguration(new UserId("integration_user_038"))
+            {
+                PublishKey = PubnubCommon.NonPAMPublishKey,
+                SubscribeKey = PubnubCommon.NONPAMSubscribeKey,
+                Secure = true,
+            };
+
+            pubnub = new Pubnub(config);
+
+            ManualResetEvent allMessagesReceived = new ManualResetEvent(false);
+            List<PNMessageResult<object>> receivedMessages = new List<PNMessageResult<object>>();
+            int expectedMessageCount = 10;
+
+            var listener = new SubscribeCallbackExt(
+                (_, message) =>
+                {
+                    if (message.Channel == channel)
+                    {
+                        receivedMessages.Add(message);
+                        if (receivedMessages.Count >= expectedMessageCount)
+                        {
+                            allMessagesReceived.Set();
+                        }
+                    }
+                },
+                (_, presence) => { },
+                (_, status) => { }
+            );
+
+            pubnub.AddListener(listener);
+
+            pubnub.Subscribe<string>()
+                .Channels(new[] { channel })
+                .Execute();
+
+            await Task.Delay(2000);
+
+            // Publish multiple messages rapidly
+            for (int i = 0; i < expectedMessageCount; i++)
+            {
+                await pubnub.Publish()
+                    .Channel(channel)
+                    .Message($"Message {i}")
+                    .ExecuteAsync();
+            }
+
+            bool received = allMessagesReceived.WaitOne(15000);
+
+            Assert.IsTrue(received, "All messages should be received");
+            Assert.AreEqual(expectedMessageCount, receivedMessages.Count, "Should receive all published messages");
+
+            // Verify messages are in order (ascending timetokens)
+            for (int i = 1; i < receivedMessages.Count; i++)
+            {
+                Assert.Greater(receivedMessages[i].Timetoken, receivedMessages[i - 1].Timetoken,
+                    $"Message {i} timetoken should be greater than message {i - 1}");
+            }
+
+            pubnub.Unsubscribe<string>()
+                .Channels(new[] { channel })
+                .Execute();
+
+            await Task.Delay(1000);
+        }
+
+        /// <summary>
+        /// Test: subscribe_integration_040
+        /// Subscribe receives messages with Unicode characters
+        /// </summary>
+        [Test]
+        public static async Task ThenUnicodeCharactersShouldBePreserved()
+        {
+            string channel = GetRandomChannelName("integration_unicode_040");
+            string unicodeMessage = "Hello 世界 🌍 Привет مرحبا";
+
+            PNConfiguration config = new PNConfiguration(new UserId("integration_user_040"))
+            {
+                PublishKey = PubnubCommon.NonPAMPublishKey,
+                SubscribeKey = PubnubCommon.NONPAMSubscribeKey,
+                Secure = true,
+            };
+
+            pubnub = new Pubnub(config);
+
+            ManualResetEvent messageReceived = new ManualResetEvent(false);
+            PNMessageResult<object> receivedMessage = null;
+
+            var listener = new SubscribeCallbackExt(
+                (_, message) =>
+                {
+                    if (message.Channel == channel)
+                    {
+                        receivedMessage = message;
+                        messageReceived.Set();
+                    }
+                },
+                (_, presence) => { },
+                (_, status) => { }
+            );
+
+            pubnub.AddListener(listener);
+
+            pubnub.Subscribe<string>()
+                .Channels(new[] { channel })
+                .Execute();
+
+            await Task.Delay(2000);
+
+            await pubnub.Publish()
+                .Channel(channel)
+                .Message(unicodeMessage)
+                .ExecuteAsync();
+
+            bool received = messageReceived.WaitOne(10000);
+
+            Assert.IsTrue(received, "Unicode message should be received");
+            Assert.IsNotNull(receivedMessage, "Received message should not be null");
+            Assert.AreEqual(unicodeMessage, receivedMessage.Message.ToString(),
+                "Unicode characters should be preserved");
+
+            pubnub.Unsubscribe<string>()
+                .Channels(new[] { channel })
+                .Execute();
+
+            await Task.Delay(1000);
+        }
+
+        #endregion
+
+        #region Listener Management Tests
+
+        /// <summary>
+        /// Test: subscribe_unit_020
+        /// Add listener before subscribing
+        /// </summary>
+        [Test]
+        public static async Task ThenAddListenerBeforeSubscribingShouldReceiveMessages()
+        {
+            string channel = GetRandomChannelName("test_listener");
+            PNConfiguration config = new PNConfiguration(new UserId("test_user_020"))
+            {
+                PublishKey = PubnubCommon.NonPAMPublishKey,
+                SubscribeKey = PubnubCommon.NONPAMSubscribeKey,
+                Secure = true,
+            };
+
+            pubnub = new Pubnub(config);
+
+            ManualResetEvent subscribeManualEvent = new ManualResetEvent(false);
+            ManualResetEvent messageManualEvent = new ManualResetEvent(false);
+            bool messageReceived = false;
+            bool listenerRegistered = false;
+
+            var listener = new SubscribeCallbackExt(
+                (_, message) =>
+                {
+                    if (message.Channel == channel)
+                    {
+                        messageReceived = true;
+                        messageManualEvent.Set();
+                    }
+                },
+                (_, presence) => { },
+                (_, status) =>
+                {
+                    if (status.Category == PNStatusCategory.PNConnectedCategory)
+                    {
+                        subscribeManualEvent.Set();
+                    }
+                }
+            );
+
+            // Add listener before subscribing
+            pubnub.AddListener(listener);
+            listenerRegistered = true;
+
+            Assert.IsTrue(listenerRegistered, "Listener should be registered");
+
+            pubnub.Subscribe<string>()
+                .Channels(new[] { channel })
+                .Execute();
+
+            subscribeManualEvent.WaitOne(10000);
+            await Task.Delay(1000);
+
+            // Publish a message
+            await pubnub.Publish()
+                .Channel(channel)
+                .Message("Test message")
+                .ExecuteAsync();
+
+            messageManualEvent.WaitOne(10000);
+
+            Assert.IsTrue(messageReceived, "Listener should receive messages after subscription");
+
+            pubnub.Unsubscribe<string>()
+                .Channels(new[] { channel })
+                .Execute();
+
+            await Task.Delay(1000);
+        }
+
+        /// <summary>
+        /// Test: subscribe_unit_021
+        /// Add multiple listeners
+        /// </summary>
+        [Test]
+        public static async Task ThenAddMultipleListenersShouldReceiveAllEvents()
+        {
+            string channel = GetRandomChannelName("test_multi_listener");
+            PNConfiguration config = new PNConfiguration(new UserId("test_user_021"))
+            {
+                PublishKey = PubnubCommon.NonPAMPublishKey,
+                SubscribeKey = PubnubCommon.NONPAMSubscribeKey,
+                Secure = true,
+            };
+
+            pubnub = new Pubnub(config);
+
+            ManualResetEvent listener1Event = new ManualResetEvent(false);
+            ManualResetEvent listener2Event = new ManualResetEvent(false);
+            ManualResetEvent listener3Event = new ManualResetEvent(false);
+
+            bool listener1Received = false;
+            bool listener2Received = false;
+            bool listener3Received = false;
+
+            var listener1 = new SubscribeCallbackExt(
+                (_, message) =>
+                {
+                    if (message.Channel == channel)
+                    {
+                        listener1Received = true;
+                        listener1Event.Set();
+                    }
+                },
+                (_, presence) => { },
+                (_, status) => { }
+            );
+
+            var listener2 = new SubscribeCallbackExt(
+                (_, message) =>
+                {
+                    if (message.Channel == channel)
+                    {
+                        listener2Received = true;
+                        listener2Event.Set();
+                    }
+                },
+                (_, presence) => { },
+                (_, status) => { }
+            );
+
+            var listener3 = new SubscribeCallbackExt(
+                (_, message) =>
+                {
+                    if (message.Channel == channel)
+                    {
+                        listener3Received = true;
+                        listener3Event.Set();
+                    }
+                },
+                (_, presence) => { },
+                (_, status) => { }
+            );
+
+            // Add multiple listeners
+            pubnub.AddListener(listener1);
+            pubnub.AddListener(listener2);
+            pubnub.AddListener(listener3);
+
+            pubnub.Subscribe<string>()
+                .Channels(new[] { channel })
+                .Execute();
+
+            await Task.Delay(2000);
+
+            // Publish a message
+            await pubnub.Publish()
+                .Channel(channel)
+                .Message("test_message")
+                .ExecuteAsync();
+
+            // All listeners should receive events
+            listener1Event.WaitOne(10000);
+            listener2Event.WaitOne(10000);
+            listener3Event.WaitOne(10000);
+
+            Assert.IsTrue(listener1Received, "Listener 1 should receive message");
+            Assert.IsTrue(listener2Received, "Listener 2 should receive message");
+            Assert.IsTrue(listener3Received, "Listener 3 should receive message");
+
+            pubnub.Unsubscribe<string>()
+                .Channels(new[] { channel })
+                .Execute();
+
+            await Task.Delay(1000);
+        }
+
+        /// <summary>
+        /// Test: subscribe_unit_022
+        /// Remove a specific listener
+        /// </summary>
+        [Test]
+        public static async Task ThenRemoveListenerShouldStopReceivingEvents()
+        {
+            string channel = GetRandomChannelName("test_remove_listener");
+            PNConfiguration config = new PNConfiguration(new UserId("test_user_022"))
+            {
+                PublishKey = PubnubCommon.NonPAMPublishKey,
+                SubscribeKey = PubnubCommon.NONPAMSubscribeKey,
+                Secure = true,
+            };
+
+            pubnub = new Pubnub(config);
+
+            ManualResetEvent listener1Event = new ManualResetEvent(false);
+            ManualResetEvent listener2Event = new ManualResetEvent(false);
+
+            int listener1MessageCount = 0;
+            int listener2MessageCount = 0;
+
+            var listener1 = new SubscribeCallbackExt(
+                (_, message) =>
+                {
+                    if (message.Channel == channel)
+                    {
+                        listener1MessageCount++;
+                        listener1Event.Set();
+                    }
+                },
+                (_, presence) => { },
+                (_, status) => { }
+            );
+
+            var listener2 = new SubscribeCallbackExt(
+                (_, message) =>
+                {
+                    if (message.Channel == channel)
+                    {
+                        listener2MessageCount++;
+                        listener2Event.Set();
+                    }
+                },
+                (_, presence) => { },
+                (_, status) => { }
+            );
+
+            // Add both listeners
+            pubnub.AddListener(listener1);
+            pubnub.AddListener(listener2);
+
+            pubnub.Subscribe<string>()
+                .Channels(new[] { channel })
+                .Execute();
+
+            await Task.Delay(2000);
+
+            // Publish first message
+            await pubnub.Publish()
+                .Channel(channel)
+                .Message("first_message")
+                .ExecuteAsync();
+
+            listener1Event.WaitOne(10000);
+            listener2Event.WaitOne(10000);
+
+            Assert.AreEqual(1, listener1MessageCount, "Listener1 should receive first message");
+            Assert.AreEqual(1, listener2MessageCount, "Listener2 should receive first message");
+
+            // Remove listener1
+            pubnub.RemoveListener(listener1);
+            listener1Event.Reset();
+            listener2Event.Reset();
+
+            await Task.Delay(1000);
+
+            // Publish second message
+            await pubnub.Publish()
+                .Channel(channel)
+                .Message("second_message")
+                .ExecuteAsync();
+
+            listener2Event.WaitOne(10000);
+            await Task.Delay(2000);
+
+            // listener1 should not receive new messages, listener2 should
+            Assert.AreEqual(1, listener1MessageCount, "Removed listener should not receive messages");
+            Assert.AreEqual(2, listener2MessageCount, "Active listener should receive message");
+
+            pubnub.Unsubscribe<string>()
+                .Channels(new[] { channel })
+                .Execute();
+
+            await Task.Delay(1000);
+        }
+
+        #endregion
+
+        #region Unsubscribe Operations Tests
+
+        /// <summary>
+        /// Test: subscribe_unit_061
+        /// Unsubscribe from a single channel
+        /// </summary>
+        [Test]
+        public static async Task ThenUnsubscribeFromSingleChannelShouldSucceed()
+        {
+            string channel = GetRandomChannelName("test_unsubscribe");
+            PNConfiguration config = new PNConfiguration(new UserId("test_user_061"))
+            {
+                PublishKey = PubnubCommon.NonPAMPublishKey,
+                SubscribeKey = PubnubCommon.NONPAMSubscribeKey,
+                Secure = true,
+            };
+
+            pubnub = new Pubnub(config);
+
+            ManualResetEvent subscribeEvent = new ManualResetEvent(false);
+            ManualResetEvent unsubscribeEvent = new ManualResetEvent(false);
+            bool disconnected = false;
+
+            var listener = new SubscribeCallbackExt(
+                (_, message) => { },
+                (_, presence) => { },
+                (_, status) =>
+                {
+                    if (status.Category == PNStatusCategory.PNConnectedCategory)
+                    {
+                        subscribeEvent.Set();
+                    }
+                    else if (status.Category == PNStatusCategory.PNDisconnectedCategory)
+                    {
+                        disconnected = true;
+                        unsubscribeEvent.Set();
+                    }
+                }
+            );
+
+            pubnub.AddListener(listener);
+
+            pubnub.Subscribe<string>()
+                .Channels(new[] { channel })
+                .Execute();
+
+            subscribeEvent.WaitOne(10000);
+
+            // Now unsubscribe
+            Assert.DoesNotThrow(() =>
+            {
+                pubnub.Unsubscribe<string>()
+                    .Channels(new[] { channel })
+                    .Execute();
+            }, "Unsubscribe should not throw exception");
+
+            unsubscribeEvent.WaitOne(5000);
+
+            Assert.IsTrue(disconnected, "Disconnection status should be received");
+
+            await Task.Delay(1000);
+        }
+
+        /// <summary>
+        /// Test: subscribe_unit_062
+        /// Unsubscribe from multiple channels
+        /// </summary>
+        [Test]
+        public static async Task ThenUnsubscribeFromMultipleChannelsShouldSucceed()
+        {
+            string[] channels =
+            {
+                GetRandomChannelName("channel_1"),
+                GetRandomChannelName("channel_2"),
+                GetRandomChannelName("channel_3")
+            };
+            PNConfiguration config = new PNConfiguration(new UserId("test_user_062"))
+            {
+                PublishKey = PubnubCommon.NonPAMPublishKey,
+                SubscribeKey = PubnubCommon.NONPAMSubscribeKey,
+                Secure = true,
+            };
+
+            pubnub = new Pubnub(config);
+
+            ManualResetEvent subscribeEvent = new ManualResetEvent(false);
+            ManualResetEvent unsubscribeEvent = new ManualResetEvent(false);
+            bool disconnected = false;
+
+            var listener = new SubscribeCallbackExt(
+                (_, message) => { },
+                (_, presence) => { },
+                (_, status) =>
+                {
+                    if (status.Category == PNStatusCategory.PNConnectedCategory)
+                    {
+                        subscribeEvent.Set();
+                    }
+                    else if (status.Category == PNStatusCategory.PNDisconnectedCategory)
+                    {
+                        disconnected = true;
+                        unsubscribeEvent.Set();
+                    }
+                }
+            );
+
+            pubnub.AddListener(listener);
+
+            pubnub.Subscribe<string>()
+                .Channels(channels)
+                .Execute();
+
+            subscribeEvent.WaitOne(10000);
+
+            // Unsubscribe from all channels
+            Assert.DoesNotThrow(() =>
+            {
+                pubnub.Unsubscribe<string>()
+                    .Channels(channels)
+                    .Execute();
+            }, "Unsubscribe from multiple channels should not throw exception");
+
+            unsubscribeEvent.WaitOne(5000);
+
+            Assert.IsTrue(disconnected, "Disconnection status should be received for all channels");
+
+            await Task.Delay(1000);
+        }
+
+        /// <summary>
+        /// Test: subscribe_unit_065
+        /// Unsubscribe from non-subscribed channel
+        /// </summary>
+        [Test]
+        public static void ThenUnsubscribeFromNonSubscribedChannelShouldNotThrowError()
+        {
+            string channel = GetRandomChannelName("test_non_subscribed");
+            PNConfiguration config = new PNConfiguration(new UserId("test_user_065"))
+            {
+                PublishKey = PubnubCommon.NonPAMPublishKey,
+                SubscribeKey = PubnubCommon.NONPAMSubscribeKey,
+                Secure = true,
+            };
+
+            pubnub = new Pubnub(config);
+
+            // Try to unsubscribe without subscribing first
+            Assert.DoesNotThrow(() =>
+            {
+                pubnub.Unsubscribe<string>()
+                    .Channels(new[] { channel })
+                    .Execute();
+            }, "Unsubscribe from non-subscribed channel should not throw exception");
+        }
+
+        /// <summary>
+        /// Test: subscribe_unit_066
+        /// UnsubscribeAll from all channels and groups
+        /// </summary>
+        [Test]
+        public static async Task ThenUnsubscribeAllShouldClearAllSubscriptions()
+        {
+            string[] channels =
+            {
+                GetRandomChannelName("channel_1"),
+                GetRandomChannelName("channel_2")
+            };
+            PNConfiguration config = new PNConfiguration(new UserId("test_user_066"))
+            {
+                PublishKey = PubnubCommon.NonPAMPublishKey,
+                SubscribeKey = PubnubCommon.NONPAMSubscribeKey,
+                Secure = true,
+            };
+
+            pubnub = new Pubnub(config);
+
+            ManualResetEvent subscribeEvent = new ManualResetEvent(false);
+            ManualResetEvent unsubscribeEvent = new ManualResetEvent(false);
+            bool disconnected = false;
+
+            var listener = new SubscribeCallbackExt(
+                (_, message) => { },
+                (_, presence) => { },
+                (_, status) =>
+                {
+                    if (status.Category == PNStatusCategory.PNConnectedCategory)
+                    {
+                        subscribeEvent.Set();
+                    }
+                    else if (status.Category == PNStatusCategory.PNDisconnectedCategory)
+                    {
+                        disconnected = true;
+                        unsubscribeEvent.Set();
+                    }
+                }
+            );
+
+            pubnub.AddListener(listener);
+
+            pubnub.Subscribe<string>()
+                .Channels(channels)
+                .Execute();
+
+            subscribeEvent.WaitOne(10000);
+
+            // UnsubscribeAll
+            Assert.DoesNotThrow(() => { pubnub.UnsubscribeAll<string>(); },
+                "UnsubscribeAll should not throw exception");
+
+            unsubscribeEvent.WaitOne(5000);
+
+            Assert.IsTrue(disconnected, "Disconnection status should be received after UnsubscribeAll");
+
+            await Task.Delay(1000);
+        }
+
+        /// <summary>
+        /// Test: subscribe_unit_067
+        /// UnsubscribeAll with no active subscriptions
+        /// </summary>
+        [Test]
+        public static void ThenUnsubscribeAllWithNoActiveSubscriptionsShouldNotThrowError()
+        {
+            PNConfiguration config = new PNConfiguration(new UserId("test_user_067"))
+            {
+                PublishKey = PubnubCommon.NonPAMPublishKey,
+                SubscribeKey = PubnubCommon.NONPAMSubscribeKey,
+                Secure = true,
+            };
+
+            pubnub = new Pubnub(config);
+
+            // Call UnsubscribeAll without any active subscriptions
+            Assert.DoesNotThrow(() => { pubnub.UnsubscribeAll<string>(); },
+                "UnsubscribeAll with no active subscriptions should not throw exception");
+        }
+
+        #endregion
+
+        #region Validation Tests
+
+        /// <summary>
+        /// Test: subscribe_unit_013
+        /// Subscribe with missing subscribe key
+        /// </summary>
+        [Test]
+        public static void ThenSubscribeWithMissingSubscribeKeyShouldThrowException()
+        {
+            string channel = GetRandomChannelName("test_channel");
+            string userId = GetRandomUserId("test_user_013");
+
+            PNConfiguration config = new PNConfiguration(new UserId(userId))
+            {
+                PublishKey = PubnubCommon.NonPAMPublishKey
+                // SubscribeKey is missing
+            };
+
+            pubnub = new Pubnub(config);
+
+            Assert.Throws<MissingMemberException>(() =>
+            {
+                pubnub.Subscribe<string>()
+                    .Channels(new[] { channel })
+                    .Execute();
+            }, "Subscribe without SubscribeKey should throw MissingMemberException");
+        }
+
+        /// <summary>
+        /// Test: subscribe_unit_014
+        /// Subscribe with empty channel array should not throw (handled gracefully by SDK)
+        /// </summary>
+        [Test]
+        public static void ThenSubscribeWithEmptyChannelArrayShouldNotThrow()
+        {
+            string userId = GetRandomUserId("test_user_014");
+
+            PNConfiguration config = new PNConfiguration(new UserId(userId))
+            {
+                PublishKey = PubnubCommon.NonPAMPublishKey,
+                SubscribeKey = PubnubCommon.NONPAMSubscribeKey
+            };
+
+            pubnub = new Pubnub(config);
+
+            // SDK handles empty arrays gracefully - no exception thrown at API level
+            Assert.DoesNotThrow(() =>
+            {
+                pubnub.Subscribe<string>()
+                    .Channels(new string[] { })
+                    .Execute();
+            }, "Subscribe with empty channel array should not throw exception");
+        }
+
+        /// <summary>
+        /// Test: subscribe_unit_018
+        /// Verify subscribe API accepts valid channel names with special characters
+        /// </summary>
+        [Test]
+        public static async Task ThenSubscribeAPIAcceptsChannelNamesWithSpecialCharacters()
+        {
+            string[] channels =
+            {
+                GetRandomChannelName("channel_with-dash"),
+                GetRandomChannelName("channel.with.dots"),
+                GetRandomChannelName("channel:with:colons")
+            };
+            string userId = GetRandomUserId("test_user_018");
+
+            PNConfiguration config = new PNConfiguration(new UserId(userId))
+            {
+                PublishKey = PubnubCommon.NonPAMPublishKey,
+                SubscribeKey = PubnubCommon.NONPAMSubscribeKey
+            };
+
+            pubnub = new Pubnub(config);
+
+            // Should not throw exception when calling subscribe with special characters
+            Assert.DoesNotThrow(() =>
+            {
+                pubnub.Subscribe<string>()
+                    .Channels(channels)
+                    .Execute();
+            }, "Subscribe API should accept channel names with special characters");
+
+            await Task.Delay(1000);
+
+            // Cleanup
+            pubnub.Unsubscribe<string>()
+                .Channels(channels)
+                .Execute();
+
+            await Task.Delay(1000);
+        }
+
+        /// <summary>
+        /// Test: subscribe_unit_019
+        /// Verify subscribe API accepts wildcard patterns
+        /// </summary>
+        [Test]
+        public static async Task ThenSubscribeAPIAcceptsWildcardPatterns()
+        {
+            string wildcardChannel = $"a.{random.Next(100000, 999999)}.*";
+            string userId = GetRandomUserId("test_user_019");
+
+            PNConfiguration config = new PNConfiguration(new UserId(userId))
+            {
+                PublishKey = PubnubCommon.NonPAMPublishKey,
+                SubscribeKey = PubnubCommon.NONPAMSubscribeKey
+            };
+
+            pubnub = new Pubnub(config);
+
+            // Should not throw exception when calling subscribe with wildcard pattern
+            Assert.DoesNotThrow(() =>
+            {
+                pubnub.Subscribe<string>()
+                    .Channels(new[] { wildcardChannel })
+                    .Execute();
+            }, "Subscribe API should accept wildcard channel patterns");
+
+            await Task.Delay(1000);
+
+            // Cleanup
+            pubnub.Unsubscribe<string>()
+                .Channels(new[] { wildcardChannel })
+                .Execute();
+
+            await Task.Delay(1000);
+        }
+
+        #endregion
+
+        #region Additional Subscribe Tests
+
+        /// <summary>
+        /// Test: Custom object deserialization
+        /// Subscribe should correctly deserialize custom object types
+        /// </summary>
+        [Test]
+        public static async Task ThenSubscribeWithCustomObjectShouldReceiveCorrectType()
+        {
+            string channel = GetRandomChannelName("custom_object_test");
+            string userId = GetRandomUserId("custom_obj_user");
+
+            PNConfiguration config = new PNConfiguration(new UserId(userId))
+            {
+                PublishKey = PubnubCommon.NonPAMPublishKey,
+                SubscribeKey = PubnubCommon.NONPAMSubscribeKey,
+                Secure = true
+            };
+
+            pubnub = new Pubnub(config);
+
+            ManualResetEvent messageReceived = new ManualResetEvent(false);
+            ManualResetEvent connected = new ManualResetEvent(false);
+            bool receivedCorrectType = false;
+
+            var testObject = new { Field1 = "Test", Field2 = 42, Field3 = new[] { "item1", "item2", "item3" } };
+
+            var listener = new SubscribeCallbackExt(
+                (_, message) =>
+                {
+                    if (message.Channel == channel && message.Message != null)
+                    {
+                        var json = pubnub.JsonPluggableLibrary.SerializeToJsonString(message.Message);
+                        if (json.Contains("Field1") && json.Contains("Field2") && json.Contains("Field3"))
+                        {
+                            receivedCorrectType = true;
+                        }
+
+                        messageReceived.Set();
+                    }
+                },
+                (_, presence) => { },
+                (_, status) =>
+                {
+                    if (status.Category == PNStatusCategory.PNConnectedCategory)
+                    {
+                        connected.Set();
+                    }
+                }
+            );
+
+            pubnub.AddListener(listener);
+
+            pubnub.Subscribe<string>()
+                .Channels(new[] { channel })
+                .Execute();
+
+            connected.WaitOne(10000);
+            await Task.Delay(1000);
+
+            // Publish the test object
+            await pubnub.Publish()
+                .Channel(channel)
+                .Message(testObject)
+                .ExecuteAsync();
+
+            messageReceived.WaitOne(10000);
+
+            Assert.IsTrue(receivedCorrectType, "Subscribe should correctly handle custom object types");
+
+            pubnub.Unsubscribe<string>()
+                .Channels(new[] { channel })
+                .Execute();
+
+            await Task.Delay(1000);
+        }
+
+        /// <summary>
+        /// Test: Subscribe with query parameters
+        /// Query parameters should be included in the request
+        /// </summary>
+        [Test]
+        public static async Task ThenSubscribeWithQueryParamsShouldWork()
+        {
+            string channel = GetRandomChannelName("query_param_test");
+            string userId = GetRandomUserId("query_param_user");
+
+            Dictionary<string, object> queryParams = new Dictionary<string, object>()
+            {
+                { "custom_param", "custom_value" },
+                { "numeric_param", 123 }
+            };
+
+            PNConfiguration config = new PNConfiguration(new UserId(userId))
+            {
+                PublishKey = PubnubCommon.NonPAMPublishKey,
+                SubscribeKey = PubnubCommon.NONPAMSubscribeKey,
+                Secure = true
+            };
+
+            pubnub = new Pubnub(config);
+
+            ManualResetEvent connected = new ManualResetEvent(false);
+
+            var listener = new SubscribeCallbackExt(
+                (_, message) => { },
+                (_, presence) => { },
+                (_, status) =>
+                {
+                    if (status.StatusCode == 200 && status.Category == PNStatusCategory.PNConnectedCategory)
+                    {
+                        connected.Set();
+                    }
+                }
+            );
+
+            pubnub.AddListener(listener);
+
+            Assert.DoesNotThrow(() =>
+            {
+                pubnub.Subscribe<string>()
+                    .Channels(new[] { channel })
+                    .QueryParam(queryParams)
+                    .Execute();
+            }, "Subscribe with query parameters should not throw exception");
+
+            bool isConnected = connected.WaitOne(10000);
+            Assert.IsTrue(isConnected, "Subscribe with query parameters should connect successfully");
+
+            pubnub.Unsubscribe<string>()
+                .Channels(new[] { channel })
+                .Execute();
+
+            await Task.Delay(1000);
+        }
+
+        /// <summary>
+        /// Test: Subscribe with channel groups only
+        /// Subscribe with only channel groups (no channels) should work
+        /// </summary>
+        [Test]
+        public static async Task ThenSubscribeWithOnlyChannelGroupsShouldWork()
+        {
+            WireMockServer mockServer = null;
+            Pubnub mockPubnub = null;
+
+            try
+            {
+                string channelGroup = "test_cg_only";
+                long initialTimetoken = 16000000000000000;
+                long nextTimetoken = 16000000000000001;
+
+                // Start WireMock server
+                mockServer = WireMockServer.Start();
+
+                // Mock: Subscribe with channel group (handshake with tt=0)
+                mockServer
+                    .Given(Request.Create()
+                        .WithPath("/v2/subscribe/demo/,/0")
+                        .WithParam("channel-group", channelGroup)
+                        .WithParam("tt", "0")
+                        .UsingGet())
+                    .RespondWith(Response.Create()
+                        .WithStatusCode(200)
+                        .WithHeader("Content-Type", "application/json")
+                        .WithBodyAsJson(new
+                        {
+                            t = new { t = initialTimetoken.ToString(), r = 12 },
+                            m = new object[] { }
+                        })
+                        .WithDelay(TimeSpan.FromMilliseconds(100)));
+
+                // Mock: Long-poll subscribe for channel group
+                mockServer
+                    .Given(Request.Create()
+                        .WithPath("/v2/subscribe/demo/,/0")
+                        .WithParam("channel-group", channelGroup)
+                        .WithParam("tt", initialTimetoken.ToString())
+                        .UsingGet())
+                    .RespondWith(Response.Create()
+                        .WithStatusCode(200)
+                        .WithHeader("Content-Type", "application/json")
+                        .WithBodyAsJson(new
+                        {
+                            t = new { t = nextTimetoken.ToString(), r = 12 },
+                            m = new object[] { }
+                        })
+                        .WithDelay(TimeSpan.FromSeconds(180)));
+
+                // Mock: Leave endpoint
+                mockServer
+                    .Given(Request.Create()
+                        .WithPath(new RegexMatcher(@"/v2/presence/sub_key/demo/channel/.*/leave"))
+                        .UsingGet())
+                    .RespondWith(Response.Create()
+                        .WithStatusCode(200)
+                        .WithHeader("Content-Type", "application/json")
+                        .WithBodyAsJson(new
+                        {
+                            status = 200,
+                            message = "OK",
+                            action = "leave",
+                            service = "Presence"
+                        }));
+
+                // Configure PubNub to use mock server
+                PNConfiguration config = new PNConfiguration(new UserId("cg_only_user"))
+                {
+                    PublishKey = "demo",
+                    SubscribeKey = "demo",
+                    Origin = $"localhost:{mockServer.Port}",
+                    Secure = false,
+                    EnableEventEngine = false // Use legacy mode for simpler testing
+                };
+
+                mockPubnub = new Pubnub(config);
+
+                ManualResetEvent connected = new ManualResetEvent(false);
+
+                var listener = new SubscribeCallbackExt(
+                    (_, message) => { },
+                    (_, presence) => { },
+                    (_, status) =>
+                    {
+                        if (status.Category == PNStatusCategory.PNConnectedCategory)
+                        {
+                            connected.Set();
+                        }
+                    }
+                );
+
+                mockPubnub.AddListener(listener);
+
+                Assert.DoesNotThrow(() =>
+                {
+                    mockPubnub.Subscribe<string>()
+                        .ChannelGroups(new[] { channelGroup })
+                        .Execute();
+                }, "Subscribe with only channel groups should not throw exception");
+
+                bool isConnected = connected.WaitOne(10000);
+                Assert.IsTrue(isConnected, "Subscribe with channel groups only should connect");
+
+                // Use UnsubscribeAll for channel groups to avoid null channel array issue
+                mockPubnub.UnsubscribeAll<string>();
+
+                await Task.Delay(1000);
+            }
+            finally
+            {
+                // Cleanup
+                if (mockPubnub != null)
+                {
+                    try
+                    {
+                        mockPubnub.Destroy();
+                    }
+                    catch
+                    {
+                    }
+                }
+
+                if (mockServer != null)
+                {
+                    try
+                    {
+                        mockServer.Stop();
+                        mockServer.Dispose();
+                    }
+                    catch
+                    {
+                    }
+                }
+            }
+        }
+
+        /// <summary>
+        /// Test: Reconnect with timetoken reset
+        /// Reconnect with reset flag should start from beginning
+        /// </summary>
+        [Test]
+        public static async Task ThenReconnectWithResetShouldStartFromBeginning()
+        {
+            string channel = GetRandomChannelName("reset_tt_test");
+            string userId = GetRandomUserId("reset_tt_user");
+
+            PNConfiguration config = new PNConfiguration(new UserId(userId))
+            {
+                PublishKey = PubnubCommon.NonPAMPublishKey,
+                SubscribeKey = PubnubCommon.NONPAMSubscribeKey,
+                Secure = true
+            };
+
+            pubnub = new Pubnub(config);
+
+            ManualResetEvent connected = new ManualResetEvent(false);
+            ManualResetEvent reconnected = new ManualResetEvent(false);
+
+            var listener = new SubscribeCallbackExt(
+                (_, message) => { },
+                (_, presence) => { },
+                (_, status) =>
+                {
+                    if (status.Category == PNStatusCategory.PNConnectedCategory && !connected.WaitOne(0))
+                    {
+                        connected.Set();
+                    }
+                    else if (status.Category == PNStatusCategory.PNReconnectedCategory)
+                    {
+                        reconnected.Set();
+                    }
+                }
+            );
+
+            pubnub.AddListener(listener);
+
+            pubnub.Subscribe<string>()
+                .Channels(new[] { channel })
+                .Execute();
+
+            connected.WaitOne(10000);
+            await Task.Delay(1000);
+
+            // Disconnect
+            pubnub.Disconnect<string>();
+            await Task.Delay(1000);
+
+            // Reconnect with reset timetoken
+            Assert.DoesNotThrow(() =>
+            {
+                pubnub.Reconnect<string>(true); // true = reset timetoken to 0
+            }, "Reconnect with reset timetoken should not throw exception");
+
+            reconnected.WaitOne(10000);
+
+            pubnub.Unsubscribe<string>()
+                .Channels(new[] { channel })
+                .Execute();
+
+            await Task.Delay(1000);
+        }
+
+        #endregion
+    }
+}

--- a/src/UnitTests/PubnubApiPCL.Tests/PubnubApiPCL.Tests.csproj
+++ b/src/UnitTests/PubnubApiPCL.Tests/PubnubApiPCL.Tests.csproj
@@ -93,13 +93,14 @@
     <Compile Include="..\PubnubApi.Tests\WhenSubscribedToAChannel.cs" Link="WhenSubscribedToAChannel.cs" />
     <Compile Include="..\PubnubApi.Tests\WhenSubscribedToAChannel2.cs" Link="WhenSubscribedToAChannel2.cs" />
     <Compile Include="..\PubnubApi.Tests\WhenSubscribedToAChannel3.cs" Link="WhenSubscribedToAChannel3.cs" />
+    <Compile Include="..\PubnubApi.Tests\WhenSubscribedToAChannelComprehensive.cs" Link="WhenSubscribedToAChannelComprehensive.cs" />
     <Compile Include="..\PubnubApi.Tests\WhenSubscribedToAChannelGroup.cs" Link="WhenSubscribedToAChannelGroup.cs" />
     <Compile Include="..\PubnubApi.Tests\WhenSubscribedToWildcardChannel.cs" Link="WhenSubscribedToWildcardChannel.cs" />
+    <Compile Include="..\PubnubApi.Tests\WhenSubscribeToChannelPresence.cs" Link="WhenSubscribeToChannelPresence.cs" />
+    <Compile Include="..\PubnubApi.Tests\WhenSubscribeWithDuplicateChannels.cs" Link="WhenSubscribeWithDuplicateChannels.cs" />
     <Compile Include="..\PubnubApi.Tests\WhenUnsubscribedToAChannel.cs" Link="WhenUnsubscribedToAChannel.cs" />
     <Compile Include="..\PubnubApi.Tests\WhenUnsubscribedToAChannelGroup.cs" Link="WhenUnsubscribedToAChannelGroup.cs" />
     <Compile Include="..\PubnubApi.Tests\WhenUserIdInPNConfig.cs" Link="WhenUserIdInPNConfig.cs" />
-    <Compile Include="..\PubnubApi.Tests\WhenSubscribeToChannelPresence.cs" Link="WhenSubscribeToChannelPresence.cs" />
-    <Compile Include="..\PubnubApi.Tests\WhenSubscribeWithDuplicateChannels.cs" Link="WhenSubscribeWithDuplicateChannels.cs" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
fix: subscription not breaking when user provided listener callback throws exception.

Fixes issue of subscription loop breaking when a listener callback throws exception.