### PR TITLE
support for publish v2 for larger publish payload size

### DIFF
--- a/.pubnub.yml
+++ b/.pubnub.yml
@@ -1,8 +1,13 @@
 name: c-sharp
-version: "8.1.0"
+version: "8.2.0"
 schema: 1
 scm: github.com/pubnub/c-sharp
 changelog:
+  - date: 2026-05-18
+    version: v8.2.0
+    changes:
+      - type: feature
+        text: "Added support for the publish v2 endpoint, allowing feature-enabled keysets to publish messages of size up to 2MB."
   - date: 2025-12-18
     version: v8.1.0
     changes:
@@ -977,14 +982,14 @@ features:
     - QUERY-PARAM
 supported-platforms:
   -
-    version: Pubnub 'C#' 8.1.0
+    version: Pubnub 'C#' 8.2.0
     platforms:
       - Windows 10 and up
       - Windows Server 2008 and up
     frameworks:
       - .Net Framework 4.5+
   -
-    version: PubnubPCL 'C#' 8.1.0
+    version: PubnubPCL 'C#' 8.2.0
     platforms:
       - Xamarin.Android
       - Xamarin.iOS
@@ -996,7 +1001,7 @@ supported-platforms:
     frameworks:
       - .Net 4.5+
   -
-    version: PubnubUWP 'C#' 8.1.0
+    version: PubnubUWP 'C#' 8.2.0
     platforms:
       - Windows Phone 10
       - Universal Windows Apps
@@ -1020,7 +1025,7 @@ sdks:
             distribution-type: source
             distribution-repository: GitHub
             package-name: Pubnub
-            location: https://github.com/pubnub/c-sharp/releases/tag/v8.1.0
+            location: https://github.com/pubnub/c-sharp/releases/tag/v8.2.0
             requires:
               -
                 name: ".Net"
@@ -1261,7 +1266,7 @@ sdks:
             distribution-type: source
             distribution-repository: GitHub
             package-name: PubNubPCL
-            location: https://github.com/pubnub/c-sharp/releases/tag/v8.1.0
+            location: https://github.com/pubnub/c-sharp/releases/tag/v8.2.0
             requires:
               -
                 name: ".Net"
@@ -1612,7 +1617,7 @@ sdks:
             distribution-type: source
             distribution-repository: GitHub
             package-name: PubnubUWP
-            location: https://github.com/pubnub/c-sharp/releases/tag/v8.1.0
+            location: https://github.com/pubnub/c-sharp/releases/tag/v8.2.0
             requires:
               -
                 name: "Universal Windows Platform Development"

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+v8.2.0 - May 18 2026
+-----------------------------
+- Added: added support for the publish v2 endpoint, allowing feature-enabled keysets to publish messages of size up to 2MB.
+
 v8.1.0 - December 18 2025
 -----------------------------
 - Added: added a config option to split multi-channel subscribes for keysets with channel sharding enabled.

--- a/src/Api/PubnubApi/EndPoint/PubSub/PublishOperation.cs
+++ b/src/Api/PubnubApi/EndPoint/PubSub/PublishOperation.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using System.Threading;
@@ -16,9 +16,11 @@ namespace PubnubApi.EndPoint
         private readonly IJsonPluggableLibrary jsonLibrary;
         private readonly IPubnubUnitTest unit;
         
-        private const int MaxPublishRequestSizeBytes = 32 * 1024;
+        private const int MaxPublishRequestSizeBytes = 32768;
+        private const int MaxMessageContentSizeBytes = 2097152;
         private const int PostBodyFramingOverheadBytes = 2;
         private object publishContent;
+        private string preparedMessageContent;
         private string channelName = "";
         private bool storeInHistory = true;
         private bool httpPost;
@@ -41,6 +43,7 @@ namespace PubnubApi.EndPoint
         public PublishOperation Message(object message)
         {
             publishContent = message;
+            preparedMessageContent = PrepareContent(message);
             return this;
         }
 
@@ -114,6 +117,8 @@ namespace PubnubApi.EndPoint
                 throw new ArgumentException("Missing userCallback");
             }
 
+            ValidateMessageContentSize();
+
             savedCallback = callback;
             logger?.Trace($"{GetType().Name} Execute invoked");
             Publish(channelName, publishContent, storeInHistory, ttl, userMetadata, queryParam, callback);
@@ -121,6 +126,7 @@ namespace PubnubApi.EndPoint
 
         public async Task<PNResult<PNPublishResult>> ExecuteAsync()
         {
+            ValidateMessageContentSize();
             syncRequest = false;
             logger?.Trace($"{GetType().Name} ExecuteAsync invoked.");
             return await Publish(channelName, publishContent, storeInHistory, ttl, userMetadata, queryParam)
@@ -138,6 +144,8 @@ namespace PubnubApi.EndPoint
             {
                 throw new MissingMemberException("publish key is required");
             }
+
+            ValidateMessageContentSize();
 
             logger?.Trace($"{GetType().Name} parameter validated.");
             ManualResetEvent syncEvent = new ManualResetEvent(false);
@@ -398,6 +406,15 @@ namespace PubnubApi.EndPoint
             }
         }
 
+        private void ValidateMessageContentSize()
+        {
+            if (preparedMessageContent != null
+                && Encoding.UTF8.GetByteCount(preparedMessageContent) > MaxMessageContentSizeBytes)
+            {
+                throw new ArgumentException("Message content size exceeds the maximum permissible size of 2 MiB.");
+            }
+        }
+
         private string PrepareContent(object originalMessage)
         {
             string message = jsonLibrary.SerializeToJsonString(originalMessage);
@@ -414,7 +431,7 @@ namespace PubnubApi.EndPoint
 
         private RequestParameter CreateRequestParameter()
         {
-            var messageContent = PrepareContent(publishContent);
+            var messageContent = preparedMessageContent;
             Dictionary<string, string> requestQueryStringParams = new Dictionary<string, string>();
 
             if (userMetadata != null)
@@ -476,6 +493,11 @@ namespace PubnubApi.EndPoint
                 PathSegment = pathSegments,
                 Query = requestQueryStringParams
             };
+
+            if (useV2Endpoint)
+            {
+                requestParam.Headers.Add("Expect", "100-continue");
+            }
 
             if (usePost)
             {

--- a/src/Api/PubnubApi/EndPoint/PubSub/PublishOperation.cs
+++ b/src/Api/PubnubApi/EndPoint/PubSub/PublishOperation.cs
@@ -15,7 +15,9 @@ namespace PubnubApi.EndPoint
         private readonly PNConfiguration config;
         private readonly IJsonPluggableLibrary jsonLibrary;
         private readonly IPubnubUnitTest unit;
-
+        
+        private const int MaxPublishRequestSizeBytes = 32 * 1024;
+        private const int PostBodyFramingOverheadBytes = 2;
         private object publishContent;
         private string channelName = "";
         private bool storeInHistory = true;
@@ -412,20 +414,7 @@ namespace PubnubApi.EndPoint
 
         private RequestParameter CreateRequestParameter()
         {
-            List<string> urlSegments =
-            [
-                "publish",
-                config.PublishKey ?? "",
-                config.SubscribeKey ?? "",
-                "0",
-                channelName,
-                "0"
-            ];
-            if (!httpPost)
-            {
-                urlSegments.Add(PrepareContent(publishContent));
-            }
-
+            var messageContent = PrepareContent(publishContent);
             Dictionary<string, string> requestQueryStringParams = new Dictionary<string, string>();
 
             if (userMetadata != null)
@@ -463,19 +452,98 @@ namespace PubnubApi.EndPoint
                 }
             }
 
-            var requestParam = new RequestParameter()
+            // Determine whether to use v2/publish endpoint and HTTP method.
+            var endpointInfo = ResolvePublishEndpoint(messageContent, requestQueryStringParams);
+            bool useV2Endpoint = endpointInfo.UseV2Endpoint;
+            bool usePost = endpointInfo.UsePost;
+
+            // Build URL path segments
+            var pathSegments = new List<string>();
+            if (useV2Endpoint)
             {
-                RequestType = httpPost ? Constants.POST : Constants.GET,
-                PathSegment = urlSegments,
+                pathSegments.Add("v2");
+            }
+            pathSegments.AddRange(["publish", config.PublishKey ?? "", config.SubscribeKey ?? "", "0", channelName, "0"]);
+
+            if (!usePost)
+            {
+                pathSegments.Add(messageContent);
+            }
+
+            var requestParam = new RequestParameter
+            {
+                RequestType = usePost ? Constants.POST : Constants.GET,
+                PathSegment = pathSegments,
                 Query = requestQueryStringParams
             };
-            if (httpPost)
+            requestParam.Headers.Add("Expect", "100-continue");
+
+            if (usePost)
             {
-                string postMessage = PrepareContent(publishContent);
-                requestParam.BodyContentString = postMessage;
+                requestParam.BodyContentString = messageContent;
             }
 
             return requestParam;
+        }
+        
+        private PublishEndpointInfo ResolvePublishEndpoint(
+            string messageContent,
+            Dictionary<string, string> queryParams)
+        {
+            int messageSizeBytes = Encoding.UTF8.GetByteCount(messageContent);
+
+            if (httpPost)
+            {
+                bool exceedsPostLimit = messageSizeBytes >= MaxPublishRequestSizeBytes - PostBodyFramingOverheadBytes;
+                return new PublishEndpointInfo { UseV2Endpoint = exceedsPostLimit, UsePost = true };
+            }
+            int urlSizeWithoutMessage = EstimateUrlSizeWithoutMessage(queryParams);
+            int availableForMessage = MaxPublishRequestSizeBytes - urlSizeWithoutMessage;
+
+            if (messageSizeBytes >= availableForMessage)
+            {
+                // Message too large for URL; switch to v2/publish with POST body
+                return new PublishEndpointInfo { UseV2Endpoint = true, UsePost = true };
+            }
+
+            return new PublishEndpointInfo { UseV2Endpoint = false, UsePost = false };
+        }
+        private struct PublishEndpointInfo
+        {
+            public bool UseV2Endpoint;
+            public bool UsePost;
+        }
+        
+        /// Estimates the total URL byte size excluding the message content.
+        /// Accounts for base URL components, path segments, user-specified query parameters,
+        /// and parameters injected later by the transport middleware
+        /// (uuid, pnsdk, requestid, instanceid, timestamp, auth, signature).
+        private int EstimateUrlSizeWithoutMessage(Dictionary<string, string> queryParams)
+        {
+            // 155 bytes covers the fixed overhead from base URL components and
+            // middleware-injected query params: scheme, origin, path separators,
+            // uuid, pnsdk, requestid, instanceid, and timestamp.
+            int estimatedSize = 155;
+
+            // Auth key adds "&auth={value}" — 5 bytes for the key portion plus the value length
+            if (config.AuthKey?.Length > 0)
+            {
+                estimatedSize += 5 + config.AuthKey.Length;
+            }
+
+            // Secret key triggers HMAC signature: "&signature=v2.{base64}" ≈ 80 bytes
+            if (!string.IsNullOrEmpty(config.SecretKey))
+            {
+                estimatedSize += 80;
+            }
+
+            // Add encoded size of the user-specified query parameters
+            estimatedSize += UriUtil.EncodeUriComponent(
+                UriUtil.BuildQueryString(queryParams),
+                PNOperationType.PNPublishOperation, false, false, false
+            ).Length;
+
+            return estimatedSize;
         }
 
         private void CleanUp()

--- a/src/Api/PubnubApi/EndPoint/PubSub/PublishOperation.cs
+++ b/src/Api/PubnubApi/EndPoint/PubSub/PublishOperation.cs
@@ -515,56 +515,55 @@ namespace PubnubApi.EndPoint
 
             if (httpPost)
             {
-                bool exceedsPostLimit = messageSizeBytes >= MaxPublishRequestSizeBytes - PostBodyFramingOverheadBytes;
-                return new PublishEndpointInfo { UseV2Endpoint = exceedsPostLimit, UsePost = true };
+                bool exceedsPostLimit = messageSizeBytes > MaxPublishRequestSizeBytes - PostBodyFramingOverheadBytes;
+                return new PublishEndpointInfo(useV2Endpoint: exceedsPostLimit, usePost: true);
             }
-            int urlSizeWithoutMessage = EstimateUrlSizeWithoutMessage(queryParams);
-            int availableForMessage = MaxPublishRequestSizeBytes - urlSizeWithoutMessage;
 
-            if (messageSizeBytes >= availableForMessage)
+            int estimatedGetUrlSizeBytes = EstimateGetPublishUrlSizeBytes(messageContent, queryParams);
+            if (estimatedGetUrlSizeBytes > MaxPublishRequestSizeBytes)
             {
                 // Message too large for URL; switch to v2/publish with POST body
-                return new PublishEndpointInfo { UseV2Endpoint = true, UsePost = true };
+                return new PublishEndpointInfo(useV2Endpoint: true, usePost: true);
             }
 
-            return new PublishEndpointInfo { UseV2Endpoint = false, UsePost = false };
+            return new PublishEndpointInfo(useV2Endpoint: false, usePost: false);
         }
-        private struct PublishEndpointInfo
+
+        private struct PublishEndpointInfo(bool useV2Endpoint, bool usePost)
         {
-            public bool UseV2Endpoint;
-            public bool UsePost;
+            public bool UseV2Endpoint = useV2Endpoint;
+            public bool UsePost = usePost;
         }
-        
-        /// Estimates the total URL byte size excluding the message content.
-        /// Accounts for base URL components, path segments, user-specified query parameters,
-        /// and parameters injected later by the transport middleware
-        /// (uuid, pnsdk, requestid, instanceid, timestamp, auth, signature).
-        private int EstimateUrlSizeWithoutMessage(Dictionary<string, string> queryParams)
+
+        /// Estimates final URL size for regular publish GET using the same middleware path
+        /// and query construction used for actual requests.
+        private int EstimateGetPublishUrlSizeBytes(string messageContent, Dictionary<string, string> queryParams)
         {
-            // 155 bytes covers the fixed overhead from base URL components and
-            // middleware-injected query params: scheme, origin, path separators,
-            // uuid, pnsdk, requestid, instanceid, and timestamp.
-            int estimatedSize = 155;
-
-            // Auth key adds "&auth={value}" — 5 bytes for the key portion plus the value length
-            if (config.AuthKey?.Length > 0)
+            var getPathSegments = new List<string>
             {
-                estimatedSize += 5 + config.AuthKey.Length;
-            }
+                "publish",
+                config.PublishKey ?? "",
+                config.SubscribeKey ?? "",
+                "0",
+                channelName,
+                "0",
+                messageContent
+            };
 
-            // Secret key triggers HMAC signature: "&signature=v2.{base64}" ≈ 80 bytes
-            if (!string.IsNullOrEmpty(config.SecretKey))
+            var requestParam = new RequestParameter
             {
-                estimatedSize += 80;
-            }
+                RequestType = Constants.GET,
+                PathSegment = getPathSegments,
+                Query = queryParams == null
+                    ? new Dictionary<string, string>()
+                    : new Dictionary<string, string>(queryParams)
+            };
 
-            // Add encoded size of the user-specified query parameters
-            estimatedSize += UriUtil.EncodeUriComponent(
-                UriUtil.BuildQueryString(queryParams),
-                PNOperationType.PNPublishOperation, false, false, false
-            ).Length;
+            var transportRequest = PubnubInstance.transportMiddleware.PreapareTransportRequest(
+                requestParameter: requestParam,
+                operationType: PNOperationType.PNPublishOperation);
 
-            return estimatedSize;
+            return Encoding.UTF8.GetByteCount(transportRequest.RequestUrl ?? string.Empty);
         }
 
         private void CleanUp()

--- a/src/Api/PubnubApi/EndPoint/PubSub/PublishOperation.cs
+++ b/src/Api/PubnubApi/EndPoint/PubSub/PublishOperation.cs
@@ -476,7 +476,6 @@ namespace PubnubApi.EndPoint
                 PathSegment = pathSegments,
                 Query = requestQueryStringParams
             };
-            requestParam.Headers.Add("Expect", "100-continue");
 
             if (usePost)
             {

--- a/src/Api/PubnubApi/JsonDataParse/PNSetChannelMetadataJsonDataParse.cs
+++ b/src/Api/PubnubApi/JsonDataParse/PNSetChannelMetadataJsonDataParse.cs
@@ -29,6 +29,9 @@ namespace PubnubApi
                     result.Type = (getSetChMetadataDataDic.ContainsKey("type") && getSetChMetadataDataDic["type"] != null)
                         ? getSetChMetadataDataDic["type"].ToString()
                         : null;
+                    result.ETag = (getSetChMetadataDataDic.ContainsKey("eTag") && getSetChMetadataDataDic["eTag"] != null)
+                        ? getSetChMetadataDataDic["eTag"].ToString()
+                        : null;
                     if (getSetChMetadataDataDic.ContainsKey("custom"))
                     {
                         result.Custom = jsonPlug.ConvertToDictionaryObject(getSetChMetadataDataDic["custom"]);

--- a/src/Api/PubnubApi/JsonDataParse/PNSetUuidMetadataJsonDataParse.cs
+++ b/src/Api/PubnubApi/JsonDataParse/PNSetUuidMetadataJsonDataParse.cs
@@ -23,6 +23,7 @@ namespace PubnubApi
                     result.Status = setUuidDataDic.ContainsKey("status") && setUuidDataDic["status"] != null ? setUuidDataDic["status"].ToString() : null;
                     result.Type = setUuidDataDic.ContainsKey("type") && setUuidDataDic["type"] != null ? setUuidDataDic["type"].ToString() : null;
                     result.Updated = setUuidDataDic.ContainsKey("updated") && setUuidDataDic["updated"] != null ? setUuidDataDic["updated"].ToString() : "";
+                    result.ETag = setUuidDataDic.ContainsKey("eTag") && setUuidDataDic["eTag"] != null ? setUuidDataDic["eTag"].ToString() : null;
                     if (setUuidDataDic.ContainsKey("custom"))
                     {
                         result.Custom = jsonPlug.ConvertToDictionaryObject(setUuidDataDic["custom"]);

--- a/src/Api/PubnubApi/Model/Consumer/Objects/PNChannelMetadataResult.cs
+++ b/src/Api/PubnubApi/Model/Consumer/Objects/PNChannelMetadataResult.cs
@@ -13,5 +13,6 @@ namespace PubnubApi
         public string Type { get; internal set; }
         public Dictionary<string, object> Custom { get; internal set; }
         public string Updated { get; internal set; }
+        public string ETag { get; internal set; }
     }
 }

--- a/src/Api/PubnubApi/Model/Consumer/Objects/PNUuidMetadataResult.cs
+++ b/src/Api/PubnubApi/Model/Consumer/Objects/PNUuidMetadataResult.cs
@@ -13,5 +13,6 @@ namespace PubnubApi
         public string ProfileUrl { get; internal set; }
         public Dictionary<string, object> Custom { get; internal set; }
         public string Updated { get; internal set; }
+        public string ETag { get; internal set; }
     }
 }

--- a/src/Api/PubnubApi/PNConfiguration.cs
+++ b/src/Api/PubnubApi/PNConfiguration.cs
@@ -198,7 +198,7 @@ namespace PubnubApi
             }
         }
 
-        public int NonSubscribeRequestTimeout { get; set; } = 120;
+        public int NonSubscribeRequestTimeout { get; set; } = 15;
 
         public PNHeartbeatNotificationOption HeartbeatNotificationOption { get; set; }
 
@@ -266,7 +266,7 @@ namespace PubnubApi
         {
             Origin = "ps.pndsn.com";
             presenceHeartbeatTimeout = 300;
-            NonSubscribeRequestTimeout = 120;
+            NonSubscribeRequestTimeout = 15;
             SubscribeTimeout = 310;
             LogVerbosity = PNLogVerbosity.NONE;
             CipherKey = "";

--- a/src/Api/PubnubApi/PNConfiguration.cs
+++ b/src/Api/PubnubApi/PNConfiguration.cs
@@ -198,7 +198,7 @@ namespace PubnubApi
             }
         }
 
-        public int NonSubscribeRequestTimeout { get; set; } = 15;
+        public int NonSubscribeRequestTimeout { get; set; } = 120;
 
         public PNHeartbeatNotificationOption HeartbeatNotificationOption { get; set; }
 
@@ -266,7 +266,7 @@ namespace PubnubApi
         {
             Origin = "ps.pndsn.com";
             presenceHeartbeatTimeout = 300;
-            NonSubscribeRequestTimeout = 15;
+            NonSubscribeRequestTimeout = 120;
             SubscribeTimeout = 310;
             LogVerbosity = PNLogVerbosity.NONE;
             CipherKey = "";

--- a/src/Api/PubnubApi/Properties/AssemblyInfo.cs
+++ b/src/Api/PubnubApi/Properties/AssemblyInfo.cs
@@ -11,8 +11,8 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyProduct("Pubnub C# SDK")]
 [assembly: AssemblyCopyright("Copyright ©  2021")]
 [assembly: AssemblyTrademark("")]
-[assembly: AssemblyVersion("8.1.0")]
-[assembly: AssemblyFileVersion("8.1.0")]
+[assembly: AssemblyVersion("8.2.0")]
+[assembly: AssemblyFileVersion("8.2.0")]
 // Setting ComVisible to false makes the types in this assembly not visible
 // to COM components.  If you need to access a type in this assembly from
 // COM, set the ComVisible attribute to true on that type.

--- a/src/Api/PubnubApi/PubnubApi.csproj
+++ b/src/Api/PubnubApi/PubnubApi.csproj
@@ -14,7 +14,7 @@
 
   <PropertyGroup>
     <PackageId>Pubnub</PackageId>
-    <PackageVersion>8.1.0</PackageVersion>
+    <PackageVersion>8.2.0</PackageVersion>
     <Title>PubNub C# .NET - Web Data Push API</Title>
     <Authors>Pandu Masabathula</Authors>
     <Owners>PubNub</Owners>
@@ -22,7 +22,7 @@
     <PackageIconUrl>http://pubnub.s3.amazonaws.com/2011/powered-by-pubnub/pubnub-icon-600x600.png</PackageIconUrl>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
     <RepositoryUrl>https://github.com/pubnub/c-sharp/</RepositoryUrl>
-    <PackageReleaseNotes>Added a config option to split multi-channel subscribes for keysets with channel sharding enabled.</PackageReleaseNotes>
+    <PackageReleaseNotes>Added support for the publish v2 endpoint, allowing feature-enabled keysets to publish messages of size up to 2MB.</PackageReleaseNotes>
     <PackageTags>Web Data Push Real-time Notifications ESB Message Broadcasting Distributed Computing</PackageTags>
     <!--<Summary>PubNub is a Massively Scalable Web Push Service for Web and Mobile Games.  This is a cloud-based service for broadcasting messages to thousands of web and mobile clients simultaneously</Summary>-->
     <Description>PubNub is a Massively Scalable Web Push Service for Web and Mobile Games.  This is a cloud-based service for broadcasting messages to thousands of web and mobile clients simultaneously</Description>

--- a/src/Api/PubnubApi/Transport/HttpClientService.cs
+++ b/src/Api/PubnubApi/Transport/HttpClientService.cs
@@ -115,10 +115,17 @@ namespace PubnubApi
                         postData.Headers.Add(transportRequestHeader.Key, transportRequestHeader.Value);
                     }
                 }
-
                 HttpRequestMessage requestMessage =
                     new HttpRequestMessage(method: HttpMethod.Post, requestUri: transportRequest.RequestUrl)
                         { Content = postData };
+                // Set Http Request header, When the header is not a payload content header.
+                if (transportRequest.Headers.Keys.Count > 0 && transportRequest.BodyContentBytes == null)
+                {
+                    foreach (var kvp in transportRequest.Headers)
+                    {
+                        requestMessage.Headers.Add(kvp.Key, kvp.Value);
+                    }
+                }
                 logger?.Debug(
                     $"HttpClient Service:Sending http request {transportRequest.RequestType} to {transportRequest.RequestUrl}" +
                     (requestMessage.Headers.Any()

--- a/src/Api/PubnubApi/Transport/Middleware.cs
+++ b/src/Api/PubnubApi/Transport/Middleware.cs
@@ -85,8 +85,11 @@ namespace PubnubApi
 				stringToSign.AppendFormat(CultureInfo.InvariantCulture, "{0}\n", configuration.PublishKey);
 				stringToSign.AppendFormat(CultureInfo.InvariantCulture, "{0}\n", pathString);
 				stringToSign.AppendFormat(CultureInfo.InvariantCulture, "{0}\n", queryString);
-				if (!string.IsNullOrEmpty(requestParameter.BodyContentString) && 
-				    !isPublishGET(requestParameter.PathSegment)) stringToSign.Append(requestParameter.BodyContentString);
+				if (!string.IsNullOrEmpty(requestParameter.BodyContentString) &&
+				    !isPublishGET(requestParameter.PathSegment))
+				{
+					stringToSign.Append(requestParameter.BodyContentString);
+				}
 				signature = Util.PubnubAccessManagerSign(configuration.SecretKey, stringToSign.ToString());
 				signature = string.Format(CultureInfo.InvariantCulture, "v2.{0}", signature.TrimEnd(new[] { '=' }));
 				requestParameter.Query.Add("signature", signature);

--- a/src/Api/PubnubApi/Transport/Middleware.cs
+++ b/src/Api/PubnubApi/Transport/Middleware.cs
@@ -80,11 +80,13 @@ namespace PubnubApi
 			{
 				string signature = string.Empty;
 				StringBuilder stringToSign = new StringBuilder();
-				stringToSign.AppendFormat(CultureInfo.InvariantCulture, "{0}\n", operationType == PNOperationType.PNPublishOperation ? "GET" : requestParameter.RequestType);
+				stringToSign.AppendFormat(CultureInfo.InvariantCulture, "{0}\n", operationType == PNOperationType.PNPublishOperation 
+					&& !requestParameter.PathSegment.Contains("v2")? "GET": requestParameter.RequestType);
 				stringToSign.AppendFormat(CultureInfo.InvariantCulture, "{0}\n", configuration.PublishKey);
 				stringToSign.AppendFormat(CultureInfo.InvariantCulture, "{0}\n", pathString);
 				stringToSign.AppendFormat(CultureInfo.InvariantCulture, "{0}\n", queryString);
-				if (!string.IsNullOrEmpty(requestParameter.BodyContentString) && operationType != PNOperationType.PNPublishOperation) stringToSign.Append(requestParameter.BodyContentString);
+				if (!string.IsNullOrEmpty(requestParameter.BodyContentString) && 
+				    !isPublishGET(requestParameter.PathSegment)) stringToSign.Append(requestParameter.BodyContentString);
 				signature = Util.PubnubAccessManagerSign(configuration.SecretKey, stringToSign.ToString());
 				signature = string.Format(CultureInfo.InvariantCulture, "v2.{0}", signature.TrimEnd(new[] { '=' }));
 				requestParameter.Query.Add("signature", signature);
@@ -152,6 +154,11 @@ namespace PubnubApi
 			TimeSpan timeSpan = dotNetUTCDateTime - new DateTime(1970, 1, 1, 0, 0, 0, DateTimeKind.Utc);
 			long timeStamp = Convert.ToInt64(timeSpan.TotalSeconds);
 			return timeStamp;
+		}
+
+		private bool isPublishGET(List<string> pathSegments)
+		{
+			return pathSegments.Contains("publish") && !pathSegments.Contains("v2");
 		}
 	}
 }

--- a/src/Api/PubnubApiPCL/PubnubApiPCL.csproj
+++ b/src/Api/PubnubApiPCL/PubnubApiPCL.csproj
@@ -14,7 +14,7 @@
 
   <PropertyGroup>
     <PackageId>PubnubPCL</PackageId>
-    <PackageVersion>8.1.0</PackageVersion>
+    <PackageVersion>8.2.0</PackageVersion>
     <Title>PubNub C# .NET - Web Data Push API</Title>
     <Authors>Pandu Masabathula</Authors>
     <Owners>PubNub</Owners>
@@ -22,7 +22,7 @@
     <PackageIconUrl>http://pubnub.s3.amazonaws.com/2011/powered-by-pubnub/pubnub-icon-600x600.png</PackageIconUrl>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
     <RepositoryUrl>https://github.com/pubnub/c-sharp/</RepositoryUrl>
-    <PackageReleaseNotes>Added a config option to split multi-channel subscribes for keysets with channel sharding enabled.</PackageReleaseNotes>
+    <PackageReleaseNotes>Added support for the publish v2 endpoint, allowing feature-enabled keysets to publish messages of size up to 2MB.</PackageReleaseNotes>
     <PackageTags>Web Data Push Real-time Notifications ESB Message Broadcasting Distributed Computing</PackageTags>
     <!--<Summary>PubNub is a Massively Scalable Web Push Service for Web and Mobile Games.  This is a cloud-based service for broadcasting messages to thousands of web and mobile clients simultaneously</Summary>-->
     <Description>PubNub is a Massively Scalable Web Push Service for Web and Mobile Games.  This is a cloud-based service for broadcasting messages to thousands of web and mobile clients simultaneously</Description>

--- a/src/Api/PubnubApiUWP/PubnubApiUWP.csproj
+++ b/src/Api/PubnubApiUWP/PubnubApiUWP.csproj
@@ -16,7 +16,7 @@
 
   <PropertyGroup>
     <PackageId>PubnubUWP</PackageId>
-    <PackageVersion>8.1.0</PackageVersion>
+    <PackageVersion>8.2.0</PackageVersion>
     <Title>PubNub C# .NET - Web Data Push API</Title>
     <Authors>Pandu Masabathula</Authors>
     <Owners>PubNub</Owners>
@@ -24,7 +24,7 @@
     <PackageIconUrl>http://pubnub.s3.amazonaws.com/2011/powered-by-pubnub/pubnub-icon-600x600.png</PackageIconUrl>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
     <RepositoryUrl>https://github.com/pubnub/c-sharp/</RepositoryUrl>
-    <PackageReleaseNotes>Added a config option to split multi-channel subscribes for keysets with channel sharding enabled.</PackageReleaseNotes>
+    <PackageReleaseNotes>Added support for the publish v2 endpoint, allowing feature-enabled keysets to publish messages of size up to 2MB.</PackageReleaseNotes>
     <PackageTags>Web Data Push Real-time Notifications ESB Message Broadcasting Distributed Computing</PackageTags>
     <!--<Summary>PubNub is a Massively Scalable Web Push Service for Web and Mobile Games.  This is a cloud-based service for broadcasting messages to thousands of web and mobile clients simultaneously</Summary>-->
     <Description>PubNub is a Massively Scalable Web Push Service for Web and Mobile Games.  This is a cloud-based service for broadcasting messages to thousands of web and mobile clients simultaneously</Description>

--- a/src/Api/PubnubApiUnity/PubnubApiUnity.csproj
+++ b/src/Api/PubnubApiUnity/PubnubApiUnity.csproj
@@ -15,7 +15,7 @@
 
   <PropertyGroup>
     <PackageId>PubnubApiUnity</PackageId>
-    <PackageVersion>8.1.0</PackageVersion>
+    <PackageVersion>8.2.0</PackageVersion>
     <Title>PubNub C# .NET - Web Data Push API</Title>
     <Authors>Pandu Masabathula</Authors>
     <Owners>PubNub</Owners>

--- a/src/UnitTests/PubnubApi.Tests/WhenAMessageIsPublished.cs
+++ b/src/UnitTests/PubnubApi.Tests/WhenAMessageIsPublished.cs
@@ -3073,7 +3073,7 @@ namespace PubNubMessaging.Tests
             // Arrange — message is one byte above the max permitted content size.
             // The SDK must throw ArgumentException before making any HTTP request.
             var pubnub = CreatePubnub();
-            var message = CreateMessageOfSerializedSize(TwoMbBoundaryBytes + 1);
+            var message = CreateMessageOfSerializedSize(TwoMbBoundaryBytes + 4);
 
             // Act & Assert
             var ex = Assert.ThrowsAsync<ArgumentException>(async () =>

--- a/src/UnitTests/PubnubApi.Tests/WhenAMessageIsPublished.cs
+++ b/src/UnitTests/PubnubApi.Tests/WhenAMessageIsPublished.cs
@@ -1,4 +1,5 @@
-﻿using System;
+using System;
+using System.Linq;
 using NUnit.Framework;
 using System.Threading;
 using PubnubApi;
@@ -13,6 +14,10 @@ using PubnubApi.Tests;
 #endif
 using PubnubApi.Security.Crypto;
 using PubnubApi.Security.Crypto.Cryptors;
+using WireMock.Server;
+using WireMock.Matchers;
+using WireMockRequest = WireMock.RequestBuilders.Request;
+using WireMockResponse = WireMock.ResponseBuilders.Response;
 
 namespace PubNubMessaging.Tests
 {
@@ -2641,5 +2646,401 @@ namespace PubNubMessaging.Tests
             publisher.PubnubUnitTest = null;
             publisher = null;
         }
+    }
+
+    /// <summary>
+    /// Tests for the v2/publish endpoint selection logic based on message payload size.
+    /// Verifies that the SDK correctly chooses between the regular publish endpoint and
+    /// the v2/publish endpoint depending on serialized message size and the UsePOST flag.
+    ///
+    /// Boundary rules under test:
+    /// <list type="bullet">
+    ///   <item>Regular publish (GET): message in URL path, total URL must stay under 32 KB.</item>
+    ///   <item>Regular publish (POST): body must be less than 32*1024 − 2 = 32 766 bytes.</item>
+    ///   <item>v2/publish (POST): used when regular limits are exceeded; server rejects bodies ≥ 2*1024*1024 − 2 bytes with 413.</item>
+    /// </list>
+    /// </summary>
+    [TestFixture]
+    public class WhenLargeMessageIsPublished
+    {
+        private WireMockServer _server;
+        private Pubnub _pubnub;
+
+        private const string Channel = "test_channel";
+        private const string PubKey = "demo";
+        private const string SubKey = "demo";
+        private const string PublishSuccessResponse = "[1,\"Sent\",\"14715278266153304\"]";
+        private const string Publish413Response =
+            "{\"status\":413,\"service\":\"Balancer\",\"error\":true,\"message\":\"Request Entity Too Large\"}";
+
+        /// <summary>
+        /// POST body boundary for the regular publish endpoint.
+        /// Matches <c>PublishOperation.MaxPublishRequestSizeBytes − PostBodyFramingOverheadBytes</c>.
+        /// At or above this size the SDK must switch to v2/publish.
+        /// </summary>
+        private const int PostBodyBoundaryBytes = 32 * 1024 - 2; // 32 766
+
+        /// <summary>
+        /// Server-side body limit for v2/publish.
+        /// PubNub servers return HTTP 413 for payloads at or above this size.
+        /// </summary>
+        private const int TwoMbBoundaryBytes = 2 * 1024 * 1024 - 2; // 2 097 150
+
+        [SetUp]
+        public void Setup()
+        {
+            _server = WireMockServer.Start();
+            SetupDefaultPublishSuccessMock();
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            _pubnub?.Destroy();
+            _server?.Stop();
+            _server?.Dispose();
+        }
+
+        /// <summary>
+        /// Registers a catch-all mock that responds with a standard publish success
+        /// regardless of path or HTTP method. Individual tests override as needed.
+        /// </summary>
+        private void SetupDefaultPublishSuccessMock()
+        {
+            _server
+                .Given(WireMockRequest.Create().UsingAnyMethod())
+                .RespondWith(WireMockResponse.Create()
+                    .WithStatusCode(200)
+                    .WithBody(PublishSuccessResponse));
+        }
+
+        private Pubnub CreatePubnub()
+        {
+            var config = new PNConfiguration(new UserId("test-uuid"))
+            {
+                PublishKey = PubKey,
+                SubscribeKey = SubKey,
+                Origin = $"localhost:{_server.Port}",
+                Secure = false
+            };
+            _pubnub = new Pubnub(config);
+            return _pubnub;
+        }
+
+        /// <summary>
+        /// Creates a plain ASCII string that, when JSON-serialized by Newtonsoft.Json,
+        /// produces exactly <paramref name="targetSerializedBytes"/> bytes.
+        /// JSON serialization of a simple string adds 2 bytes for the surrounding double-quotes.
+        /// </summary>
+        private static string CreateMessageOfSerializedSize(int targetSerializedBytes)
+        {
+            // 'a' is a single UTF-8 byte that requires no JSON escaping.
+            // Serialized form: "aaa...a" → (targetSerializedBytes − 2) chars + 2 quote bytes.
+            return new string('a', targetSerializedBytes - 2);
+        }
+
+        /// <summary>
+        /// Expected URL path prefix for the regular publish endpoint.
+        /// Format: <c>/publish/{pubKey}/{subKey}/0/{channel}/0</c>.
+        /// For GET, the encoded message is appended after this prefix.
+        /// </summary>
+        private static readonly string RegularPublishPathBase =
+            $"/publish/{PubKey}/{SubKey}/0/{Channel}/0";
+
+        /// <summary>
+        /// Expected URL path for the v2/publish endpoint (no message in path).
+        /// Format: <c>/v2/publish/{pubKey}/{subKey}/0/{channel}/0</c>.
+        /// </summary>
+        private static readonly string V2PublishPath =
+            $"/v2/publish/{PubKey}/{SubKey}/0/{Channel}/0";
+
+        /// <summary>
+        /// Asserts that the last HTTP request used the regular publish endpoint
+        /// with the expected method, correct path structure, and no v2 prefix.
+        /// </summary>
+        private void AssertRegularPublishEndpoint(string expectedMethod)
+        {
+            var entry = _server.LogEntries.Last();
+            Assert.That(entry.RequestMessage.Method, Is.EqualTo(expectedMethod),
+                $"Expected HTTP method {expectedMethod}.");
+            Assert.That(entry.RequestMessage.Path, Does.StartWith(RegularPublishPathBase),
+                $"Path should follow the regular publish structure: {RegularPublishPathBase}");
+            Assert.That(entry.RequestMessage.Path, Does.Not.StartWith("/v2/"),
+                "Should NOT use the /v2/publish/ endpoint.");
+        }
+
+        /// <summary>
+        /// Asserts that the last HTTP request used the v2/publish endpoint
+        /// with POST method and the correct path structure.
+        /// </summary>
+        private void AssertV2PublishEndpoint()
+        {
+            var entry = _server.LogEntries.Last();
+            Assert.That(entry.RequestMessage.Method, Is.EqualTo("POST"),
+                "v2/publish always uses POST.");
+            Assert.That(entry.RequestMessage.Path, Is.EqualTo(V2PublishPath),
+                $"Path should exactly match the v2/publish structure: {V2PublishPath}");
+        }
+
+        #region Small payload — regular publish endpoint respects UsePOST flag
+
+        [Test]
+        public async Task ThenSmallPayload_GetMode_UsesRegularPublishGetEndpoint()
+        {
+            // Arrange
+            var pubnub = CreatePubnub();
+
+            // Act
+            var result = await pubnub.Publish()
+                .Channel(Channel)
+                .Message("Hello")
+                .ExecuteAsync();
+
+            // Assert — publish succeeded
+            Assert.That(result.Result, Is.Not.Null, "Publish result should not be null.");
+            Assert.That(result.Status.Error, Is.False, "Publish should succeed.");
+            Assert.That(result.Result.Timetoken, Is.GreaterThan(0), "Timetoken should be set.");
+            AssertRegularPublishEndpoint("GET");
+
+            // Assert — for GET, message is in the URL path, not in the body
+            var entry = _server.LogEntries.Last();
+            Assert.That(entry.RequestMessage.Path, Does.Contain("Hello"),
+                "GET publish should include the message in the URL path.");
+            Assert.That(entry.RequestMessage.Body, Is.Null.Or.Empty,
+                "GET publish should not have a request body.");
+        }
+
+        [Test]
+        public async Task ThenSmallPayload_PostMode_UsesRegularPublishPostEndpoint()
+        {
+            // Arrange
+            var pubnub = CreatePubnub();
+
+            // Act
+            var result = await pubnub.Publish()
+                .Channel(Channel)
+                .Message("Hello")
+                .UsePOST(true)
+                .ExecuteAsync();
+
+            // Assert — publish succeeded
+            Assert.That(result.Result, Is.Not.Null, "Publish result should not be null.");
+            Assert.That(result.Status.Error, Is.False, "Publish should succeed.");
+            Assert.That(result.Result.Timetoken, Is.GreaterThan(0), "Timetoken should be set.");
+            AssertRegularPublishEndpoint("POST");
+
+            // Assert — for POST, message is in the body and the path ends at /0
+            var entry = _server.LogEntries.Last();
+            Assert.That(entry.RequestMessage.Body, Does.Contain("Hello"),
+                "POST publish should include the message in the request body.");
+            Assert.That(entry.RequestMessage.Path, Is.EqualTo(RegularPublishPathBase),
+                "Regular POST path should not contain the message.");
+        }
+
+        #endregion
+
+        #region 32 KB POST-body boundary — v2/publish activation
+
+        [Test]
+        public async Task ThenPostBody_ExactlyAtBoundary_32766Bytes_UsesV2PublishEndpoint()
+        {
+            // Arrange — serialized message is exactly at the 32 766-byte boundary
+            var pubnub = CreatePubnub();
+            var message = CreateMessageOfSerializedSize(PostBodyBoundaryBytes);
+
+            // Act
+            var result = await pubnub.Publish()
+                .Channel(Channel)
+                .Message(message)
+                .UsePOST(true)
+                .ExecuteAsync();
+
+            // Assert
+            Assert.That(result.Result, Is.Not.Null, "Publish result should not be null.");
+            Assert.That(result.Status.Error, Is.False, "Publish should succeed.");
+            AssertV2PublishEndpoint();
+        }
+
+        [Test]
+        public async Task ThenPostBody_OneBelowBoundary_32765Bytes_UsesRegularPublishEndpoint()
+        {
+            // Arrange — serialized message is one byte below the boundary
+            var pubnub = CreatePubnub();
+            var message = CreateMessageOfSerializedSize(PostBodyBoundaryBytes - 1);
+
+            // Act
+            var result = await pubnub.Publish()
+                .Channel(Channel)
+                .Message(message)
+                .UsePOST(true)
+                .ExecuteAsync();
+
+            // Assert
+            Assert.That(result.Result, Is.Not.Null, "Publish result should not be null.");
+            Assert.That(result.Status.Error, Is.False, "Publish should succeed.");
+            AssertRegularPublishEndpoint("POST");
+        }
+
+        #endregion
+
+        #region Large payload — v2/publish forced regardless of UsePOST flag
+
+        [Test]
+        public async Task ThenLargePayload_GetMode_FallsBackToV2PublishPostEndpoint()
+        {
+            // Arrange — 40 KB message, well above the 32 KB URL limit; UsePOST not set
+            var pubnub = CreatePubnub();
+            var message = CreateMessageOfSerializedSize(40_000);
+
+            // Act
+            var result = await pubnub.Publish()
+                .Channel(Channel)
+                .Message(message)
+                .ExecuteAsync();
+
+            // Assert — SDK should auto-switch to v2/publish with POST
+            Assert.That(result.Result, Is.Not.Null, "Publish result should not be null.");
+            Assert.That(result.Status.Error, Is.False, "Publish should succeed.");
+            AssertV2PublishEndpoint();
+        }
+
+        [Test]
+        public async Task ThenLargePayload_PostMode_AboveBoundary_UsesV2PublishEndpoint()
+        {
+            // Arrange — 100 bytes above the POST-body boundary, with UsePOST(true)
+            var pubnub = CreatePubnub();
+            var message = CreateMessageOfSerializedSize(PostBodyBoundaryBytes + 100);
+
+            // Act
+            var result = await pubnub.Publish()
+                .Channel(Channel)
+                .Message(message)
+                .UsePOST(true)
+                .ExecuteAsync();
+
+            // Assert
+            Assert.That(result.Result, Is.Not.Null, "Publish result should not be null.");
+            Assert.That(result.Status.Error, Is.False, "Publish should succeed.");
+            AssertV2PublishEndpoint();
+        }
+
+        [Test]
+        public async Task ThenLargePayload_ExplicitGetMode_StillForcedToV2PublishPost()
+        {
+            // Arrange — explicitly set UsePOST(false) with a large message.
+            // The SDK must override this and use v2/publish with POST.
+            var pubnub = CreatePubnub();
+            var message = CreateMessageOfSerializedSize(40_000);
+
+            // Act
+            var result = await pubnub.Publish()
+                .Channel(Channel)
+                .Message(message)
+                .UsePOST(false)
+                .ExecuteAsync();
+
+            // Assert — UsePOST(false) should be overridden for large payloads
+            Assert.That(result.Result, Is.Not.Null, "Publish result should not be null.");
+            Assert.That(result.Status.Error, Is.False, "Publish should succeed.");
+            AssertV2PublishEndpoint();
+
+            // Assert — message is in the body, not in the URL path
+            var entry = _server.LogEntries.Last();
+            Assert.That(entry.RequestMessage.Body, Is.Not.Null.And.Not.Empty,
+                "v2/publish should carry the message in the request body.");
+        }
+
+        #endregion
+
+        #region Non-string payload — JSON object endpoint selection
+
+        [Test]
+        public async Task ThenLargeJsonObjectPayload_GetMode_UsesV2PublishEndpoint()
+        {
+            // Arrange — a large dictionary that serializes to > 32 KB of JSON
+            var pubnub = CreatePubnub();
+            var largeObject = new Dictionary<string, string>();
+            for (int i = 0; i < 500; i++)
+            {
+                largeObject[$"key_{i:D4}"] = new string('x', 100);
+            }
+
+            // Act — no UsePOST, so GET mode is attempted first
+            var result = await pubnub.Publish()
+                .Channel(Channel)
+                .Message(largeObject)
+                .ExecuteAsync();
+
+            // Assert — large JSON object should trigger v2/publish with POST
+            Assert.That(result.Result, Is.Not.Null, "Publish result should not be null.");
+            Assert.That(result.Status.Error, Is.False, "Publish should succeed.");
+            AssertV2PublishEndpoint();
+        }
+
+        #endregion
+
+        #region 2 MB server-side boundary — HTTP 413 Request Entity Too Large
+
+        [Test]
+        public async Task ThenPayload_Above2MBBoundary_UsesV2PublishAndServerReturns413()
+        {
+            // Arrange — override the default mock so v2/publish returns 413
+            _server.Reset();
+            _server
+                .Given(WireMockRequest.Create()
+                    .WithPath(new WildcardMatcher("/v2/publish/*"))
+                    .UsingPost())
+                .RespondWith(WireMockResponse.Create()
+                    .WithStatusCode(413)
+                    .WithBody(Publish413Response));
+
+            var pubnub = CreatePubnub();
+            var message = CreateMessageOfSerializedSize(TwoMbBoundaryBytes);
+
+            // Act
+            var result = await pubnub.Publish()
+                .Channel(Channel)
+                .Message(message)
+                .UsePOST(true)
+                .ExecuteAsync();
+
+            // Assert — verify the request went to v2/publish
+            Assert.That(_server.LogEntries.Count(), Is.GreaterThanOrEqualTo(1),
+                "At least one request should have been made.");
+            var entry = _server.LogEntries.Last();
+            Assert.That(entry.RequestMessage.Method, Is.EqualTo("POST"));
+            Assert.That(entry.RequestMessage.Path, Does.StartWith("/v2/publish/"),
+                "Payload at the 2 MB boundary should use v2/publish.");
+
+            // Assert — verify the 413 error was surfaced through the SDK
+            Assert.That(result.Result, Is.Null,
+                "Publish should not return a result when the server rejects with 413.");
+            Assert.That(result.Status, Is.Not.Null, "Status should always be set.");
+            Assert.That(result.Status.Error, Is.True,
+                "Server 413 rejection should be reported as an error.");
+        }
+
+        [Test]
+        public async Task ThenPayload_JustBelow2MBBoundary_UsesV2PublishAndSucceeds()
+        {
+            // Arrange — one byte below the 2 MB boundary; default success mock handles it
+            var pubnub = CreatePubnub();
+            var message = CreateMessageOfSerializedSize(TwoMbBoundaryBytes - 1);
+
+            // Act
+            var result = await pubnub.Publish()
+                .Channel(Channel)
+                .Message(message)
+                .UsePOST(true)
+                .ExecuteAsync();
+
+            // Assert
+            Assert.That(result.Result, Is.Not.Null, "Publish result should not be null.");
+            Assert.That(result.Status.Error, Is.False,
+                "Payload one byte below the 2 MB boundary should succeed.");
+            AssertV2PublishEndpoint();
+        }
+
+        #endregion
     }
 }

--- a/src/UnitTests/PubnubApi.Tests/WhenAMessageIsPublished.cs
+++ b/src/UnitTests/PubnubApi.Tests/WhenAMessageIsPublished.cs
@@ -2866,6 +2866,26 @@ namespace PubNubMessaging.Tests
         #region 32 KB POST-body boundary — v2/publish activation
 
         [Test]
+        public async Task ThenPostBody_MoreThanBoundary_32766Bytes_UsesV2PublishEndpoint()
+        {
+            // Arrange — serialized message is more than at the 32 766-byte boundary
+            var pubnub = CreatePubnub();
+            var message = CreateMessageOfSerializedSize(PostBodyBoundaryBytes +1);
+
+            // Act
+            var result = await pubnub.Publish()
+                .Channel(Channel)
+                .Message(message)
+                .UsePOST(true)
+                .ExecuteAsync();
+
+            // Assert
+            Assert.That(result.Result, Is.Not.Null, "Publish result should not be null.");
+            Assert.That(result.Status.Error, Is.False, "Publish should succeed.");
+            AssertV2PublishEndpoint();
+        }
+        
+        [Test]
         public async Task ThenPostBody_ExactlyAtBoundary_32766Bytes_UsesV2PublishEndpoint()
         {
             // Arrange — serialized message is exactly at the 32 766-byte boundary
@@ -2882,7 +2902,7 @@ namespace PubNubMessaging.Tests
             // Assert
             Assert.That(result.Result, Is.Not.Null, "Publish result should not be null.");
             Assert.That(result.Status.Error, Is.False, "Publish should succeed.");
-            AssertV2PublishEndpoint();
+            AssertRegularPublishEndpoint("POST");
         }
 
         [Test]
@@ -3185,6 +3205,34 @@ namespace PubNubMessaging.Tests
                 "Exception message should describe the size violation.");
             Assert.That(_server.LogEntries.Count(), Is.EqualTo(0),
                 "No HTTP request should be made when the encrypted message exceeds the size limit.");
+        }
+
+        #endregion
+
+        #region Publish 2 MB size message using prod server 
+
+        [Test]
+        public async Task Then_2MB_Size_Message_Published_to_Prod_server()
+        {
+            // Arrange — message is one byte above the max permitted content size.
+            // The SDK must throw ArgumentException before making any HTTP request.
+            var pubnub = new Pubnub(new PNConfiguration(new UserId("test-user"))
+            {
+                PublishKey = PubnubCommon.NonPAMPublishKey,
+                SubscribeKey = PubnubCommon.NONPAMSubscribeKey
+            });
+            var message = CreateMessageOfSerializedSize(TwoMbBoundaryBytes - 4);
+            var publishResponseFor2MbMessage = await pubnub.Publish()
+                    .Channel(Channel)
+                    .Message(message)
+                    .ExecuteAsync();
+
+            Assert.That(publishResponseFor2MbMessage.Status.Error, Is.False ,
+                "2MB size message publish response should not have error");
+            Assert.That(publishResponseFor2MbMessage.Result, Is.Not.Null,
+                "2MB size message publish result should not be null.");
+            Assert.That(publishResponseFor2MbMessage.Result.Timetoken, Is.Not.Null, 
+                "2MB size message publish response should contain valid time token");
         }
 
         #endregion

--- a/src/UnitTests/PubnubApi.Tests/WhenAMessageIsPublished.cs
+++ b/src/UnitTests/PubnubApi.Tests/WhenAMessageIsPublished.cs
@@ -2658,6 +2658,9 @@ namespace PubNubMessaging.Tests
     ///   <item>Regular publish (GET): message in URL path, total URL must stay under 32 KB.</item>
     ///   <item>Regular publish (POST): body must be less than 32*1024 − 2 = 32 766 bytes.</item>
     ///   <item>v2/publish (POST): used when regular limits are exceeded; server rejects bodies ≥ 2*1024*1024 − 2 bytes with 413.</item>
+    ///   <item>Client-side validation: prepared message content (including encryption overhead)
+    ///         exceeding 2*1024*1024 − 2 bytes throws <see cref="ArgumentException"/> before
+    ///         any HTTP request is made.</item>
     /// </list>
     /// </summary>
     [TestFixture]
@@ -2681,8 +2684,10 @@ namespace PubNubMessaging.Tests
         private const int PostBodyBoundaryBytes = 32 * 1024 - 2; // 32 766
 
         /// <summary>
-        /// Server-side body limit for v2/publish.
-        /// PubNub servers return HTTP 413 for payloads at or above this size.
+        /// Maximum permitted size for the prepared message content (2 MiB − 2 bytes).
+        /// The SDK throws <see cref="ArgumentException"/> client-side for payloads
+        /// strictly exceeding this value. Payloads exactly at this size are sent to
+        /// the server, which returns HTTP 413.
         /// </summary>
         private const int TwoMbBoundaryBytes = 2 * 1024 * 1024 - 2; // 2 097 150
 
@@ -2722,6 +2727,25 @@ namespace PubNubMessaging.Tests
                 SubscribeKey = SubKey,
                 Origin = $"localhost:{_server.Port}",
                 Secure = false
+            };
+            _pubnub = new Pubnub(config);
+            return _pubnub;
+        }
+
+        /// <summary>
+        /// Creates a Pubnub instance with CryptoModule configured using LegacyCryptor.
+        /// Encryption adds overhead (AES-CBC IV, PKCS7 padding, Base64 encoding, JSON wrapping),
+        /// so the final serialized payload will be larger than the original plaintext.
+        /// </summary>
+        private Pubnub CreatePubnubWithCrypto()
+        {
+            var config = new PNConfiguration(new UserId("test-uuid"))
+            {
+                PublishKey = PubKey,
+                SubscribeKey = SubKey,
+                Origin = $"localhost:{_server.Port}",
+                Secure = false,
+                CryptoModule = new CryptoModule(new LegacyCryptor("enigma"), null)
             };
             _pubnub = new Pubnub(config);
             return _pubnub;
@@ -2979,12 +3003,14 @@ namespace PubNubMessaging.Tests
 
         #endregion
 
-        #region 2 MB server-side boundary — HTTP 413 Request Entity Too Large
+        #region 2 MB boundary — client-side ArgumentException and server-side HTTP 413
 
         [Test]
-        public async Task ThenPayload_Above2MBBoundary_UsesV2PublishAndServerReturns413()
+        public async Task ThenPayload_AtTwoMBBoundary_UsesV2PublishAndServerReturns413()
         {
-            // Arrange — override the default mock so v2/publish returns 413
+            // Arrange — message is exactly at TwoMbBoundaryBytes (2,097,150 bytes).
+            // This passes the client-side validation (> check, not >=) but the server
+            // rejects it with 413.
             _server.Reset();
             _server
                 .Given(WireMockRequest.Create()
@@ -3039,6 +3065,126 @@ namespace PubNubMessaging.Tests
             Assert.That(result.Status.Error, Is.False,
                 "Payload one byte below the 2 MB boundary should succeed.");
             AssertV2PublishEndpoint();
+        }
+
+        [Test]
+        public void ThenPayload_AboveTwoMBBoundary_ThrowsArgumentException()
+        {
+            // Arrange — message is one byte above the max permitted content size.
+            // The SDK must throw ArgumentException before making any HTTP request.
+            var pubnub = CreatePubnub();
+            var message = CreateMessageOfSerializedSize(TwoMbBoundaryBytes + 1);
+
+            // Act & Assert
+            var ex = Assert.ThrowsAsync<ArgumentException>(async () =>
+            {
+                await pubnub.Publish()
+                    .Channel(Channel)
+                    .Message(message)
+                    .UsePOST(true)
+                    .ExecuteAsync();
+            });
+
+            Assert.That(ex!.Message, Does.Contain("Message content size exceeds"),
+                "Exception message should describe the size violation.");
+            Assert.That(_server.LogEntries.Count(), Is.EqualTo(0),
+                "No HTTP request should be made when the message exceeds the size limit.");
+        }
+
+        #endregion
+
+        #region 2 MB server-side boundary with CryptoModule — encrypted payload near limit
+
+        [Test]
+        public async Task ThenEncryptedPayload_JustBelowTwoMBBoundary_WithCryptoModule_UsesV2PublishAndSucceeds()
+        {
+            // Arrange
+            //
+            // When CryptoModule is configured, the SDK encrypts the message before publishing.
+            // The encryption pipeline in PrepareContent is:
+            //   1. JSON-serialize the plaintext         → adds 2 bytes (surrounding quotes)
+            //   2. AES-256-CBC encrypt with PKCS7 pad   → rounds up to next 16-byte block
+            //   3. Prepend 16-byte random IV             → +16 bytes
+            //   4. Base64-encode the encrypted bytes     → ~33 % expansion (4/3 ratio)
+            //   5. JSON-serialize the Base64 string      → adds 2 bytes (surrounding quotes)
+            //
+            // For a plaintext of 1,572,829 ASCII characters the sizes are:
+            //   Step 1 → 1,572,831 bytes   (1,572,829 + 2)
+            //   Step 2 → 1,572,832 bytes   (1,572,831 + 1 byte PKCS7 padding)
+            //   Step 3 → 1,572,848 bytes   (1,572,832 + 16)
+            //   Step 4 → 2,097,132 bytes   (ceil(1,572,848 / 3) × 4 = 524,283 × 4)
+            //   Step 5 → 2,097,134 bytes   (2,097,132 + 2)
+            //
+            // 2,097,134 < 2,097,150 (TwoMbBoundaryBytes), so this payload fits just under
+            // the 2 MB − 2 server-side limit.  Due to AES block alignment and Base64 step
+            // quantization, this is the largest achievable encrypted payload below the limit.
+            const int plaintextLength = 1_572_829;
+
+            var pubnub = CreatePubnubWithCrypto();
+            var message = new string('a', plaintextLength);
+
+            // Act
+            var result = await pubnub.Publish()
+                .Channel(Channel)
+                .Message(message)
+                .UsePOST(true)
+                .ExecuteAsync();
+
+            // Assert — publish succeeded via v2/publish
+            Assert.That(result.Result, Is.Not.Null, "Publish result should not be null.");
+            Assert.That(result.Status.Error, Is.False,
+                "Encrypted payload just below the 2 MB − 2 boundary should publish successfully.");
+            AssertV2PublishEndpoint();
+
+            // Assert — verify the message body is encrypted (no plaintext leakage)
+            var entry = _server.LogEntries.Last();
+            var bodyString = entry.RequestMessage.Body;
+            Assert.That(bodyString, Is.Not.Null.And.Not.Empty,
+                "v2/publish POST body should contain the encrypted message.");
+            Assert.That(bodyString, Does.Not.Contain(new string('a', 100)),
+                "POST body should contain encrypted data, not the original plaintext.");
+
+            // Assert — verify the encrypted payload is under the 2 MB − 2 server limit
+            Assert.That(System.Text.Encoding.UTF8.GetByteCount(bodyString!),
+                Is.LessThan(TwoMbBoundaryBytes),
+                "Encrypted payload byte size should be below the 2 MB − 2 server-side limit.");
+        }
+
+        [Test]
+        public void ThenEncryptedPayload_AboveTwoMBBoundary_WithCryptoModule_ThrowsArgumentException()
+        {
+            // Arrange
+            //
+            // A plaintext of 1,572,830 ASCII chars encrypts to 2,097,154 bytes — 4 bytes
+            // above MaxMessageContentSizeBytes (2,097,150).  The client-side validation
+            // must reject this before any HTTP request is made.
+            //
+            // Encryption size breakdown for 1,572,830 chars:
+            //   JSON serialize       → 1,572,832 bytes  (plaintext + 2 quote bytes)
+            //   AES-CBC + PKCS7 pad  → 1,572,848 bytes  (1,572,832 is a 16-byte multiple,
+            //                                             so PKCS7 appends a full 16-byte block)
+            //   Prepend 16-byte IV   → 1,572,864 bytes
+            //   Base64 encode        → 2,097,152 bytes  (1,572,864 / 3 × 4 = 524,288 × 4)
+            //   JSON wrap (quotes)   → 2,097,154 bytes  (> 2,097,150 = TwoMbBoundaryBytes)
+            const int plaintextLength = 1_572_830;
+
+            var pubnub = CreatePubnubWithCrypto();
+            var message = new string('a', plaintextLength);
+
+            // Act & Assert
+            var ex = Assert.ThrowsAsync<ArgumentException>(async () =>
+            {
+                await pubnub.Publish()
+                    .Channel(Channel)
+                    .Message(message)
+                    .UsePOST(true)
+                    .ExecuteAsync();
+            });
+
+            Assert.That(ex!.Message, Does.Contain("Message content size exceeds"),
+                "Exception message should describe the size violation.");
+            Assert.That(_server.LogEntries.Count(), Is.EqualTo(0),
+                "No HTTP request should be made when the encrypted message exceeds the size limit.");
         }
 
         #endregion

--- a/src/UnitTests/PubnubApi.Tests/WhenAMessageIsPublished.cs
+++ b/src/UnitTests/PubnubApi.Tests/WhenAMessageIsPublished.cs
@@ -2453,26 +2453,17 @@ namespace PubNubMessaging.Tests
         [Test]
         public static void ThenPublishWithCustomMessageTypeAndSubscribeShouldReceiveCorrectMessageType()
         {
-            string channel = "hello_my_channel";
-            string message = "some_message_lalala";
+            var randomiser = new Random();
+            string channel = $"hello_my_channel_{randomiser.Next(1000, 10000)}";
+            string message = $"some_message_{randomiser.Next(1000, 10000)}";
             string customType = "customtype";
 
             PNConfiguration config = new PNConfiguration(new UserId("mytestuuid"))
             {
-                PublishKey = PubnubCommon.PublishKey,
-                SubscribeKey = PubnubCommon.SubscribeKey,
-                SecretKey = PubnubCommon.SecretKey,
-                Secure = false,
+                PublishKey = PubnubCommon.NonPAMPublishKey,
+                SubscribeKey = PubnubCommon.NONPAMSubscribeKey,
             };
-            if (PubnubCommon.PAMServerSideRun)
-            {
-                config.SecretKey = PubnubCommon.SecretKey;
-            }
-            else if (!string.IsNullOrEmpty(authToken) && !PubnubCommon.SuppressAuthKey)
-            {
-                config.AuthKey = authToken;
-            }
-            pubnub = createPubNubInstance(config, authToken);
+            pubnub = createPubNubInstance(config);
 
             manualResetEventWaitTimeout = 310 * 1000;
 

--- a/src/UnitTests/PubnubApi.Tests/WhenObjectChannelMetadata.cs
+++ b/src/UnitTests/PubnubApi.Tests/WhenObjectChannelMetadata.cs
@@ -1217,5 +1217,97 @@ namespace PubNubMessaging.Tests
             pubnub.Destroy();
             channelMetadataSetter.Destroy();
         }
+
+        [Test]
+        public static async Task ThenSetChannelMetadataShouldReturnETagAndAcceptItForIfMatch()
+        {
+            if (PubnubCommon.EnableStubTest)
+            {
+                Assert.Ignore("Ignored ThenSetChannelMetadataShouldReturnETagAndAcceptItForIfMatch");
+                return;
+            }
+
+            var r = new Random();
+            string channelMetadataId = $"channel{r.Next(100, 1000)}";
+            string name = $"name{r.Next(100, 1000)}";
+            string updatedName = $"name{r.Next(1000, 2000)}";
+
+            PNConfiguration configuration = new PNConfiguration(new UserId($"user{r.Next(100, 1000)}"))
+            {
+                PublishKey = PubnubCommon.NonPAMPublishKey,
+                SubscribeKey = PubnubCommon.NONPAMSubscribeKey,
+            };
+            pubnub = createPubNubInstance(configuration);
+
+            await pubnub.RemoveChannelMetadata().Channel(channelMetadataId).ExecuteAsync();
+
+            var createResult = await pubnub.SetChannelMetadata()
+                .Channel(channelMetadataId)
+                .Name(name)
+                .ExecuteAsync();
+
+            Assert.That(createResult.Result, Is.Not.Null, "Create result should not be null");
+            Assert.That(createResult.Status.StatusCode, Is.EqualTo(200), "Create should succeed with 200");
+            Assert.That(createResult.Result.ETag, Is.Not.Null.And.Not.Empty, "ETag should be present in response");
+
+            string capturedETag = createResult.Result.ETag;
+
+            var updateResult = await pubnub.SetChannelMetadata()
+                .Channel(channelMetadataId)
+                .Name(updatedName)
+                .IfMatchesEtag(capturedETag)
+                .ExecuteAsync();
+
+            Assert.That(updateResult.Result, Is.Not.Null, "Update result should not be null");
+            Assert.That(updateResult.Status.StatusCode, Is.EqualTo(200), "Update with matching eTag should succeed");
+            Assert.That(updateResult.Result.Name, Is.EqualTo(updatedName), "Name should be updated");
+            Assert.That(updateResult.Result.ETag, Is.Not.Null.And.Not.Empty, "Update response should also include ETag");
+
+            await pubnub.RemoveChannelMetadata().Channel(channelMetadataId).ExecuteAsync();
+            pubnub.Destroy();
+            pubnub = null;
+        }
+
+        [Test]
+        public static async Task ThenSetChannelMetadataWithInvalidETagShouldReturn412()
+        {
+            if (PubnubCommon.EnableStubTest)
+            {
+                Assert.Ignore("Ignored ThenSetChannelMetadataWithInvalidETagShouldReturn412");
+                return;
+            }
+
+            var r = new Random();
+            string channelMetadataId = $"channel{r.Next(100, 1000)}";
+            string name = $"name{r.Next(100, 1000)}";
+
+            PNConfiguration configuration = new PNConfiguration(new UserId($"user{r.Next(100, 1000)}"))
+            {
+                PublishKey = PubnubCommon.NonPAMPublishKey,
+                SubscribeKey = PubnubCommon.NONPAMSubscribeKey,
+            };
+            pubnub = createPubNubInstance(configuration);
+
+            await pubnub.RemoveChannelMetadata().Channel(channelMetadataId).ExecuteAsync();
+
+            var createResult = await pubnub.SetChannelMetadata()
+                .Channel(channelMetadataId)
+                .Name(name)
+                .ExecuteAsync();
+            Assert.That(createResult.Status.StatusCode, Is.EqualTo(200), "Create should succeed");
+
+            var updateResult = await pubnub.SetChannelMetadata()
+                .Channel(channelMetadataId)
+                .Name(name + "-updated")
+                .IfMatchesEtag("invalid-etag-value")
+                .ExecuteAsync();
+
+            Assert.That(updateResult.Status.Error, Is.True, "Status should indicate error for mismatched eTag");
+            Assert.That(updateResult.Status.StatusCode, Is.EqualTo(412), "Status code should be 412 Precondition Failed");
+
+            await pubnub.RemoveChannelMetadata().Channel(channelMetadataId).ExecuteAsync();
+            pubnub.Destroy();
+            pubnub = null;
+        }
     }
 }

--- a/src/UnitTests/PubnubApi.Tests/WhenObjectUuidMetadata.cs
+++ b/src/UnitTests/PubnubApi.Tests/WhenObjectUuidMetadata.cs
@@ -1147,5 +1147,97 @@ namespace PubNubMessaging.Tests
             pubnub.Destroy();
             uuidSetter.Destroy();
         }
+
+        [Test]
+        public static async Task ThenSetUuidMetadataShouldReturnETagAndAcceptItForIfMatch()
+        {
+            if (PubnubCommon.EnableStubTest)
+            {
+                Assert.Ignore("Ignored ThenSetUuidMetadataShouldReturnETagAndAcceptItForIfMatch");
+                return;
+            }
+
+            var r = new Random();
+            string uuidMetadataId = $"uuid{r.Next(100, 1000)}";
+            string name = $"name{r.Next(100, 1000)}";
+            string updatedName = $"name{r.Next(1000, 2000)}";
+
+            PNConfiguration configuration = new PNConfiguration(new UserId($"user{r.Next(100, 1000)}"))
+            {
+                PublishKey = PubnubCommon.NonPAMPublishKey,
+                SubscribeKey = PubnubCommon.NONPAMSubscribeKey,
+            };
+            pubnub = createPubNubInstance(configuration);
+
+            await pubnub.RemoveUuidMetadata().Uuid(uuidMetadataId).ExecuteAsync();
+
+            var createResult = await pubnub.SetUuidMetadata()
+                .Uuid(uuidMetadataId)
+                .Name(name)
+                .ExecuteAsync();
+
+            Assert.That(createResult.Result, Is.Not.Null, "Create result should not be null");
+            Assert.That(createResult.Status.StatusCode, Is.EqualTo(200), "Create should succeed with 200");
+            Assert.That(createResult.Result.ETag, Is.Not.Null.And.Not.Empty, "ETag should be present in response");
+
+            string capturedETag = createResult.Result.ETag;
+
+            var updateResult = await pubnub.SetUuidMetadata()
+                .Uuid(uuidMetadataId)
+                .Name(updatedName)
+                .IfMatchesEtag(capturedETag)
+                .ExecuteAsync();
+
+            Assert.That(updateResult.Result, Is.Not.Null, "Update result should not be null");
+            Assert.That(updateResult.Status.StatusCode, Is.EqualTo(200), "Update with matching eTag should succeed");
+            Assert.That(updateResult.Result.Name, Is.EqualTo(updatedName), "Name should be updated");
+            Assert.That(updateResult.Result.ETag, Is.Not.Null.And.Not.Empty, "Update response should also include ETag");
+
+            await pubnub.RemoveUuidMetadata().Uuid(uuidMetadataId).ExecuteAsync();
+            pubnub.Destroy();
+            pubnub = null;
+        }
+
+        [Test]
+        public static async Task ThenSetUuidMetadataWithInvalidETagShouldReturn412()
+        {
+            if (PubnubCommon.EnableStubTest)
+            {
+                Assert.Ignore("Ignored ThenSetUuidMetadataWithInvalidETagShouldReturn412");
+                return;
+            }
+
+            var r = new Random();
+            string uuidMetadataId = $"uuid{r.Next(100, 1000)}";
+            string name = $"name{r.Next(100, 1000)}";
+
+            PNConfiguration configuration = new PNConfiguration(new UserId($"user{r.Next(100, 1000)}"))
+            {
+                PublishKey = PubnubCommon.NonPAMPublishKey,
+                SubscribeKey = PubnubCommon.NONPAMSubscribeKey,
+            };
+            pubnub = createPubNubInstance(configuration);
+
+            await pubnub.RemoveUuidMetadata().Uuid(uuidMetadataId).ExecuteAsync();
+
+            var createResult = await pubnub.SetUuidMetadata()
+                .Uuid(uuidMetadataId)
+                .Name(name)
+                .ExecuteAsync();
+            Assert.That(createResult.Status.StatusCode, Is.EqualTo(200), "Create should succeed");
+
+            var updateResult = await pubnub.SetUuidMetadata()
+                .Uuid(uuidMetadataId)
+                .Name(name + "-updated")
+                .IfMatchesEtag("invalid-etag-value")
+                .ExecuteAsync();
+
+            Assert.That(updateResult.Status.Error, Is.True, "Status should indicate error for mismatched eTag");
+            Assert.That(updateResult.Status.StatusCode, Is.EqualTo(412), "Status code should be 412 Precondition Failed");
+
+            await pubnub.RemoveUuidMetadata().Uuid(uuidMetadataId).ExecuteAsync();
+            pubnub.Destroy();
+            pubnub = null;
+        }
     }
 }

--- a/src/UnitTests/PubnubApi.Tests/WhenSubscribedToAChannelComprehensive.cs
+++ b/src/UnitTests/PubnubApi.Tests/WhenSubscribedToAChannelComprehensive.cs
@@ -1489,6 +1489,7 @@ namespace PubNubMessaging.Tests
             // Publish multiple messages rapidly
             for (int i = 0; i < expectedMessageCount; i++)
             {
+                await Task.Delay(1000);
                 await pubnub.Publish()
                     .Channel(channel)
                     .Message($"Message {i}")


### PR DESCRIPTION
feat(publishV2): support for the publish v2 endpoint, allowing feature-enabled keysets to publish messages of size up to 2MB.

Added support for the publish v2 endpoint, allowing feature-enabled keysets to publish messages of size up to 2MB.